### PR TITLE
Fix handshake workers to process pending events

### DIFF
--- a/crates/relayer/src/channel.rs
+++ b/crates/relayer/src/channel.rs
@@ -762,6 +762,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
             _ => None,
         };
 
+        // Abort if the channel is at OpenAck or OpenConfirm stage, as there is nothing more for the worker to do
         match event {
             Some(IbcEvent::OpenConfirmChannel(_)) | Some(IbcEvent::OpenAckChannel(_)) => {
                 Ok((event, Next::Abort))

--- a/crates/relayer/src/channel.rs
+++ b/crates/relayer/src/channel.rs
@@ -747,7 +747,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
         &mut self,
         state: State,
     ) -> Result<(Option<IbcEvent>, Next), ChannelError> {
-        let res = match (state, self.counterparty_state()?) {
+        let event = match (state, self.counterparty_state()?) {
             (State::Init, State::Uninitialized) => Some(self.build_chan_open_try_and_send()?),
             (State::Init, State::Init) => Some(self.build_chan_open_try_and_send()?),
             (State::TryOpen, State::Init) => Some(self.build_chan_open_ack_and_send()?),
@@ -762,7 +762,12 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
             _ => None,
         };
 
-        Ok((res, Next::Continue))
+        match event {
+            Some(IbcEvent::OpenConfirmChannel(_)) | Some(IbcEvent::OpenAckChannel(_)) => {
+                Ok((event, Next::Abort))
+            }
+            _ => Ok((event, Next::Continue)),
+        }
     }
 
     pub fn step_state(&mut self, state: State, index: u64) -> RetryResult<Next, u64> {

--- a/crates/relayer/src/connection.rs
+++ b/crates/relayer/src/connection.rs
@@ -726,6 +726,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
             _ => None,
         };
 
+        // Abort if the connection is at OpenAck or OpenConfirm stage, as there is nothing more for the worker to do
         match event {
             Some(IbcEvent::OpenConfirmConnection(_)) | Some(IbcEvent::OpenAckConnection(_)) => {
                 Ok((event, Next::Abort))

--- a/crates/relayer/src/connection.rs
+++ b/crates/relayer/src/connection.rs
@@ -726,7 +726,12 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
             _ => None,
         };
 
-        Ok((event, Next::Continue))
+        match event {
+            Some(IbcEvent::OpenConfirmConnection(_)) | Some(IbcEvent::OpenAckConnection(_)) => {
+                Ok((event, Next::Abort))
+            }
+            _ => Ok((event, Next::Continue)),
+        }
     }
 
     pub fn step_state(&mut self, state: State, index: u64) -> RetryResult<Next, u64> {

--- a/crates/relayer/src/worker/channel.rs
+++ b/crates/relayer/src/worker/channel.rs
@@ -19,6 +19,7 @@ pub fn spawn_channel_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
     chains: ChainHandlePair<ChainA, ChainB>,
     cmd_rx: Receiver<WorkerCmd>,
 ) -> TaskHandle {
+    let mut clear_pending = true;
     spawn_background_task(
         error_span!("worker.channel", channel = %channel.short_name()),
         Some(Duration::from_millis(200)),
@@ -31,6 +32,7 @@ pub fn spawn_channel_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
                         let last_event = batch.events.last();
                         debug!("starts processing {:?}", last_event);
 
+                        clear_pending = false;
                         if let Some(event_with_height) = last_event {
                             let mut handshake_channel = RelayChannel::restore_from_event(
                                 chains.a.clone(),
@@ -48,11 +50,33 @@ pub fn spawn_channel_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
                         }
                     }
 
-                    // nothing to do
-                    WorkerCmd::NewBlock { .. } => Ok(Next::Continue),
+                    WorkerCmd::NewBlock {
+                        height: current_height,
+                        new_block: _,
+                    } if clear_pending => {
+                        debug!("starts processing block event at {:#?}", current_height);
+
+                        let height = current_height
+                            .decrement()
+                            .map_err(|e| TaskError::Fatal(RunError::ics02(e)))?;
+
+                        let (mut handshake_channel, state) = RelayChannel::restore_from_state(
+                            chains.a.clone(),
+                            chains.b.clone(),
+                            channel.clone(),
+                            height,
+                        )
+                        .map_err(|e| TaskError::Fatal(RunError::channel(e)))?;
+
+                        clear_pending = false;
+                        retry_with_index(retry_strategy::worker_default_strategy(), |index| {
+                            handshake_channel.step_state(state, index)
+                        })
+                        .map_err(|e| TaskError::Fatal(RunError::retry(e)))
+                    }
 
                     // nothing to do
-                    WorkerCmd::ClearPendingPackets => Ok(Next::Continue),
+                    _ => Ok(Next::Continue),
                 }
             } else {
                 Ok(Next::Continue)

--- a/crates/relayer/src/worker/connection.rs
+++ b/crates/relayer/src/worker/connection.rs
@@ -19,6 +19,7 @@ pub fn spawn_connection_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
     chains: ChainHandlePair<ChainA, ChainB>,
     cmd_rx: Receiver<WorkerCmd>,
 ) -> TaskHandle {
+    let mut clear_pending = true;
     spawn_background_task(
         error_span!("worker.connection", connection = %connection.short_name()),
         Some(Duration::from_millis(200)),
@@ -32,6 +33,7 @@ pub fn spawn_connection_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
 
                         debug!("starts processing {:?}", last_event_with_height);
 
+                        clear_pending = false;
                         if let Some(event_with_height) = last_event_with_height {
                             let mut handshake_connection = RelayConnection::restore_from_event(
                                 chains.a.clone(),
@@ -49,11 +51,35 @@ pub fn spawn_connection_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
                         }
                     }
 
-                    // nothing to do
-                    WorkerCmd::NewBlock { .. } => Ok(Next::Continue),
+                    WorkerCmd::NewBlock {
+                        height: current_height,
+                        new_block: _,
+                    } if clear_pending => {
+                        debug!("starts processing block event at {}", current_height);
+
+                        let height = current_height
+                            .decrement()
+                            .map_err(|e| TaskError::Fatal(RunError::ics02(e)))?;
+
+                        let (mut handshake_connection, state) =
+                            RelayConnection::restore_from_state(
+                                chains.a.clone(),
+                                chains.b.clone(),
+                                connection.clone(),
+                                height,
+                            )
+                            .map_err(|e| TaskError::Fatal(RunError::connection(e)))?;
+
+                        clear_pending = false;
+
+                        retry_with_index(retry_strategy::worker_default_strategy(), |index| {
+                            handshake_connection.step_state(state, index)
+                        })
+                        .map_err(|e| TaskError::Fatal(RunError::retry(e)))
+                    }
 
                     // nothing to do
-                    WorkerCmd::ClearPendingPackets => Ok(Next::Continue),
+                    _ => Ok(Next::Continue),
                 }
             } else {
                 Ok(Next::Continue)

--- a/e2e/e2e/channel.py
+++ b/e2e/e2e/channel.py
@@ -548,13 +548,10 @@ def verify_state(c: Config,
     ibc1_chan_id: ChannelId, port_id: PortId):
 
     mode = toml.load(c.config_file)['mode']
-    clients_enabled = mode['clients']['enabled']
-    conn_enabled = mode['connections']['enabled']
     chan_enabled = mode['channels']['enabled']
-    packets_enabled = mode['packets']['enabled']
 
-    # verify connection state on both chains, should be 'Open' or 'Init' depending on config 'mode'
-    if clients_enabled and conn_enabled and chan_enabled and packets_enabled:
+    # verify channel state on both chains, should be 'Open' or 'Init' depending on config 'mode'
+    if chan_enabled:
         sleep(10.0)
         for i in range(20):
             sleep(2.0)

--- a/e2e/e2e/connection.py
+++ b/e2e/e2e/connection.py
@@ -264,13 +264,10 @@ def verify_state(c: Config,
     ibc1_conn_id: ConnectionId):
 
     mode = toml.load(c.config_file)['mode']
-    clients_enabled = mode['clients']['enabled']
     conn_enabled = mode['connections']['enabled']
-    chan_enabled = mode['channels']['enabled']
-    packets_enabled = mode['packets']['enabled']
 
     # verify connection state on both chains, should be 'Open' or 'Init' depending on config 'mode'
-    if clients_enabled and conn_enabled and chan_enabled and packets_enabled:
+    if conn_enabled:
         sleep(10.0)
         for i in range(20):
             sleep(5.0)

--- a/tools/integration-test/src/tests/handshake_on_start.rs
+++ b/tools/integration-test/src/tests/handshake_on_start.rs
@@ -1,0 +1,116 @@
+use ibc_test_framework::{
+    prelude::*,
+    relayer::{
+        channel::{assert_eventually_channel_established, init_channel},
+        connection::{assert_eventually_connection_established, init_connection},
+    },
+};
+
+#[test]
+fn test_connection_handshake() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionHandshake)
+}
+
+#[test]
+fn test_channel_handshake() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelHandshake)
+}
+
+pub struct ConnectionHandshake;
+
+impl TestOverrides for ConnectionHandshake {
+    fn modify_test_config(&self, config: &mut TestConfig) {
+        config.bootstrap_with_random_ids = false;
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.channels.enabled = false;
+        config.mode.packets.enabled = false;
+        config.mode.clients.enabled = false;
+        config.mode.connections.enabled = true;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChainTest for ConnectionHandshake {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let (connection_id_b, _) = init_connection(
+            &chains.handle_a,
+            &chains.handle_b,
+            &chains.foreign_clients.client_id_a(),
+            &chains.foreign_clients.client_id_b(),
+        )?;
+
+        relayer.with_supervisor(|| {
+            assert_eventually_connection_established(
+                &chains.handle_b,
+                &chains.handle_a,
+                &connection_id_b.as_ref(),
+            )?;
+
+            Ok(())
+        })
+    }
+}
+
+pub struct ChannelHandshake;
+
+impl TestOverrides for ChannelHandshake {
+    fn modify_test_config(&self, config: &mut TestConfig) {
+        config.bootstrap_with_random_ids = false;
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.channels.enabled = true;
+        config.mode.packets.enabled = false;
+        config.mode.clients.enabled = false;
+        config.mode.connections.enabled = false;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryConnectionTest for ChannelHandshake {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        connection: ConnectedConnection<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let port_a = tagged_transfer_port();
+        let port_b = tagged_transfer_port();
+
+        let (channel_id_b, _) = init_channel(
+            &chains.handle_a,
+            &chains.handle_b,
+            &chains.client_id_a(),
+            &chains.client_id_b(),
+            &connection.connection_id_a.as_ref(),
+            &connection.connection_id_b.as_ref(),
+            &port_a.as_ref(),
+            &port_b.as_ref(),
+        )?;
+
+        relayer.with_supervisor(|| {
+            assert_eventually_channel_established(
+                &chains.handle_b,
+                &chains.handle_a,
+                &channel_id_b.as_ref(),
+                &port_b.as_ref(),
+            )?;
+
+            Ok(())
+        })
+    }
+}

--- a/tools/integration-test/src/tests/handshake_on_start.rs
+++ b/tools/integration-test/src/tests/handshake_on_start.rs
@@ -1,33 +1,113 @@
 use ibc_test_framework::{
     prelude::*,
     relayer::{
-        channel::{assert_eventually_channel_established, init_channel},
-        connection::{assert_eventually_connection_established, init_connection},
+        channel::{ack_channel, assert_eventually_channel_established, init_channel, try_channel},
+        connection::{
+            ack_connection, assert_eventually_connection_established, init_connection,
+            try_connection,
+        },
     },
 };
 
 #[test]
-fn test_connection_handshake() -> Result<(), Error> {
-    run_binary_chain_test(&ConnectionHandshake)
+fn test_connection_open_handshake() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionOpenHandshake {
+        enable_worker: true,
+    })
 }
 
 #[test]
-fn test_channel_handshake() -> Result<(), Error> {
-    run_binary_connection_test(&ChannelHandshake)
+fn test_connection_open_handshake_no_worker() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionOpenHandshake {
+        enable_worker: false,
+    })
 }
 
