### PR TITLE
Add test for clearing packets on an ordered channel

### DIFF
--- a/crates/relayer/src/chain/cosmos/types/config.rs
+++ b/crates/relayer/src/chain/cosmos/types/config.rs
@@ -6,6 +6,7 @@ use ibc_proto::google::protobuf::Any;
 use tendermint_rpc::{HttpClient, Url};
 
 use crate::chain::cosmos::types::gas::GasConfig;
+use crate::config::types::{MaxMsgNum, MaxTxSize};
 use crate::config::{AddressType, ChainConfig};
 use crate::error::Error;
 
@@ -18,6 +19,8 @@ pub struct TxConfig {
     pub grpc_address: Uri,
     pub rpc_timeout: Duration,
     pub address_type: AddressType,
+    pub max_msg_num: MaxMsgNum,
+    pub max_tx_size: MaxTxSize,
     pub extension_options: Vec<Any>,
 }
 
@@ -47,6 +50,8 @@ impl<'a> TryFrom<&'a ChainConfig> for TxConfig {
             grpc_address,
             rpc_timeout: config.rpc_timeout,
             address_type: config.address_type.clone(),
+            max_msg_num: config.max_msg_num,
+            max_tx_size: config.max_tx_size,
             extension_options,
         })
     }

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -7,15 +7,15 @@
 
 pub mod clear_packet;
 pub mod client_expiration;
-mod client_refresh;
-mod client_settings;
+pub mod client_refresh;
+pub mod client_settings;
 pub mod connection_delay;
 pub mod denom_trace;
 pub mod error_events;
 pub mod execute_schedule;
 pub mod memo;
 pub mod python;
-mod query_packet;
+pub mod query_packet;
 pub mod supervisor;
 pub mod tendermint;
 pub mod ternary_transfer;
@@ -23,6 +23,9 @@ pub mod transfer;
 
 #[cfg(any(doc, feature = "ordered"))]
 pub mod ordered_channel;
+
+#[cfg(any(doc, feature = "ordered"))]
+pub mod ordered_channel_clear;
 
 #[cfg(any(doc, feature = "ica"))]
 pub mod ica;

--- a/tools/integration-test/src/tests/ordered_channel_clear.rs
+++ b/tools/integration-test/src/tests/ordered_channel_clear.rs
@@ -1,0 +1,103 @@
+use ibc_relayer::link::{Link, LinkParameters};
+use ibc_test_framework::ibc::denom::derive_ibc_denom;
+use ibc_test_framework::prelude::*;
+use ibc_test_framework::util::random::random_u64_range;
+
+#[test]
+fn test_ordered_channel_clear() -> Result<(), Error> {
+    run_binary_channel_test(&OrderedChannelClearTest)
+}
+
+pub struct OrderedChannelClearTest;
+
+impl TestOverrides for OrderedChannelClearTest {
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+
+    fn channel_order(&self) -> Order {
+        Order::Ordered
+    }
+}
+
+impl BinaryChannelTest for OrderedChannelClearTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        _relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channel: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let denom_a = chains.node_a.denom();
+
+        let wallet_a = chains.node_a.wallets().user1().cloned();
+        let wallet_b = chains.node_b.wallets().user1().cloned();
+
+        let balance_a = chains
+            .node_a
+            .chain_driver()
+            .query_balance(&wallet_a.address(), &denom_a)?;
+
+        let amount = random_u64_range(1000, 5000);
+        let num_msgs = 300_usize;
+        let total_amount = amount * u64::try_from(num_msgs).unwrap();
+
+        info!(
+            "Performing {} IBC transfers with amount {} on an ordered channel",
+            num_msgs, amount
+        );
+
+        chains.node_a.chain_driver().ibc_transfer_token_multiple(
+            &channel.port_a.as_ref(),
+            &channel.channel_id_a.as_ref(),
+            &wallet_a.as_ref(),
+            &wallet_b.address(),
+            &denom_a,
+            amount,
+            num_msgs,
+        )?;
+
+        sleep(Duration::from_secs(10));
+
+        let chain_a_link_opts = LinkParameters {
+            src_port_id: channel.port_a.clone().into_value(),
+            src_channel_id: channel.channel_id_a.clone().into_value(),
+        };
+
+        let chain_a_link = Link::new_from_opts(
+            chains.handle_a().clone(),
+            chains.handle_b().clone(),
+            chain_a_link_opts,
+            true,
+        )?;
+
+        let mut relay_path_a_to_b = chain_a_link.a_to_b;
+
+        relay_path_a_to_b.schedule_packet_clearing(None)?;
+        relay_path_a_to_b.execute_schedule()?;
+
+        sleep(Duration::from_secs(10));
+
+        let denom_b = derive_ibc_denom(
+            &channel.port_b.as_ref(),
+            &channel.channel_id_b.as_ref(),
+            &denom_a,
+        )?;
+
+        // Wallet on chain A should have sum of amounts deducted
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a.address(),
+            balance_a - total_amount,
+            &denom_a,
+        )?;
+
+        // Wallet on chain B should received IBC transfers
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b.address(),
+            amount + total_amount,
+            &denom_b.as_ref(),
+        )?;
+
+        Ok(())
+    }
+}

--- a/tools/test-framework/src/chain/ext/transfer.rs
+++ b/tools/test-framework/src/chain/ext/transfer.rs
@@ -39,6 +39,17 @@ pub trait ChainTransferMethodsExt<Chain> {
         amount: u64,
     ) -> Result<(), Error>;
 
+    fn ibc_transfer_token_multiple<Counterparty>(
+        &self,
+        port_id: &TaggedPortIdRef<Chain, Counterparty>,
+        channel_id: &TaggedChannelIdRef<Chain, Counterparty>,
+        sender: &MonoTagged<Chain, &Wallet>,
+        recipient: &MonoTagged<Counterparty, &WalletAddress>,
+        denom: &MonoTagged<Chain, &Denom>,
+        amount: u64,
+        num_msgs: usize,
+    ) -> Result<(), Error>;
+
     fn local_transfer_token(
         &self,
         sender: &MonoTagged<Chain, &Wallet>,
@@ -66,6 +77,29 @@ impl<'a, Chain: Send> ChainTransferMethodsExt<Chain> for MonoTagged<Chain, &'a C
             recipient,
             denom,
             amount,
+            1,
+        ))
+    }
+
+    fn ibc_transfer_token_multiple<Counterparty>(
+        &self,
+        port_id: &TaggedPortIdRef<Chain, Counterparty>,
+        channel_id: &TaggedChannelIdRef<Chain, Counterparty>,
+        sender: &MonoTagged<Chain, &Wallet>,
+        recipient: &MonoTagged<Counterparty, &WalletAddress>,
+        denom: &MonoTagged<Chain, &Denom>,
+        amount: u64,
+        num_msgs: usize,
+    ) -> Result<(), Error> {
+        self.value().runtime.block_on(ibc_token_transfer(
+            &self.tx_config(),
+            port_id,
+            channel_id,
+            sender,
+            recipient,
+            denom,
+            amount,
+            num_msgs,
         ))
     }
 


### PR DESCRIPTION
Temporary PR to exercise the packet clearing on an ordered channel described in #2670 and tentatively fixed in #2687.

Will eventually be merged into #2687.