### PR TITLE
Corrected mismatch in `config.toml` comment

### DIFF
--- a/.changelog/unreleased/bug-fixes/2750-update-config-documentation.md
+++ b/.changelog/unreleased/bug-fixes/2750-update-config-documentation.md
@@ -1,0 +1,3 @@
+- Fix comment in `config.toml` to correctly state that the default value
+  of `clear_on_start` is `true`.
+  ([#2750](https://github.com/informalsystems/ibc-rs/issues/2750))

--- a/config.toml
+++ b/config.toml
@@ -50,7 +50,7 @@ enabled = true
 # periodic packet clearing. [Default: 100]
 clear_interval = 100
 
-# Whether or not to clear packets on start. [Default: false]
+# Whether or not to clear packets on start. [Default: true]
 clear_on_start = true
 
 # Toggle the transaction confirmation mechanism.

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -240,17 +240,6 @@ pub struct Packets {
     pub tx_confirmation: bool,
 }
 
-impl Default for Packets {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            clear_interval: default::clear_packets_interval(),
-            clear_on_start: false,
-            tx_confirmation: default::tx_confirmation(),
-        }
-    }
-}
-
 /// Log levels are wrappers over [`tracing_core::Level`].
 ///
 /// [`tracing_core::Level`]: https://docs.rs/tracing-core/0.1.17/tracing_core/struct.Level.html


### PR DESCRIPTION
Closes: #2750

## Description

This PR updates the comment in the example `config.toml` to correctly state that the default value for `clear_on_start` is `true`.
In addition the implementation of `Default` for the packet configuration values, struct `Packet`, has been removed as it was unused and had different values from the default values used in the `Default` implementation for `ModeConfig`.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
