### PR TITLE
Pin nightly version for no-std check until it works again on latest nightly

### DIFF
--- a/.github/workflows/no-std.yaml
+++ b/.github/workflows/no-std.yaml
@@ -30,6 +30,7 @@ jobs:
           override: true
       - run: |
           cd ci/no-std-check
+          make setup
           make check-panic-conflict
 
   check-substrate:
@@ -44,4 +45,5 @@ jobs:
           override: true
       - run: |
           cd ci/no-std-check
+          make setup
           make check-substrate

--- a/ci/no-std-check/Makefile
+++ b/ci/no-std-check/Makefile
@@ -1,4 +1,4 @@
-NIGHTLY_VERSION=nightly
+NIGHTLY_VERSION=nightly-2022-09-22
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
The `no_std` check for Substrate is broken on current nightly because of an internal compiler error (ICE).