### PR TITLE
Use deterministic clients, connections and channels ids in integration tests

### DIFF
--- a/tools/integration-test/src/bin/test_setup_with_binary_channel.rs
+++ b/tools/integration-test/src/bin/test_setup_with_binary_channel.rs
@@ -36,7 +36,6 @@ struct Test {
 
 impl TestOverrides for Test {
     fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
         config.chain_store_dir = self.store_dir.clone();
     }
 

--- a/tools/integration-test/src/bin/test_setup_with_fee_enabled_binary_channel.rs
+++ b/tools/integration-test/src/bin/test_setup_with_fee_enabled_binary_channel.rs
@@ -37,7 +37,6 @@ struct Test {
 
 impl TestOverrides for Test {
     fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
         config.chain_store_dir = self.store_dir.clone();
     }
 

--- a/tools/integration-test/src/bin/test_setup_with_ternary_channel.rs
+++ b/tools/integration-test/src/bin/test_setup_with_ternary_channel.rs
@@ -36,7 +36,6 @@ struct Test {
 
 impl TestOverrides for Test {
     fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
         config.chain_store_dir = self.store_dir.clone();
     }
 

--- a/tools/integration-test/src/mbt/transfer.rs
+++ b/tools/integration-test/src/mbt/transfer.rs
@@ -139,10 +139,6 @@ fn test_self_connected_ibc_transfer() -> Result<(), Error> {
 pub struct IbcTransferMBT(Vec<State>);
 
 impl TestOverrides for IbcTransferMBT {
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode = ModeConfig {
             clients: ConfigClients {

--- a/tools/integration-test/src/tests/client_expiration.rs
+++ b/tools/integration-test/src/tests/client_expiration.rs
@@ -97,10 +97,6 @@ pub struct CreateOnExpiredClientTest;
 pub struct MisbehaviorExpirationTest;
 
 impl TestOverrides for ExpirationTestOverrides {
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode = ModeConfig {
             clients: config::Clients {

--- a/tools/integration-test/src/tests/ica.rs
+++ b/tools/integration-test/src/tests/ica.rs
@@ -40,11 +40,6 @@ impl IcaFilterTestAllow {
 }
 
 impl TestOverrides for IcaFilterTestAllow {
-    // Use `icad` binary and deterministic identifiers for clients, connections, and channels
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     // Enable channel workers and allow relaying on ICA channels
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode.channels.enabled = true;
@@ -179,11 +174,6 @@ fn test_ica_filter_deny() -> Result<(), Error> {
 pub struct IcaFilterTestDeny;
 
 impl TestOverrides for IcaFilterTestDeny {
-    // Use deterministic identifiers for clients, connections, and channels
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     // Enable channel workers and deny ICA ports
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode.channels.enabled = true;

--- a/tools/integration-test/src/tests/ordered_channel_clear.rs
+++ b/tools/integration-test/src/tests/ordered_channel_clear.rs
@@ -46,10 +46,6 @@ impl OrderedChannelClearTest {
 }
 
 impl TestOverrides for OrderedChannelClearTest {
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode.packets.tx_confirmation = self.tx_confirmation;
         config.chains[0].sequential_batch_tx = self.sequential_batch_tx;
@@ -172,10 +168,6 @@ impl BinaryChannelTest for OrderedChannelClearTest {
 pub struct OrderedChannelClearEqualCLITest;
 
 impl TestOverrides for OrderedChannelClearEqualCLITest {
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode.packets.tx_confirmation = true;
 

--- a/tools/integration-test/src/tests/python.rs
+++ b/tools/integration-test/src/tests/python.rs
@@ -6,10 +6,6 @@ use std::process::{Command, Stdio};
 struct PythonTest;
 
 impl TestOverrides for PythonTest {
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     fn modify_relayer_config(&self, config: &mut Config) {
         for mut chain in config.chains.iter_mut() {
             // Modify the key store type to `Store::Test` so that the wallet

--- a/tools/integration-test/src/tests/ternary_transfer.rs
+++ b/tools/integration-test/src/tests/ternary_transfer.rs
@@ -9,10 +9,6 @@ fn test_ternary_ibc_transfer() -> Result<(), Error> {
 pub struct TernaryIbcTransferTest;
 
 impl TestOverrides for TernaryIbcTransferTest {
-    fn modify_test_config(&self, config: &mut TestConfig) {
-        config.bootstrap_with_random_ids = false;
-    }
-
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode.clients.misbehaviour = false;
     }

--- a/tools/test-framework/src/bootstrap/init.rs
+++ b/tools/test-framework/src/bootstrap/init.rs
@@ -59,7 +59,7 @@ pub fn init_test() -> Result<TestConfig, Error> {
         chain_store_dir,
         account_prefix,
         hang_on_fail,
-        bootstrap_with_random_ids: true,
+        bootstrap_with_random_ids: false,
     })
 }
 


### PR DESCRIPTION
## Description

It does not seem like using randoms identifiers buys much in the existing tests, so let's disable it to improve running time a little bit.

Note that this can still be enabled on a per test basis if needed.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
