### PR TITLE
Improve `hermes keys balance` command to output more information

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer-cli/2726-new-keys-balance-flag.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/2726-new-keys-balance-flag.md
@@ -1,0 +1,4 @@
+- Added a new optional flag, `--denom` to the `hermes keys balance` command in order
+  to specify for which denomination the balance is queried. A special
+  value, `all`, can be used to query the balance for all denominations
+  ([#2726](https://github.com/informalsystems/ibc-rs/issues/2726))

--- a/crates/relayer/src/chain/cosmos/query/balance.rs
+++ b/crates/relayer/src/chain/cosmos/query/balance.rs
@@ -58,15 +58,14 @@ pub async fn query_all_balances(
         .map(|r| r.into_inner())
         .map_err(Error::grpc_status)?;
 
-    // Querying for a balance might fail, i.e. if the account doesn't actually exist
-    let balances = response.balances;
-
-    let balances = balances
-        .iter()
+    let balances = response
+        .balances
+        .into_iter()
         .map(|balance| Balance {
-            amount: balance.amount.clone(),
-            denom: balance.denom.clone(),
+            amount: balance.amount,
+            denom: balance.denom,
         })
         .collect();
+
     Ok(balances)
 }

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -162,9 +162,18 @@ pub trait ChainEndpoint: Sized {
 
     // Queries
 
-    /// Query the balance of the given account for the denom used to pay tx fees.
+    /// Query the balance of the given account for the given denom.
     /// If no account is given, behavior must be specified, e.g. retrieve it from configuration file.
-    fn query_balance(&self, key_name: Option<String>) -> Result<Balance, Error>;
+    /// If no denom is given, behavior must be specified, e.g. retrieve the denom used to pay tx fees.
+    fn query_balance(
+        &self,
+        key_name: Option<String>,
+        denom: Option<String>,
+    ) -> Result<Balance, Error>;
+
+    /// Query the balances of the given account for all the denom.
+    /// If no account is given, behavior must be specified, e.g. retrieve it from configuration file.
+    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error>;
 
     /// Query the denomination trace given a trace hash.
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error>;

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -165,15 +165,11 @@ pub trait ChainEndpoint: Sized {
     /// Query the balance of the given account for the given denom.
     /// If no account is given, behavior must be specified, e.g. retrieve it from configuration file.
     /// If no denom is given, behavior must be specified, e.g. retrieve the denom used to pay tx fees.
-    fn query_balance(
-        &self,
-        key_name: Option<String>,
-        denom: Option<String>,
-    ) -> Result<Balance, Error>;
+    fn query_balance(&self, key_name: Option<&str>, denom: Option<&str>) -> Result<Balance, Error>;
 
     /// Query the balances of the given account for all the denom.
     /// If no account is given, behavior must be specified, e.g. retrieve it from configuration file.
-    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error>;
+    fn query_all_balances(&self, key_name: Option<&str>) -> Result<Vec<Balance>, Error>;
 
     /// Query the denomination trace given a trace hash.
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error>;

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -144,7 +144,13 @@ pub enum ChainRequest {
 
     QueryBalance {
         key_name: Option<String>,
+        denom: Option<String>,
         reply_to: ReplyTo<Balance>,
+    },
+
+    QueryAllBalances {
+        key_name: Option<String>,
+        reply_to: ReplyTo<Vec<Balance>>,
     },
 
     QueryDenomTrace {
@@ -385,9 +391,18 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
     /// Return the version of the IBC protocol that this chain is running, if known.
     fn ibc_version(&self) -> Result<Option<semver::Version>, Error>;
 
-    /// Query the balance of the given account for the denom used to pay tx fees.
+    /// Query the balance of the given account for the given denom.
     /// If no account is given, behavior must be specified, e.g. retrieve it from configuration file.
-    fn query_balance(&self, key_name: Option<String>) -> Result<Balance, Error>;
+    /// If no denom is given, behavior must be specified, e.g. using the denom used to pay tx fees
+    fn query_balance(
+        &self,
+        key_name: Option<String>,
+        denom: Option<String>,
+    ) -> Result<Balance, Error>;
+
+    /// Query the balances from all denom of the given account.
+    /// If no account is given, behavior must be specified, e.g. retrieve it from configuration file.
+    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error>;
 
     /// Query the denomination trace given a trace hash.
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error>;

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -146,8 +146,20 @@ impl ChainHandle for BaseChainHandle {
         self.send(|reply_to| ChainRequest::IbcVersion { reply_to })
     }
 
-    fn query_balance(&self, key_name: Option<String>) -> Result<Balance, Error> {
-        self.send(|reply_to| ChainRequest::QueryBalance { key_name, reply_to })
+    fn query_balance(
+        &self,
+        key_name: Option<String>,
+        denom: Option<String>,
+    ) -> Result<Balance, Error> {
+        self.send(|reply_to| ChainRequest::QueryBalance {
+            key_name,
+            denom,
+            reply_to,
+        })
+    }
+
+    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error> {
+        self.send(|reply_to| ChainRequest::QueryAllBalances { key_name, reply_to })
     }
 
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error> {

--- a/crates/relayer/src/chain/handle/cache.rs
+++ b/crates/relayer/src/chain/handle/cache.rs
@@ -126,8 +126,16 @@ impl<Handle: ChainHandle> ChainHandle for CachingChainHandle<Handle> {
         self.inner().ibc_version()
     }
 
-    fn query_balance(&self, key_name: Option<String>) -> Result<Balance, Error> {
-        self.inner().query_balance(key_name)
+    fn query_balance(
+        &self,
+        key_name: Option<String>,
+        denom: Option<String>,
+    ) -> Result<Balance, Error> {
+        self.inner().query_balance(key_name, denom)
+    }
+
+    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error> {
+        self.inner().query_all_balances(key_name)
     }
 
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error> {

--- a/crates/relayer/src/chain/handle/counting.rs
+++ b/crates/relayer/src/chain/handle/counting.rs
@@ -151,9 +151,18 @@ impl<Handle: ChainHandle> ChainHandle for CountingChainHandle<Handle> {
         self.inner().ibc_version()
     }
 
-    fn query_balance(&self, key_name: Option<String>) -> Result<Balance, Error> {
+    fn query_balance(
+        &self,
+        key_name: Option<String>,
+        denom: Option<String>,
+    ) -> Result<Balance, Error> {
         self.inc_metric("query_balance");
-        self.inner().query_balance(key_name)
+        self.inner().query_balance(key_name, denom)
+    }
+
+    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error> {
+        self.inc_metric("query_all_balance");
+        self.inner().query_all_balances(key_name)
     }
 
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error> {

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -303,8 +303,12 @@ where
                             self.build_channel_proofs(port_id, channel_id, height, reply_to)?
                         },
 
-                        ChainRequest::QueryBalance { key_name, reply_to } => {
-                            self.query_balance(key_name, reply_to)?
+                        ChainRequest::QueryBalance { key_name, denom, reply_to } => {
+                            self.query_balance(key_name, denom, reply_to)?
+                        },
+
+                        ChainRequest::QueryAllBalances { key_name, reply_to } => {
+                            self.query_all_balances(key_name, reply_to)?
                         },
 
                         ChainRequest::QueryDenomTrace { hash, reply_to } => {
@@ -474,10 +478,20 @@ where
     fn query_balance(
         &self,
         key_name: Option<String>,
+        denom: Option<String>,
         reply_to: ReplyTo<Balance>,
     ) -> Result<(), Error> {
-        let balance = self.chain.query_balance(key_name);
+        let balance = self.chain.query_balance(key_name, denom);
         reply_to.send(balance).map_err(Error::send)
+    }
+
+    fn query_all_balances(
+        &self,
+        key_name: Option<String>,
+        reply_to: ReplyTo<Vec<Balance>>,
+    ) -> Result<(), Error> {
+        let balances = self.chain.query_all_balances(key_name);
+        reply_to.send(balances).map_err(Error::send)
     }
 
     fn query_denom_trace(&self, hash: String, reply_to: ReplyTo<DenomTrace>) -> Result<(), Error> {

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -481,7 +481,10 @@ where
         denom: Option<String>,
         reply_to: ReplyTo<Balance>,
     ) -> Result<(), Error> {
-        let balance = self.chain.query_balance(key_name, denom);
+        let balance = self
+            .chain
+            .query_balance(key_name.as_deref(), denom.as_deref());
+
         reply_to.send(balance).map_err(Error::send)
     }
 
@@ -490,7 +493,7 @@ where
         key_name: Option<String>,
         reply_to: ReplyTo<Vec<Balance>>,
     ) -> Result<(), Error> {
-        let balances = self.chain.query_all_balances(key_name);
+        let balances = self.chain.query_all_balances(key_name.as_deref());
         reply_to.send(balances).map_err(Error::send)
     }
 

--- a/crates/relayer/src/worker/wallet.rs
+++ b/crates/relayer/src/worker/wallet.rs
@@ -16,7 +16,7 @@ pub fn spawn_wallet_worker<Chain: ChainHandle>(chain: Chain) -> TaskHandle {
             TaskError::Fatal(format!("failed to get key in use by the relayer: {e}"))
         })?;
 
-        let balance = chain.query_balance(None).map_err(|e| {
+        let balance = chain.query_balance(None, None).map_err(|e| {
             TaskError::Ignore(format!("failed to query balance for the account: {e}"))
         })?;
 

--- a/guide/src/templates/help_templates/keys/balance.md
+++ b/guide/src/templates/help_templates/keys/balance.md
@@ -6,6 +6,10 @@ USAGE:
     hermes keys balance [OPTIONS] --chain <CHAIN_ID>
 
 OPTIONS:
+        --all                    (optional) query the balance for all denom. This flag overwrites
+                                 the `--denom` flag (defaults to false)
+        --denom <DENOM>          (optional) query the balance for the given denom (defaults to the
+                                 `denom` defined in the config for the gas price)
     -h, --help                   Print help information
         --key-name <KEY_NAME>    (optional) name of the key (defaults to the `key_name` defined in
                                  the config)

--- a/tools/test-framework/src/relayer/chain.rs
+++ b/tools/test-framework/src/relayer/chain.rs
@@ -400,8 +400,16 @@ where
         self.value().query_host_consensus_state(request)
     }
 
-    fn query_balance(&self, key_name: Option<String>) -> Result<Balance, Error> {
-        self.value().query_balance(key_name)
+    fn query_balance(
+        &self,
+        key_name: Option<String>,
+        denom: Option<String>,
+    ) -> Result<Balance, Error> {
+        self.value().query_balance(key_name, denom)
+    }
+
+    fn query_all_balances(&self, key_name: Option<String>) -> Result<Vec<Balance>, Error> {
+        self.value().query_all_balances(key_name)
     }
 
     fn query_denom_trace(&self, hash: String) -> Result<DenomTrace, Error> {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2726

## Description

The command `hermes keys balance` only output the balance of the config's `gas_price` denomination.
This PR adds an optional flag `--denom` which allows the user to specify the denomination desired, ~as well as a special argument for the new flag `all` which lists the balance for all denominations~.
A second optional flag `--all` can be used to display the balance of all denominations. If both `--denom` and `--all` are passed, the flag `--all` overwrites the flag `--denom`. 

### Testing

In order to test the new flag first setup the environment using gm, with the following `gm.toml`:

```
[global]
  add_to_hermes = false
  auto_maintain_config = true
  extra_wallets = 2
  gaiad_binary = "/Users/luca/go/bin/gaiad"
  hdpath = ""
  home_dir = "/Users/luca/.gm"
  ports_start_at = 27000
  validator_mnemonic = ""
  wallet_mnemonic = ""

  [global.hermes]
    binary = "$HOME/.hermes/bin/hermes"
    config = "$HOME/.hermes/config.toml"
    log_level = "info"
    telemetry_enabled = true
    telemetry_host = "127.0.0.1"
    telemetry_port = 3001

[ibc-0]
  ports_start_at = 27010

[ibc-1]
  ports_start_at = 27020

[ibc-2]
  ports_start_at = 27030

[ibc-3]
  ports_start_at = 27040

[node-0]
  add_to_hermes = true
  network = "ibc-0"
  ports_start_at = 27050

[node-1]
  add_to_hermes = true
  network = "ibc-1"
  ports_start_at = 27060

[node-2]
  add_to_hermes = true
  network = "ibc-2"
  ports_start_at = 27070

[node-3]
  add_to_hermes = true
  network = "ibc-3"
  ports_start_at = 27080
```

Run the following commands:

1. `gm start`
2. `gm hermes config`
3. `gm hermes keys`

The denom specified in the Hermes `config.toml` file should be `stake` (`gas_price = { price = 0.01, denom = 'stake' }`).

The following commands have different results :

1. `hermes keys balance --chain ibc-1`
    * Outputs the balance in `stake` for the user specified in the Hermes `config.toml` (`key_name = 'wallet'`)
2. `hermes keys balance --chain ibc-1 --denom samoleans`
    * Outputs the balance in `samoleans` for the user specified in the Hermes `config.toml` (`key_name = 'wallet'`)
3. `hermes keys balance --chain ibc-1 --all`
    * Outputs the balance for `stake` and `samoleans ` for the user specified in the Hermes `config.toml` (`key_name = 'wallet'`)
4. `hermes keys balance --chain ibc-1 --denom samoleans --all`
    * Ignore the `--denom samoleans` flag and outputs the balance for `stake` and `samoleans ` for the user specified in the Hermes `config.toml` (`key_name = 'wallet'`)

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
