### PR TITLE
#1024 Sort optimize client_id_suffix

### DIFF
--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -957,9 +957,7 @@ impl ChainEndpoint for CosmosSdkChain {
             .collect();
 
         // Sort by client identifier counter
-        clients.sort_by_cached_key(|c|
-            client_id_suffix(&c.client_id)
-                .unwrap_or(0));
+        clients.sort_by_cached_key(|c| client_id_suffix(&c.client_id).unwrap_or(0));
 
         Ok(clients)
     }
@@ -2119,12 +2117,12 @@ fn mul_ceil(a: u64, f: f64) -> u64 {
 #[cfg(test)]
 mod tests {
     use ibc::{
-        Height,
         ics02_client::client_state::{AnyClientState, IdentifiedAnyClientState},
         ics02_client::client_type::ClientType,
         ics24_host::identifier::ClientId,
         mock::client_state::MockClientState,
-        mock::header::MockHeader
+        mock::header::MockHeader,
+        Height,
     };
 
     use crate::chain::cosmos::client_id_suffix;
@@ -2145,25 +2143,26 @@ mod tests {
         let mut clients: Vec<IdentifiedAnyClientState> = vec![
             IdentifiedAnyClientState::new(
                 ClientId::new(ClientType::Tendermint, 4).unwrap(),
-                AnyClientState::Mock(
-                    MockClientState(
-                        MockHeader::new(Height::new(0, 0))))),
+                AnyClientState::Mock(MockClientState(MockHeader::new(Height::new(0, 0)))),
+            ),
             IdentifiedAnyClientState::new(
                 ClientId::new(ClientType::Tendermint, 1).unwrap(),
-                AnyClientState::Mock(
-                    MockClientState(
-                        MockHeader::new(Height::new(0, 0))))),
+                AnyClientState::Mock(MockClientState(MockHeader::new(Height::new(0, 0)))),
+            ),
             IdentifiedAnyClientState::new(
                 ClientId::new(ClientType::Tendermint, 7).unwrap(),
-                AnyClientState::Mock(
-                    MockClientState(
-                        MockHeader::new(Height::new(0, 0))))),
+                AnyClientState::Mock(MockClientState(MockHeader::new(Height::new(0, 0)))),
+            ),
         ];
-        clients.sort_by_cached_key(|c|
-            client_id_suffix(&c.client_id)
-                .unwrap_or(0));
-        assert_eq!(client_id_suffix(&clients.first().unwrap().client_id).unwrap(), 1);
+        clients.sort_by_cached_key(|c| client_id_suffix(&c.client_id).unwrap_or(0));
+        assert_eq!(
+            client_id_suffix(&clients.first().unwrap().client_id).unwrap(),
+            1
+        );
         assert_eq!(client_id_suffix(&clients[1].client_id).unwrap(), 4);
-        assert_eq!(client_id_suffix(&clients.last().unwrap().client_id).unwrap(), 7);
+        assert_eq!(
+            client_id_suffix(&clients.last().unwrap().client_id).unwrap(),
+            7
+        );
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1024
Great to participate in Codefest :)
As requested in the contribution guidelines, I'm starting with a draft PR to signal undertaking this one.

## Description

Replace a clients `sort_by` with `sort_by_cached_key` to avoid calling `client_id_suffix()` repeatedly.
______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
