### PR TITLE
Hide backtraces when printing errors in the logs

### DIFF
--- a/modules/src/ics02_client/events.rs
+++ b/modules/src/ics02_client/events.rs
@@ -74,7 +74,7 @@ pub fn extract_header_from_tx(event: &tendermint::abci::Event) -> Option<AnyHead
             let result = match Protobuf::decode(header_bytes.as_ref()) {
                 Ok(header) => Some(header),
                 Err(e) => {
-                    tracing::error!("error {} while decoding {:?}", e, header_bytes);
+                    tracing::error!("error {} while decoding {:?}", e.detail(), header_bytes);
                     None
                 }
             };

--- a/relayer-cli/src/commands/config/validate.rs
+++ b/relayer-cli/src/commands/config/validate.rs
@@ -15,7 +15,7 @@ impl Runnable for ValidateCmd {
 
         match config::validate_config(&config) {
             Ok(_) => Output::success("validation passed successfully").exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/create/connection.rs
+++ b/relayer-cli/src/commands/create/connection.rs
@@ -93,7 +93,7 @@ impl CreateConnectionCommand {
         let delay = Duration::from_secs(self.delay);
         match Connection::new(client_a, client_b, delay) {
             Ok(conn) => Output::success(conn).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 
@@ -104,7 +104,7 @@ impl CreateConnectionCommand {
         // Validate & spawn runtime for chain_a.
         let chain_a = match spawn_chain_runtime(&config, &self.chain_a_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         // Unwrap the identifier of the client on chain_a.
@@ -125,7 +125,9 @@ impl CreateConnectionCommand {
             Err(e) => {
                 return Output::error(format!(
                     "Failed while querying client '{}' on chain '{}' with error: {}",
-                    client_a_id, self.chain_a_id, e
+                    client_a_id,
+                    self.chain_a_id,
+                    e.detail()
                 ))
                 .exit()
             }
@@ -134,7 +136,7 @@ impl CreateConnectionCommand {
         // Validate & spawn runtime for chain_b.
         let chain_b = match spawn_chain_runtime(&config, &chain_b_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         // Unwrap the identifier of the client on chain_b.
@@ -163,7 +165,7 @@ impl CreateConnectionCommand {
         let delay = Duration::from_secs(self.delay);
         match Connection::new(client_a, client_b, delay) {
             Ok(conn) => Output::success(conn).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -73,7 +73,7 @@ impl Runnable for KeysAddCmd {
         let config = app_config();
 
         let opts = match self.options(&config) {
-            Err(err) => return Output::error(err).exit(),
+            Err(e) => return Output::error(e).exit(),
             Ok(result) => result,
         };
 

--- a/relayer-cli/src/commands/listen.rs
+++ b/relayer-cli/src/commands/listen.rs
@@ -130,7 +130,7 @@ pub fn listen(
 
                 info!("");
             }
-            Err(e) => error!("- error: {}", e),
+            Err(e) => error!("- error: {}", e.detail()),
         }
     }
 

--- a/relayer-cli/src/commands/misbehaviour.rs
+++ b/relayer-cli/src/commands/misbehaviour.rs
@@ -47,8 +47,13 @@ pub fn monitor_misbehaviour(
     client_id: &ClientId,
     config: &config::Reader<CliApp>,
 ) -> Result<Option<IbcEvent>, Box<dyn std::error::Error>> {
-    let chain = spawn_chain_runtime(config, chain_id)
-        .map_err(|e| format!("could not spawn the chain runtime for {}: {}", chain_id, e))?;
+    let chain = spawn_chain_runtime(config, chain_id).map_err(|e| {
+        format!(
+            "could not spawn the chain runtime for {}: {}",
+            chain_id,
+            e.detail()
+        )
+    })?;
 
     let subscription = chain.subscribe()?;
 
@@ -101,7 +106,13 @@ fn misbehaviour_handling<Chain: ChainHandle>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client_state = chain
         .query_client_state(&client_id, Height::zero())
-        .map_err(|e| format!("could not query client state for {}: {}", client_id, e))?;
+        .map_err(|e| {
+            format!(
+                "could not query client state for {}: {}",
+                client_id,
+                e.detail()
+            )
+        })?;
 
     if client_state.is_frozen() {
         return Err(format!("client {} is already frozen", client_id).into());

--- a/relayer-cli/src/commands/query/channel.rs
+++ b/relayer-cli/src/commands/query/channel.rs
@@ -60,7 +60,7 @@ impl Runnable for QueryChannelEndCmd {
                     Output::success(channel_end).exit()
                 }
             }
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -55,7 +55,7 @@ impl Runnable for QueryClientStateCmd {
 
         match chain.query_client_state(&self.client_id, height) {
             Ok(cs) => Output::success(cs).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -109,7 +109,9 @@ impl Runnable for QueryClientConsensusCmd {
             Err(e) => {
                 return Output::error(format!(
                     "Failed while querying client '{}' on chain '{}' with error: {}",
-                    self.client_id, self.chain_id, e
+                    self.client_id,
+                    self.chain_id,
+                    e.detail()
                 ))
                 .exit()
             }
@@ -125,7 +127,7 @@ impl Runnable for QueryClientConsensusCmd {
 
                 match res {
                     Ok(cs) => Output::success(cs).exit(),
-                    Err(e) => Output::error(format!("{}", e)).exit(),
+                    Err(e) => Output::error(format!("{}", e.detail())).exit(),
                 }
             }
             None => {
@@ -143,7 +145,7 @@ impl Runnable for QueryClientConsensusCmd {
                             Output::success(states).exit()
                         }
                     }
-                    Err(e) => Output::error(format!("{}", e)).exit(),
+                    Err(e) => Output::error(format!("{}", e.detail())).exit(),
                 }
             }
         }
@@ -192,7 +194,9 @@ impl Runnable for QueryClientHeaderCmd {
             Err(e) => {
                 return Output::error(format!(
                     "Failed while querying client '{}' on chain '{}' with error: {}",
-                    self.client_id, self.chain_id, e
+                    self.client_id,
+                    self.chain_id,
+                    e.detail()
                 ))
                 .exit()
             }
@@ -211,7 +215,7 @@ impl Runnable for QueryClientHeaderCmd {
 
         match res {
             Ok(header) => Output::success(header).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -258,7 +262,7 @@ impl Runnable for QueryClientConnectionsCmd {
 
         match res {
             Ok(ce) => Output::success(ce).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/clients.rs
+++ b/relayer-cli/src/commands/query/clients.rs
@@ -110,7 +110,7 @@ impl Runnable for QueryAllClientsCmd {
                     }
                 }
             }
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/connection.rs
+++ b/relayer-cli/src/commands/query/connection.rs
@@ -62,7 +62,7 @@ impl Runnable for QueryConnectionEndCmd {
                     Output::success(connection_end).exit()
                 }
             }
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -117,7 +117,7 @@ impl Runnable for QueryConnectionChannelsCmd {
                     .collect();
                 Output::success(ids).exit()
             }
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/connections.rs
+++ b/relayer-cli/src/commands/query/connections.rs
@@ -52,7 +52,7 @@ impl Runnable for QueryConnectionsCmd {
 
                 Output::success(ids).exit()
             }
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet/ack.rs
+++ b/relayer-cli/src/commands/query/packet/ack.rs
@@ -59,7 +59,7 @@ impl Runnable for QueryPacketAcknowledgmentCmd {
     fn run(&self) {
         match self.execute() {
             Ok(hex) => Output::success(hex).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet/acks.rs
+++ b/relayer-cli/src/commands/query/packet/acks.rs
@@ -59,7 +59,7 @@ impl Runnable for QueryPacketAcknowledgementsCmd {
     fn run(&self) {
         match self.execute() {
             Ok(ps) => Output::success(ps).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet/commitment.rs
+++ b/relayer-cli/src/commands/query/packet/commitment.rs
@@ -69,7 +69,7 @@ impl Runnable for QueryPacketCommitmentCmd {
     fn run(&self) {
         match self.execute() {
             Ok(hex) => Output::success(hex).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet/commitments.rs
+++ b/relayer-cli/src/commands/query/packet/commitments.rs
@@ -61,7 +61,7 @@ impl Runnable for QueryPacketCommitmentsCmd {
     fn run(&self) {
         match self.execute() {
             Ok(p) => Output::success(p).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet/unreceived_acks.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_acks.rs
@@ -54,7 +54,7 @@ impl Runnable for QueryUnreceivedAcknowledgementCmd {
     fn run(&self) {
         match self.execute() {
             Ok(seqs) => Output::success(seqs).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet/unreceived_packets.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_packets.rs
@@ -62,7 +62,7 @@ impl Runnable for QueryUnreceivedPacketsCmd {
     fn run(&self) {
         match self.execute() {
             Ok(seqs) => Output::success(seqs).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -45,7 +45,11 @@ impl Runnable for StartCmd {
         info!("Hermes has started");
         match supervisor.run() {
             Ok(()) => Output::success_msg("done").exit(),
-            Err(e) => Output::error(format!("Hermes failed to start, last error: {}", e)).exit(),
+            Err(e) => Output::error(format!(
+                "Hermes failed to start, last error: {}",
+                e.detail()
+            ))
+            .exit(),
         }
     }
 }
@@ -71,7 +75,7 @@ fn register_signals(reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Resu
                     match reload.reload() {
                         Ok(true) => info!("configuration successfully reloaded"),
                         Ok(false) => info!("configuration did not change"),
-                        Err(e) => error!("failed to reload configuration: {}", e),
+                        Err(e) => error!("failed to reload configuration: {}", e.detail()),
                     }
                 }
                 SIGUSR1 => {

--- a/relayer-cli/src/commands/tx/channel.rs
+++ b/relayer-cli/src/commands/tx/channel.rs
@@ -20,7 +20,7 @@ macro_rules! tx_chan_cmd {
         let chains = match ChainHandlePair::spawn(&config, &$self.src_chain_id, &$self.dst_chain_id)
         {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         // Retrieve the connection
@@ -29,7 +29,7 @@ macro_rules! tx_chan_cmd {
             .query_connection(&$self.dst_conn_id, Height::default())
         {
             Ok(connection) => connection,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let channel = $chan(chains, dst_connection);
@@ -40,7 +40,7 @@ macro_rules! tx_chan_cmd {
 
         match res {
             Ok(receipt) => Output::success(receipt).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     };
 }
@@ -72,7 +72,7 @@ impl Runnable for TxRawChanOpenInitCmd {
 
         let chains = match ChainHandlePair::spawn(&config, &self.src_chain_id, &self.dst_chain_id) {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         // Retrieve the connection
@@ -81,7 +81,7 @@ impl Runnable for TxRawChanOpenInitCmd {
             .query_connection(&self.dst_conn_id, Height::default())
         {
             Ok(connection) => connection,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let channel = Channel {
@@ -112,7 +112,7 @@ impl Runnable for TxRawChanOpenInitCmd {
 
         match res {
             Ok(receipt) => Output::success(receipt).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -156,7 +156,7 @@ impl Runnable for TxRawChanOpenTryCmd {
 
         let chains = match ChainHandlePair::spawn(&config, &self.src_chain_id, &self.dst_chain_id) {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         // Retrieve the connection
@@ -165,7 +165,7 @@ impl Runnable for TxRawChanOpenTryCmd {
             .query_connection(&self.dst_conn_id, Height::default())
         {
             Ok(connection) => connection,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let channel = Channel {
@@ -196,7 +196,7 @@ impl Runnable for TxRawChanOpenTryCmd {
 
         match res {
             Ok(receipt) => Output::success(receipt).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
 
         tx_chan_cmd!(

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -35,7 +35,7 @@ impl Runnable for TxCreateClientCmd {
 
         let chains = match ChainHandlePair::spawn(&config, &self.src_chain_id, &self.dst_chain_id) {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let client = ForeignClient::restore(ClientId::default(), chains.dst, chains.src);
@@ -47,7 +47,7 @@ impl Runnable for TxCreateClientCmd {
 
         match res {
             Ok(receipt) => Output::success(receipt).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -77,7 +77,7 @@ impl Runnable for TxUpdateClientCmd {
 
         let dst_chain = match spawn_chain_runtime(&config, &self.dst_chain_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let src_chain_id =
@@ -86,7 +86,9 @@ impl Runnable for TxUpdateClientCmd {
                 Err(e) => {
                     return Output::error(format!(
                         "Query of client '{}' on chain '{}' failed with error: {}",
-                        self.dst_client_id, self.dst_chain_id, e
+                        self.dst_client_id,
+                        self.dst_chain_id,
+                        e.detail()
                     ))
                     .exit();
                 }
@@ -94,7 +96,7 @@ impl Runnable for TxUpdateClientCmd {
 
         let src_chain = match spawn_chain_runtime(&config, &src_chain_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let height = match self.target_height {
@@ -116,7 +118,7 @@ impl Runnable for TxUpdateClientCmd {
 
         match res {
             Ok(events) => Output::success(events).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -136,7 +138,7 @@ impl Runnable for TxUpgradeClientCmd {
 
         let dst_chain = match spawn_chain_runtime(&config, &self.chain_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let src_chain_id = match dst_chain.query_client_state(&self.client_id, ibc::Height::zero())
@@ -145,7 +147,9 @@ impl Runnable for TxUpgradeClientCmd {
             Err(e) => {
                 return Output::error(format!(
                     "Query of client '{}' on chain '{}' failed with error: {}",
-                    self.client_id, self.chain_id, e
+                    self.client_id,
+                    self.chain_id,
+                    e.detail()
                 ))
                 .exit();
             }
@@ -153,7 +157,7 @@ impl Runnable for TxUpgradeClientCmd {
 
         let src_chain = match spawn_chain_runtime(&config, &src_chain_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let client = ForeignClient::find(src_chain, dst_chain, &self.client_id)
@@ -163,7 +167,7 @@ impl Runnable for TxUpgradeClientCmd {
 
         match outcome {
             Ok(receipt) => Output::success(receipt).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -183,7 +187,7 @@ impl Runnable for TxUpgradeClientsCmd {
         let config = app_config();
         let src_chain = match spawn_chain_runtime(&config, &self.src_chain_id) {
             Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let results = config
@@ -267,11 +271,11 @@ impl fmt::Display for OutputBuffer {
                         )?;
                         match inner_result {
                             Ok(events) => writeln!(f, "{:#?}", events)?,
-                            Err(e) => writeln!(f, "{}", e.to_string())?,
+                            Err(e) => writeln!(f, "{}", e.detail())?,
                         }
                     }
                 }
-                Err(e) => writeln!(f, " {}", e.to_string())?,
+                Err(e) => writeln!(f, " {}", e.detail())?,
             }
         }
         Ok(())

--- a/relayer-cli/src/commands/tx/connection.rs
+++ b/relayer-cli/src/commands/tx/connection.rs
@@ -17,7 +17,7 @@ macro_rules! conn_open_cmd {
         let chains = match ChainHandlePair::spawn(&config, &$self.src_chain_id, &$self.dst_chain_id)
         {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let connection = $conn(chains);
@@ -28,7 +28,7 @@ macro_rules! conn_open_cmd {
 
         match res {
             Ok(receipt) => Output::success(receipt).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     };
 }

--- a/relayer-cli/src/commands/tx/packet.rs
+++ b/relayer-cli/src/commands/tx/packet.rs
@@ -30,7 +30,7 @@ impl Runnable for TxRawPacketRecvCmd {
 
         let chains = match ChainHandlePair::spawn(&config, &self.src_chain_id, &self.dst_chain_id) {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let opts = LinkParameters {
@@ -39,7 +39,7 @@ impl Runnable for TxRawPacketRecvCmd {
         };
         let mut link = match Link::new_from_opts(chains.src, chains.dst, opts, false) {
             Ok(link) => link,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let res: Result<Vec<IbcEvent>, Error> = link
@@ -48,7 +48,7 @@ impl Runnable for TxRawPacketRecvCmd {
 
         match res {
             Ok(ev) => Output::success(ev).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }
@@ -74,7 +74,7 @@ impl Runnable for TxRawPacketAckCmd {
 
         let chains = match ChainHandlePair::spawn(&config, &self.src_chain_id, &self.dst_chain_id) {
             Ok(chains) => chains,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let opts = LinkParameters {
@@ -83,7 +83,7 @@ impl Runnable for TxRawPacketAckCmd {
         };
         let mut link = match Link::new_from_opts(chains.src, chains.dst, opts, false) {
             Ok(link) => link,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let res: Result<Vec<IbcEvent>, Error> = link
@@ -92,7 +92,7 @@ impl Runnable for TxRawPacketAckCmd {
 
         match res {
             Ok(ev) => Output::success(ev).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/tx/transfer.rs
+++ b/relayer-cli/src/commands/tx/transfer.rs
@@ -139,7 +139,7 @@ impl Runnable for TxIcs20MsgTransferCmd {
         let config = app_config();
 
         let opts = match self.validate_options(&config) {
-            Err(err) => return Output::error(err).exit(),
+            Err(e) => return Output::error(e).exit(),
             Ok(result) => result,
         };
 
@@ -214,7 +214,7 @@ impl Runnable for TxIcs20MsgTransferCmd {
 
         match res {
             Ok(ev) => Output::success(ev).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/tx/upgrade.rs
+++ b/relayer-cli/src/commands/tx/upgrade.rs
@@ -123,14 +123,14 @@ impl Runnable for TxIbcUpgradeChainCmd {
             .map_err(Error::relayer);
         let src_chain = match src_chain_res {
             Ok(chain) => chain,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let dst_chain_res =
             CosmosSdkChain::bootstrap(opts.dst_chain_config.clone(), rt).map_err(Error::relayer);
         let dst_chain = match dst_chain_res {
             Ok(chain) => chain,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
+            Err(e) => return Output::error(format!("{}", e.detail())).exit(),
         };
 
         let res: Result<Vec<IbcEvent>, Error> =
@@ -139,7 +139,7 @@ impl Runnable for TxIbcUpgradeChainCmd {
 
         match res {
             Ok(ev) => Output::success(ev).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Err(e) => Output::error(format!("{}", e.detail())).exit(),
         }
     }
 }

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -132,7 +132,7 @@ where
         let id = handle.id();
         let thread = thread::spawn(move || {
             if let Err(e) = chain_runtime.run() {
-                error!("failed to start runtime for chain '{}': {}", id, e);
+                error!("failed to start runtime for chain '{}': {}", id, e.detail());
             }
         });
 

--- a/relayer/src/channel.rs
+++ b/relayer/src/channel.rs
@@ -383,7 +383,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
 
     fn do_chan_open_try_and_send(&mut self) -> Result<(), ChannelError> {
         let event = self.build_chan_open_try_and_send().map_err(|e| {
-            error!("Failed ChanTry {:?}: {:?}", self.b_side, e);
+            error!("Failed ChanTry {:?}: {:?}", self.b_side, e.detail());
             e
         })?;
 
@@ -616,7 +616,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
 
         match self.handshake_step(state) {
             Err(e) => {
-                error!("Failed Chan{:?} with error: {}", state, e);
+                error!("Failed Chan{:?} with error: {}", state, e.detail());
                 RetryResult::Retry(index)
             }
             Ok(ev) => {
@@ -975,7 +975,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
         }
 
         do_build_chan_open_ack_and_send(self).map_err(|e| {
-            error!("failed ChanAck {:?}: {}", self.b_side, e);
+            error!("failed ChanAck {:?}: {}", self.b_side, e.detail());
             e
         })
     }
@@ -1068,7 +1068,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
         }
 
         do_build_chan_open_confirm_and_send(self).map_err(|e| {
-            error!("failed ChanConfirm {:?}: {}", self.b_side, e);
+            error!("failed ChanConfirm {:?}: {}", self.b_side, e.detail());
             e
         })
     }

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -482,7 +482,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
             counter += 1;
             match self.flipped().build_conn_init_and_send() {
                 Err(e) => {
-                    error!("Failed ConnInit {:?}: {}", self.a_side, e);
+                    error!("Failed ConnInit {:?}: {}", self.a_side, e.detail());
                     continue;
                 }
                 Ok(result) => {
@@ -499,7 +499,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
             counter += 1;
             match self.build_conn_try_and_send() {
                 Err(e) => {
-                    error!("Failed ConnTry {:?}: {}", self.b_side, e);
+                    error!("Failed ConnTry {:?}: {}", self.b_side, e.detail());
                     continue;
                 }
                 Ok(result) => {
@@ -535,7 +535,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
                 (State::Init, State::TryOpen) | (State::TryOpen, State::TryOpen) => {
                     // Ack to a_chain
                     match self.flipped().build_conn_ack_and_send() {
-                        Err(e) => error!("Failed ConnAck {:?}: {}", self.a_side, e),
+                        Err(e) => error!("Failed ConnAck {:?}: {}", self.a_side, e.detail()),
                         Ok(event) => {
                             println!("{}  {} => {:#?}\n", done, self.a_side.chain.id(), event)
                         }
@@ -544,7 +544,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
                 (State::Open, State::TryOpen) => {
                     // Confirm to b_chain
                     match self.build_conn_confirm_and_send() {
-                        Err(e) => error!("Failed ConnConfirm {:?}: {}", self.b_side, e),
+                        Err(e) => error!("Failed ConnConfirm {:?}: {}", self.b_side, e.detail()),
                         Ok(event) => {
                             println!("{}  {} => {:#?}\n", done, self.b_side.chain.id(), event)
                         }
@@ -553,7 +553,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
                 (State::TryOpen, State::Open) => {
                     // Confirm to a_chain
                     match self.flipped().build_conn_confirm_and_send() {
-                        Err(e) => error!("Failed ConnConfirm {:?}: {}", self.a_side, e),
+                        Err(e) => error!("Failed ConnConfirm {:?}: {}", self.a_side, e.detail()),
                         Ok(event) => {
                             println!("{}  {} => {:#?}\n", done, self.a_side.chain.id(), event)
                         }

--- a/relayer/src/event/monitor.rs
+++ b/relayer/src/event/monitor.rs
@@ -373,7 +373,7 @@ impl EventMonitor {
 
             match result {
                 Ok(batch) => self.process_batch(batch).unwrap_or_else(|e| {
-                    error!("[{}] {}", self.chain_id, e);
+                    error!("[{}] {}", self.chain_id, e.detail());
                 }),
                 Err(e) => {
                     match e.detail() {
@@ -384,7 +384,7 @@ impl EventMonitor {
                             );
 
                             self.propagate_error(e).unwrap_or_else(|e| {
-                                error!("[{}] {}", self.chain_id, e);
+                                error!("[{}] {}", self.chain_id, e.detail());
                             });
 
                             // Reconnect to the WebSocket endpoint, and subscribe again to the queries.
@@ -397,7 +397,11 @@ impl EventMonitor {
                             return Next::Continue;
                         }
                         _ => {
-                            error!("[{}] failed to collect events: {}", self.chain_id, e);
+                            error!(
+                                "[{}] failed to collect events: {}",
+                                self.chain_id,
+                                e.detail()
+                            );
 
                             // Reconnect to the WebSocket endpoint, and subscribe again to the queries.
                             self.reconnect();

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -498,7 +498,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
     /// Sends the client creation transaction & subsequently sets the id of this ForeignClient
     fn create(&mut self) -> Result<(), ForeignClientError> {
         let event = self.build_create_client_and_send().map_err(|e| {
-            error!("[{}]  failed CreateClient: {}", self, e);
+            error!("[{}]  failed CreateClient: {}", self, e.detail());
             e
         })?;
 
@@ -826,7 +826,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
                     error!(
                         "[{}] query_tx with error {}, retry {}/{}",
                         self,
-                        e,
+                        e.detail(),
                         i + 1,
                         MAX_RETRIES
                     );

--- a/relayer/src/link/pending.rs
+++ b/relayer/src/link/pending.rs
@@ -207,7 +207,9 @@ impl<Chain: ChainHandle> PendingTxs<Chain> {
 
                     error!(
                         "[{}] error querying for tx hashes {}: {}. will retry again later",
-                        self, tx_hashes, e
+                        self,
+                        tx_hashes,
+                        e.detail()
                     );
 
                     // Push it to the back of the pending queue to process it

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -567,7 +567,9 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
                 error!(
                     "[{}] failed to regenerate operational data from initial data: {} \
                     with error {}, discarding this op. data",
-                    self, initial_odata, e
+                    self,
+                    initial_odata,
+                    e.detail()
                 );
                 return None;
             } // Cannot retry, contain the error by reporting a None
@@ -585,7 +587,9 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
                     error!(
                         "[{}] failed to schedule newly-generated operational data from \
                     initial data: {} with error {}, discarding this op. data",
-                        self, initial_odata, e
+                        self,
+                        initial_odata,
+                        e.detail()
                     );
                     return None;
                 }
@@ -1232,14 +1236,17 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
         }
 
         let mut summary_src = self.process_pending_txs_src().unwrap_or_else(|e| {
-            error!("error processing pending events in source chain: {}", e);
+            error!(
+                "error processing pending events in source chain: {}",
+                e.detail()
+            );
             RelaySummary::empty()
         });
 
         let summary_dst = self.process_pending_txs_dst().unwrap_or_else(|e| {
             error!(
                 "error processing pending events in destination chain: {}",
-                e
+                e.detail()
             );
             RelaySummary::empty()
         });

--- a/relayer/src/supervisor/spawn.rs
+++ b/relayer/src/supervisor/spawn.rs
@@ -97,7 +97,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {}, reason: failed to spawn chain runtime with error: {}",
-                    from_chain_id, e
+                    from_chain_id, e.detail()
                 );
 
                 return;
@@ -109,7 +109,8 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {}, reason: failed to query clients with error: {}",
-                    from_chain_id, e
+                    from_chain_id,
+                    e.detail()
                 );
 
                 return;
@@ -133,7 +134,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {}, reason: failed to spawn chain runtime with error: {}",
-                    chain_id, e
+                    chain_id, e.detail()
                 );
 
                 return;
@@ -145,7 +146,8 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {}, reason: failed to query clients with error: {}",
-                    chain_id, e
+                    chain_id,
+                    e.detail()
                 );
 
                 return;
@@ -228,7 +230,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {}, reason: failed to query client connections for client {}: {}",
-                    chain_id, client.client_id, e
+                    chain_id, client.client_id, e.detail()
                 );
 
                 return;
@@ -253,7 +255,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {} and connection {}, reason: failed to query connection end: {}",
-                    chain_id, connection_id, e
+                    chain_id, connection_id, e.detail()
                 );
                 return;
             }
@@ -282,7 +284,11 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
                     return;
                 }
                 Err(e) => {
-                    error!("skipping workers for chain {}. reason: {}", chain_id, e);
+                    error!(
+                        "skipping workers for chain {}. reason: {}",
+                        chain_id,
+                        e.detail()
+                    );
                     return;
                 }
                 _ => {} // allowed
@@ -299,7 +305,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
                 "skipped workers for connection {} on chain {}, reason: {}",
                 connection.connection_id,
                 chain.id(),
-                e
+                e.detail()
             ),
         }
 
@@ -343,7 +349,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             Err(e) => {
                 error!(
                     "skipping workers for chain {} and connection {}, reason: failed to query its channels: {}",
-                    chain.id(), connection_id, e
+                    chain.id(), connection_id, e.detail()
                 );
 
                 return;
@@ -363,7 +369,7 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
                     "skipped workers for chain {} and channel {} due to error {}",
                     chain.id(),
                     channel_id,
-                    e
+                    e.detail()
                 ),
             }
         }

--- a/relayer/src/worker.rs
+++ b/relayer/src/worker.rs
@@ -131,7 +131,7 @@ impl<ChainA: ChainHandle + 'static, ChainB: ChainHandle + 'static> Worker<ChainA
         };
 
         if let Err(e) = result {
-            error!("[{}] worker aborted with error: {}", name, e);
+            error!("[{}] worker aborted with error: {}", name, e.detail());
         }
 
         if let Err(e) = msg_tx.send(WorkerMsg::Stopped(id, object)) {

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -145,7 +145,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
                 error!(
                     path = %self.path.short_name(),
                     "[{}] worker: handling command encountered error: {}",
-                    link.a_to_b, e
+                    link.a_to_b, e.detail()
                 );
 
                 return RetryResult::Retry(index);
@@ -159,7 +159,8 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
         {
             error!(
                 "[{}] worker: schedule execution encountered error: {}",
-                link.a_to_b, e
+                link.a_to_b,
+                e.detail()
             );
             return RetryResult::Retry(index);
         }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

Before:

```
$ hermes start
Oct 11 17:31:14.783  INFO ThreadId(01) using default configuration from '/Users/coromac/.hermes/config.toml'
Oct 11 17:31:14.786  INFO ThreadId(01) telemetry service running, exposing metrics at http://127.0.0.1:3001/metrics
Oct 11 17:31:14.787  INFO ThreadId(01) starting REST API server listening at http://127.0.0.1:3002
Oct 11 17:31:14.788  INFO ThreadId(01) Hermes has started
Oct 11 17:31:18.166 ERROR ThreadId(01) skipping health check for chain ibc-0, reason: failed to spawn chain runtime with error:
   0: relayer error
   1: RPC error to endpoint http://127.0.0.1:26657/
   2:
   2:    0: HTTP error
   2:    1: error trying to connect: tcp connect error: Connection refused (os error 61)

   2: Location:
   2:    /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.3/src/tracer_impl/eyre.rs:10

   2:   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   2:                                 ⋮ 10 frames hidden ⋮
   2:   11: flex_error::tracer_impl::eyre::<impl flex_error::tracer::ErrorMessageTracer for eyre::Report>::new_message::hcb1a49df74ce3449
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.3/src/tracer_impl/eyre.rs:10
   2:   12: <flex_error::source::DisplayOnly<E> as flex_error::source::ErrorSource<Tracer>>::error_details::hd2a4aff1a7423413
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.3/src/source.rs:142
   2:   13: tendermint_rpc::error::Error::trace_from::hf9dff4da5257af13
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.3/src/macros.rs:547
   2:   14: tendermint_rpc::error::Error::hyper::hea3725d13ab2d3f2
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.3/src/macros.rs:863
   2:   15: core::ops::function::FnOnce::call_once::h09b8eac2c3504890
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227
   2:   16: core::result::Result<T,E>::map_err::h43f719b44ab8c3f9
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/result.rs:835
   2:   17: tendermint_rpc::client::transport::http::sealed::HyperClient<C>::perform::{{closure}}::h823af48468bd348b
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tendermint-rpc-0.22.0/src/client/transport/http.rs:187
   2:   18: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hd5e8ca7f82b3f902
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80
   2:   19: tendermint_rpc::client::transport::http::sealed::HttpClient::perform::{{closure}}::h59e981148e84adfa
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tendermint-rpc-0.22.0/src/client/transport/http.rs:275
   2:   20: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hc32390206ac7d05e
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80
   2:   21: <tendermint_rpc::client::transport::http::HttpClient as tendermint_rpc::client::Client>::perform::{{closure}}::he0a65fb42c42a666
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tendermint-rpc-0.22.0/src/client/transport/http.rs:88
   2:   22: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h63449808ba065413
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80
   2:   23: <core::pin::Pin<P> as core::future::future::Future>::poll::hdef627ab66b343da
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/future.rs:119
   2:   24: tendermint_rpc::client::Client::status::{{closure}}::hb3d2b0868941e21e
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tendermint-rpc-0.22.0/src/client.rs:231
   2:   25: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h94e0006c74871840
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80
   2:   26: <core::pin::Pin<P> as core::future::future::Future>::poll::hdef627ab66b343da
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/future.rs:119
   2:   27: tokio::park::thread::CachedParkThread::block_on::{{closure}}::hcb785b80eeb7570f
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/park/thread.rs:263
   2:   28: tokio::coop::with_budget::{{closure}}::hd074088bb2479ed1
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/coop.rs:106
   2:   29: std::thread::local::LocalKey<T>::try_with::he81ef500470dd44e
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/thread/local.rs:399
   2:   30: std::thread::local::LocalKey<T>::with::h8632e339f62425ac
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/thread/local.rs:375
   2:   31: tokio::coop::with_budget::hc2f94ef94a351e0b
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/coop.rs:99
   2:   32: tokio::coop::budget::h1a80f2d6e539a9bd
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/coop.rs:76
   2:   33: tokio::park::thread::CachedParkThread::block_on::hd9b9eff7a7f8f75d
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/park/thread.rs:263
   2:   34: tokio::runtime::enter::Enter::block_on::heb686770cbe1dc97
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/enter.rs:151
   2:   35: tokio::runtime::thread_pool::ThreadPool::block_on::h19b5e3705eabd5c3
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/mod.rs:77
   2:   36: tokio::runtime::Runtime::block_on::h180209b8f88d55bf
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/mod.rs:463
   2:   37: <ibc_relayer::chain::cosmos::CosmosSdkChain as ibc_relayer::chain::ChainEndpoint>::init_light_client::h78cbf6f94df49471
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/chain/cosmos.rs:694
   2:   38: ibc_relayer::chain::runtime::ChainRuntime<Endpoint>::spawn::h6be76ea9f3332111
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/chain/runtime.rs:107
   2:   39: ibc_relayer::registry::spawn_chain_runtime::hd73ea981d5844d11
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/registry.rs:131
   2:   40: ibc_relayer::registry::Registry<Chain>::spawn::he4f37beb3d815811
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/registry.rs:97
   2:   41: ibc_relayer::registry::Registry<Chain>::get_or_spawn::h6a5068f288e57bf7
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/registry.rs:81
   2:   42: ibc_relayer::supervisor::Supervisor<Chain>::health_check::h5cbc1da3bb323caf
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/supervisor.rs:366
   2:   43: ibc_relayer::supervisor::Supervisor<Chain>::run::ha8ca781f5a3b692c
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer/src/supervisor.rs:386
   2:   44: <ibc_relayer_cli::commands::start::StartCmd as abscissa_core::runnable::Runnable>::run::h32c4de1a12b4de76
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer-cli/src/commands/start.rs:46
   2:   45: ibc_relayer_cli::commands::_DERIVE_Runnable_FOR_CliCmd::<impl abscissa_core::runnable::Runnable for ibc_relayer_cli::commands::CliCmd>::run::h128d87ca72049e11
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer-cli/src/commands.rs:43
   2:   46: <ibc_relayer_cli::entry::EntryPoint<Cmd> as abscissa_core::runnable::Runnable>::run::h2b9aa9a495118aff
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer-cli/src/entry.rs:47
   2:   47: abscissa_core::application::Application::run::hd8db04c06eb86bab
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/application.rs:64
   2:   48: abscissa_core::application::boot::h23fa3d5c78938564
   2:       at /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/application.rs:196
   2:   49: hermes::main::h3e2a597f132ab923
   2:       at /Users/coromac/Informal/Code/Current/ibc-rs/relayer-cli/src/bin/hermes/main.rs:11
   2:   50: core::ops::function::FnOnce::call_once::h95907b9fd5b19c96
   2:       at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227
   2:                                 ⋮ 13 frames hidden ⋮

   2: Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
   2: Run with RUST_BACKTRACE=full to include source snippets.
   3: HTTP error
   4: error trying to connect: tcp connect error: Connection refused (os error 61)

Location:
   /Users/coromac/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.3/src/tracer_impl/eyre.rs:31
```

After:

```
$ hermes start
Oct 11 17:44:20.305  INFO ThreadId(01) using default configuration from '/Users/coromac/.hermes/config.toml'
Oct 11 17:44:20.308  INFO ThreadId(01) telemetry service running, exposing metrics at http://127.0.0.1:3001/metrics
Oct 11 17:44:20.308  INFO ThreadId(01) starting REST API server listening at http://127.0.0.1:3002
Oct 11 17:44:20.310  INFO ThreadId(01) Hermes has started
Oct 11 17:44:23.840 ERROR ThreadId(01) skipping health check for chain ibc-0, reason: failed to spawn chain runtime with error: relayer error
Oct 11 17:44:23.843 ERROR ThreadId(01) skipping health check for chain ibc-1, reason: failed to spawn chain runtime with error: relayer error
Oct 11 17:44:23.868 ERROR ThreadId(01) skipping workers for chain ibc-0, reason: failed to spawn chain runtime with error: relayer error
Oct 11 17:44:23.872 ERROR ThreadId(01) skipping workers for chain ibc-1, reason: failed to spawn chain runtime with error: relayer error
Oct 11 17:44:23.876 ERROR ThreadId(01) failed to spawn chain runtime for ibc-0: relayer error
Oct 11 17:44:23.878 ERROR ThreadId(01) failed to spawn chain runtime for ibc-1: relayer error
Error: Hermes failed to start, last error: supervisor was not able to connect to any chains
```

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