-pub struct ConnectionHandshake;
+#[test]
+fn test_connection_try_handshake() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionTryHandshake {
+        enable_worker: true,
+    })
+}
 
-impl TestOverrides for ConnectionHandshake {
+#[test]
+fn test_connection_try_handshake_no_worker() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionTryHandshake {
+        enable_worker: false,
+    })
+}
+
+#[test]
+fn test_connection_ack_handshake() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionAckHandshake {
+        enable_worker: true,
+    })
+}
+
+#[test]
+fn test_connection_ack_handshake_no_worker() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionAckHandshake {
+        enable_worker: false,
+    })
+}
+
+#[test]
+fn test_channel_open_handshake() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelOpenHandshake {
+        enable_worker: true,
+    })
+}
+
+#[test]
+fn test_channel_open_handshake_no_worker() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelOpenHandshake {
+        enable_worker: false,
+    })
+}
+
+#[test]
+fn test_channel_try_handshake() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelTryHandshake {
+        enable_worker: true,
+    })
+}
+
+#[test]
+fn test_channel_try_handshake_no_worker() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelTryHandshake {
+        enable_worker: false,
+    })
+}
+
+#[test]
+fn test_channel_ack_handshake() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelAckHandshake {
+        enable_worker: true,
+    })
+}
+
+#[test]
+fn test_channel_ack_handshake_no_worker() -> Result<(), Error> {
+    run_binary_connection_test(&ChannelAckHandshake {
+        enable_worker: false,
+    })
+}
+
+pub struct ConnectionOpenHandshake {
+    enable_worker: bool,
+}
+
+impl TestOverrides for ConnectionOpenHandshake {
     fn modify_test_config(&self, config: &mut TestConfig) {
         config.bootstrap_with_random_ids = false;
     }
 
     fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.connections.enabled = self.enable_worker;
+
         config.mode.channels.enabled = false;
         config.mode.packets.enabled = false;
         config.mode.clients.enabled = false;
-        config.mode.connections.enabled = true;
     }
 
     fn should_spawn_supervisor(&self) -> bool {
@@ -35,7 +115,7 @@ impl TestOverrides for ConnectionHandshake {
     }
 }
 
