### PR TITLE
Fix how headers are decoded from events

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/2739-fix-decode-header.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/2739-fix-decode-header.md
@@ -1,0 +1,2 @@
+- Fix how headers are decoded from events
+  ([#2739](https://github.com/informalsystems/ibc-rs/issues/2739))

--- a/crates/relayer-types/src/core/ics02_client/error.rs
+++ b/crates/relayer-types/src/core/ics02_client/error.rs
@@ -136,6 +136,9 @@ define_error! {
             [ TraceError<TendermintProtoError> ]
             | _ | { "invalid raw header" },
 
+        MalformedHeader
+            | _ | { "malformed header; expected to be hex encoded" },
+
         MissingRawHeader
             | _ | { "missing raw header" },
 

--- a/crates/relayer/src/event.rs
+++ b/crates/relayer/src/event.rs
@@ -22,7 +22,7 @@ use ibc_relayer_types::{
 use serde::Serialize;
 use tendermint::abci::Event as AbciEvent;
 
-use crate::light_client::AnyHeader;
+use crate::light_client::decode_header;
 
 pub mod bus;
 pub mod monitor;
@@ -311,7 +311,8 @@ pub fn extract_header_from_tx(event: &AbciEvent) -> Result<Box<dyn Header>, Clie
         let key = tag.key.as_ref();
         let value = tag.value.as_ref();
         if key == HEADER_ATTRIBUTE_KEY {
-            return AnyHeader::decode_from_string(value).map(AnyHeader::into_box);
+            let header_bytes = hex::decode(value).map_err(|_| ClientError::malformed_header())?;
+            return decode_header(&header_bytes);
         }
     }
     Err(ClientError::missing_raw_header())

--- a/crates/relayer/src/event.rs
+++ b/crates/relayer/src/event.rs
@@ -442,47 +442,25 @@ pub fn parse_timeout_height(s: &str) -> Result<TimeoutHeight, ChannelError> {
 mod tests {
     use super::*;
 
-    // use ibc_relayer_types::core::ics02_client::client_type::ClientType;
-    // use ibc_relayer_types::core::ics02_client::header::Header;
+    use ibc_proto::google::protobuf::Any;
+    use ibc_proto::protobuf::Protobuf;
+    use ibc_relayer_types::clients::ics07_tendermint::header::test_util::get_dummy_ics07_header;
+    use ibc_relayer_types::clients::ics07_tendermint::header::Header as TmHeader;
+    use ibc_relayer_types::core::ics02_client::header::downcast_header;
     use ibc_relayer_types::core::ics04_channel::packet::Sequence;
     use ibc_relayer_types::timestamp::Timestamp;
 
-    // #[test]
-    // fn client_event_to_abci_event() {
-    //     let consensus_height = Height::new(1, 1).unwrap();
-    //     let attributes = ClientAttributes {
-    //         client_id: "test_client".parse().unwrap(),
-    //         client_type: ClientType::Tendermint,
-    //         consensus_height,
-    //     };
-    //     let mut abci_events = vec![];
-    //     let create_client = client_events::CreateClient::from(attributes.clone());
-    //     abci_events.push(AbciEvent::from(create_client.clone()));
-    //     let client_misbehaviour = client_events::ClientMisbehaviour::from(attributes.clone());
-    //     abci_events.push(AbciEvent::from(client_misbehaviour.clone()));
-    //     let upgrade_client = client_events::UpgradeClient::from(attributes.clone());
-    //     abci_events.push(AbciEvent::from(upgrade_client.clone()));
-    //     let mut update_client = client_events::UpdateClient::from(attributes);
-    //     let header = AnyHeader::Mock(MockHeader::new(consensus_height));
-    //     update_client.header = Some(header.into_box());
-    //     abci_events.push(AbciEvent::from(update_client.clone()));
+    #[test]
+    fn extract_header() {
+        let header = get_dummy_ics07_header();
+        let mut header_bytes = Vec::new();
+        Protobuf::<Any>::encode(&header, &mut header_bytes).unwrap();
 
-    //     for abci_event in abci_events {
-    //         match ibc_event_try_from_abci_event(&abci_event).ok() {
-    //             Some(ibc_event) => match ibc_event {
-    //                 IbcEvent::CreateClient(e) => assert_eq!(e.0, create_client.0),
-    //                 IbcEvent::ClientMisbehaviour(e) => assert_eq!(e.0, client_misbehaviour.0),
-    //                 IbcEvent::UpgradeClient(e) => assert_eq!(e.0, upgrade_client.0),
-    //                 IbcEvent::UpdateClient(e) => {
-    //                     assert_eq!(e.common, update_client.common);
-    //                     assert_eq!(e.header, update_client.header);
-    //                 }
-    //                 _ => panic!("unexpected event type"),
-    //             },
-    //             None => panic!("converted event was wrong"),
-    //         }
-    //     }
-    // }
+        let decoded_dyn_header = decode_header(&header_bytes).unwrap();
+        let decoded_tm_header: &TmHeader = downcast_header(decoded_dyn_header.as_ref()).unwrap();
+
+        assert_eq!(&header, decoded_tm_header);
+    }
 
     #[test]
     fn connection_event_to_abci_event() {

--- a/crates/relayer/src/light_client.rs
+++ b/crates/relayer/src/light_client.rs
@@ -6,7 +6,7 @@ use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::lightclients::tendermint::v1::Header as RawTmHeader;
 use ibc_proto::protobuf::Protobuf as ErasedProtobuf;
 use ibc_relayer_types::clients::ics07_tendermint::header::{
-    decode_header, Header as TendermintHeader, TENDERMINT_HEADER_TYPE_URL,
+    decode_header as tm_decode_header, Header as TendermintHeader, TENDERMINT_HEADER_TYPE_URL,
 };
 use ibc_relayer_types::core::ics02_client::client_type::ClientType;
 use ibc_relayer_types::core::ics02_client::error::Error;
@@ -15,7 +15,6 @@ use ibc_relayer_types::core::ics02_client::header::Header;
 use ibc_relayer_types::timestamp::Timestamp;
 use ibc_relayer_types::Height;
 use serde::{Deserialize, Serialize};
-use subtle_encoding::hex;
 
 use crate::chain::endpoint::ChainEndpoint;
 use crate::client_state::AnyClientState;
@@ -65,6 +64,17 @@ pub trait LightClient<C: ChainEndpoint>: Send + Sync {
     fn fetch(&mut self, height: Height) -> Result<C::LightBlock, error::Error>;
 }
 
+/// Decodes an encoded header into a known `Header` type,
+pub fn decode_header(header_bytes: &[u8]) -> Result<Box<dyn Header>, Error> {
+    // For now, we only have tendermint; however when there is more than one, we
+    // can try decoding into all the known types, and return an error only if
+    // none work
+    let header: TendermintHeader =
+        ErasedProtobuf::<Any>::decode(header_bytes.as_ref()).map_err(Error::invalid_raw_header)?;
+
+    Ok(Box::new(header))
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum AnyHeader {
@@ -91,19 +101,6 @@ impl Header for AnyHeader {
     }
 }
 
-impl AnyHeader {
-    pub fn encode_to_string(&self) -> String {
-        let buf = ErasedProtobuf::encode_vec(self).expect("encoding shouldn't fail");
-        let encoded = hex::encode(buf);
-        String::from_utf8(encoded).expect("hex-encoded string should always be valid UTF-8")
-    }
-
-    pub fn decode_from_string(s: &str) -> Result<Self, Error> {
-        let header_bytes = hex::decode(s).unwrap();
-        ErasedProtobuf::decode(header_bytes.as_ref()).map_err(Error::invalid_raw_header)
-    }
-}
-
 impl ErasedProtobuf<Any> for AnyHeader {}
 
 impl TryFrom<Any> for AnyHeader {
@@ -112,7 +109,7 @@ impl TryFrom<Any> for AnyHeader {
     fn try_from(raw: Any) -> Result<Self, Error> {
         match raw.type_url.as_str() {
             TENDERMINT_HEADER_TYPE_URL => {
-                let val = decode_header(raw.value.deref())?;
+                let val = tm_decode_header(raw.value.deref())?;
 
                 Ok(AnyHeader::Tendermint(val))
             }

--- a/crates/relayer/src/light_client.rs
+++ b/crates/relayer/src/light_client.rs
@@ -70,7 +70,7 @@ pub fn decode_header(header_bytes: &[u8]) -> Result<Box<dyn Header>, Error> {
     // can try decoding into all the known types, and return an error only if
     // none work
     let header: TendermintHeader =
-        ErasedProtobuf::<Any>::decode(header_bytes.as_ref()).map_err(Error::invalid_raw_header)?;
+        ErasedProtobuf::<Any>::decode(header_bytes).map_err(Error::invalid_raw_header)?;
 
     Ok(Box::new(header))
 }


### PR DESCRIPTION

Closes: #2739

## Description

This fixes all issues on my machine; please ensure that everything is fixed as well.

The core of the issue was that we were wrapping `AnyHeader` into a `Box<dyn Header>`; when came the time to downcast to a `TendermintHeader`, the `downcast_header()` failed (`AnyHeader != TendermintHeader`).

I also believe that `AnyHeader` should be removed, and all instances should be changed to `Box<dyn Header>` (to avoid similar problems in the future). Didn't check extensively though if there's actually a good use for it.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