-impl BinaryChainTest for ConnectionHandshake {
+impl BinaryChainTest for ConnectionOpenHandshake {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
         &self,
         _config: &TestConfig,
@@ -50,26 +130,160 @@ impl BinaryChainTest for ConnectionHandshake {
         )?;
 
         relayer.with_supervisor(|| {
-            assert_eventually_connection_established(
+            let result = assert_eventually_connection_established(
                 &chains.handle_b,
                 &chains.handle_a,
                 &connection_id_b.as_ref(),
-            )?;
+            );
+
+            if self.enable_worker {
+                result?;
+            } else {
+                assert_err(
+                    "connection should not end up open when worker is disabled",
+                    result,
+                )?;
+            }
 
             Ok(())
         })
     }
 }
 
-pub struct ChannelHandshake;
+pub struct ConnectionTryHandshake {
+    enable_worker: bool,
+}
 
-impl TestOverrides for ChannelHandshake {
+impl TestOverrides for ConnectionTryHandshake {
     fn modify_test_config(&self, config: &mut TestConfig) {
         config.bootstrap_with_random_ids = false;
     }
 
     fn modify_relayer_config(&self, config: &mut Config) {
-        config.mode.channels.enabled = true;
+        config.mode.connections.enabled = self.enable_worker;
+
+        config.mode.channels.enabled = false;
+        config.mode.packets.enabled = false;
+        config.mode.clients.enabled = false;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChainTest for ConnectionTryHandshake {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let (_connection_id_on_b, connection_to_a_on_b) = init_connection(
+            &chains.handle_a,
+            &chains.handle_b,
+            &chains.foreign_clients.client_id_a(),
+            &chains.foreign_clients.client_id_b(),
+        )?;
+
+        let (connection_id_on_a, _connection_to_b_on_a) =
+            try_connection(&chains.handle_b, &chains.handle_a, &connection_to_a_on_b)?;
+
+        relayer.with_supervisor(|| {
+            let result = assert_eventually_connection_established(
+                &chains.handle_a,
+                &chains.handle_b,
+                &connection_id_on_a.as_ref(),
+            );
+
+            if self.enable_worker {
+                result?;
+            } else {
+                assert_err(
+                    "connection should not end up open when worker is disabled",
+                    result,
+                )?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+pub struct ConnectionAckHandshake {
+    enable_worker: bool,
+}
+
+impl TestOverrides for ConnectionAckHandshake {
+    fn modify_test_config(&self, config: &mut TestConfig) {
+        config.bootstrap_with_random_ids = false;
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.connections.enabled = self.enable_worker;
+
+        config.mode.channels.enabled = false;
+        config.mode.packets.enabled = false;
+        config.mode.clients.enabled = false;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChainTest for ConnectionAckHandshake {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let (connection_id_on_b, connection_to_a_on_b) = init_connection(
+            &chains.handle_a,
+            &chains.handle_b,
+            &chains.foreign_clients.client_id_a(),
+            &chains.foreign_clients.client_id_b(),
+        )?;
+
+        let (_connection_id_on_a, connection_to_b_on_a) =
+            try_connection(&chains.handle_b, &chains.handle_a, &connection_to_a_on_b)?;
+
+        let _ = ack_connection(&chains.handle_a, &chains.handle_b, &connection_to_b_on_a)?;
+
+        relayer.with_supervisor(|| {
+            let result = assert_eventually_connection_established(
+                &chains.handle_b,
+                &chains.handle_a,
+                &connection_id_on_b.as_ref(),
+            );
+
+            if self.enable_worker {
+                result?;
+            } else {
+                assert_err(
+                    "connection should not end up open when worker is disabled",
+                    result,
+                )?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+pub struct ChannelOpenHandshake {
+    enable_worker: bool,
+}
+
+impl TestOverrides for ChannelOpenHandshake {
+    fn modify_test_config(&self, config: &mut TestConfig) {
+        config.bootstrap_with_random_ids = false;
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.channels.enabled = self.enable_worker;
+
         config.mode.packets.enabled = false;
         config.mode.clients.enabled = false;
         config.mode.connections.enabled = false;
@@ -80,7 +294,7 @@ impl TestOverrides for ChannelHandshake {
     }
 }
 
-impl BinaryConnectionTest for ChannelHandshake {
+impl BinaryConnectionTest for ChannelOpenHandshake {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
         &self,
         _config: &TestConfig,
@@ -103,12 +317,161 @@ impl BinaryConnectionTest for ChannelHandshake {
         )?;
 
         relayer.with_supervisor(|| {
-            assert_eventually_channel_established(
+            let result = assert_eventually_channel_established(
                 &chains.handle_b,
                 &chains.handle_a,
                 &channel_id_b.as_ref(),
                 &port_b.as_ref(),
-            )?;
+            );
+
+            if self.enable_worker {
+                result?;
+            } else {
+                assert_err(
+                    "channel should not end up open when worker is disabled",
+                    result,
+                )?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+pub struct ChannelTryHandshake {
+    enable_worker: bool,
+}
+
+impl TestOverrides for ChannelTryHandshake {
+    fn modify_test_config(&self, config: &mut TestConfig) {
+        config.bootstrap_with_random_ids = false;
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.channels.enabled = self.enable_worker;
+
+        config.mode.packets.enabled = false;
+        config.mode.clients.enabled = false;
+        config.mode.connections.enabled = false;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryConnectionTest for ChannelTryHandshake {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        connection: ConnectedConnection<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let port_a = tagged_transfer_port();
+        let port_b = tagged_transfer_port();
+
+        let (_channel_id_on_b, channel_to_a_on_b) = init_channel(
+            &chains.handle_a,
+            &chains.handle_b,
+            &chains.client_id_a(),
+            &chains.client_id_b(),
+            &connection.connection_id_a.as_ref(),
+            &connection.connection_id_b.as_ref(),
+            &port_a.as_ref(),
+            &port_b.as_ref(),
+        )?;
+
+        let (channel_id_on_a, _channel_to_b_on_a) =
+            try_channel(&chains.handle_a, &chains.handle_b, &channel_to_a_on_b)?;
+
+        relayer.with_supervisor(|| {
+            let result = assert_eventually_channel_established(
+                &chains.handle_a,
+                &chains.handle_b,
+                &channel_id_on_a.as_ref(),
+                &port_a.as_ref(),
+            );
+
+            if self.enable_worker {
+                result?;
+            } else {
+                assert_err(
+                    "channel should not end up open when worker is disabled",
+                    result,
+                )?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+pub struct ChannelAckHandshake {
+    enable_worker: bool,
+}
+
+impl TestOverrides for ChannelAckHandshake {
+    fn modify_test_config(&self, config: &mut TestConfig) {
+        config.bootstrap_with_random_ids = false;
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.channels.enabled = self.enable_worker;
+
+        config.mode.packets.enabled = false;
+        config.mode.clients.enabled = false;
+        config.mode.connections.enabled = false;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryConnectionTest for ChannelAckHandshake {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        connection: ConnectedConnection<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let port_a = tagged_transfer_port();
+        let port_b = tagged_transfer_port();
+
+        let (channel_id_on_b, channel_to_a_on_b) = init_channel(
+            &chains.handle_a,
+            &chains.handle_b,
+            &chains.client_id_a(),
+            &chains.client_id_b(),
+            &connection.connection_id_a.as_ref(),
+            &connection.connection_id_b.as_ref(),
+            &port_a.as_ref(),
+            &port_b.as_ref(),
+        )?;
+
+        let (_channel_id_on_a, channel_to_b_on_a) =
+            try_channel(&chains.handle_a, &chains.handle_b, &channel_to_a_on_b)?;
+
+        let _ = ack_channel(&chains.handle_b, &chains.handle_a, &channel_to_b_on_a)?;
+
+        relayer.with_supervisor(|| {
+            let result = assert_eventually_channel_established(
+                &chains.handle_b,
+                &chains.handle_a,
+                &channel_id_on_b.as_ref(),
+                &port_b.as_ref(),
+            );
+
+            if self.enable_worker {
+                result?;
+            } else {
+                assert_err(
+                    "channel should not end up open when worker is disabled",
+                    result,
+                )?;
+            }
 
             Ok(())
         })

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -13,6 +13,7 @@ pub mod connection_delay;
 pub mod denom_trace;
 pub mod error_events;
 pub mod execute_schedule;
+pub mod handshake_on_start;
 pub mod memo;
 pub mod python;
 pub mod query_packet;

--- a/tools/test-framework/src/relayer/channel.rs
+++ b/tools/test-framework/src/relayer/channel.rs
@@ -64,10 +64,32 @@ pub fn init_channel<ChainA: ChainHandle, ChainB: ChainHandle>(
     };
 
     let event = channel.build_chan_open_init_and_send()?;
-
     let channel_id = extract_channel_id(&event)?.clone();
-
     let channel2 = Channel::restore_from_event(handle_b.clone(), handle_a.clone(), event)?;
+
+    Ok((DualTagged::new(channel_id), channel2))
+}
+
+pub fn try_channel<ChainA: ChainHandle, ChainB: ChainHandle>(
+    handle_a: &ChainA,
+    handle_b: &ChainB,
+    channel: &Channel<ChainB, ChainA>,
+) -> Result<(TaggedChannelId<ChainA, ChainB>, Channel<ChainA, ChainB>), Error> {
+    let event = channel.build_chan_open_try_and_send()?;
+    let channel_id = extract_channel_id(&event)?.clone();
+    let channel2 = Channel::restore_from_event(handle_a.clone(), handle_b.clone(), event)?;
+
+    Ok((DualTagged::new(channel_id), channel2))
+}
+
+pub fn ack_channel<ChainA: ChainHandle, ChainB: ChainHandle>(
+    handle_a: &ChainA,
+    handle_b: &ChainB,
+    channel: &Channel<ChainB, ChainA>,
+) -> Result<(TaggedChannelId<ChainA, ChainB>, Channel<ChainA, ChainB>), Error> {
+    let event = channel.build_chan_open_ack_and_send()?;
+    let channel_id = extract_channel_id(&event)?.clone();
+    let channel2 = Channel::restore_from_event(handle_a.clone(), handle_b.clone(), event)?;
 
     Ok((DualTagged::new(channel_id), channel2))
 }

--- a/tools/test-framework/src/relayer/connection.rs
+++ b/tools/test-framework/src/relayer/connection.rs
@@ -78,9 +78,43 @@ pub fn init_connection<ChainA: ChainHandle, ChainB: ChainHandle>(
     };
 
     let event = connection.build_conn_init_and_send()?;
-
     let connection_id = extract_connection_id(&event)?.clone();
+    let connection2 = Connection::restore_from_event(handle_b.clone(), handle_a.clone(), &event)?;
 
+    Ok((DualTagged::new(connection_id), connection2))
+}
+
+pub fn try_connection<ChainA: ChainHandle, ChainB: ChainHandle>(
+    handle_a: &ChainA,
+    handle_b: &ChainB,
+    connection: &Connection<ChainA, ChainB>,
+) -> Result<
+    (
+        TaggedConnectionId<ChainB, ChainA>,
+        Connection<ChainB, ChainA>,
+    ),
+    Error,
+> {
+    let event = connection.build_conn_try_and_send()?;
+    let connection_id = extract_connection_id(&event)?.clone();
+    let connection2 = Connection::restore_from_event(handle_b.clone(), handle_a.clone(), &event)?;
+
+    Ok((DualTagged::new(connection_id), connection2))
+}
+
+pub fn ack_connection<ChainA: ChainHandle, ChainB: ChainHandle>(
+    handle_a: &ChainA,
+    handle_b: &ChainB,
+    connection: &Connection<ChainA, ChainB>,
+) -> Result<
+    (
+        TaggedConnectionId<ChainB, ChainA>,
+        Connection<ChainB, ChainA>,
+    ),
+    Error,
+> {
+    let event = connection.build_conn_ack_and_send()?;
+    let connection_id = extract_connection_id(&event)?.clone();
     let connection2 = Connection::restore_from_event(handle_b.clone(), handle_a.clone(), &event)?;
 
     Ok((DualTagged::new(connection_id), connection2))

--- a/tools/test-framework/src/util/assert.rs
+++ b/tools/test-framework/src/util/assert.rs
@@ -34,3 +34,14 @@ pub fn assert_gt<T: Ord + Debug>(message: &str, left: &T, right: &T) -> Result<(
         )))
     }
 }
+
+pub fn assert_err<T: Debug, E: Debug>(message: &str, result: Result<T, E>) -> Result<(), Error> {
+    if result.is_err() {
+        Ok(())
+    } else {
+        Err(Error::assertion(format!(
+            "expect result ({:?}) to be an error: {}",
+            result, message
+        )))
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2743
At first look I thought it might help with #2608 but the hermes releases don't match. Also it is not clear what exactly doesn't work there. Will investigate in parallel.

## Description
#2484 removed all new block event processing such that now pending handshakes are not picked up. Instead we should process the pending events on first NewBlock event. 
It didn't help that the e2e script has been broken for a long time therefore not catching this issue.

- [x] Fix e2e scripts 
- [x] Process first NewBlock event
- [x] Stop handshake on OpenAck and OpenConfirm events

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
