### PR TITLE
fix(dockerfile): rolling ubuntu base, COPY libssl, ci caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,5 @@ jobs:
           push: true
           build-args: TAG=v${{env.TAG}}
           tags: informalsystems/hermes:${{env.TAG}}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/ci/release/hermes.Dockerfile
+++ b/ci/release/hermes.Dockerfile
@@ -20,6 +20,4 @@ WORKDIR /home/hermes
 USER hermes:hermes
 ENTRYPOINT ["/usr/bin/hermes"]
 
-COPY --chown=0:0 --from=build-env /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libssl.so.1.1
-COPY --chown=0:0 --from=build-env /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
 COPY --chown=0:0 --from=build-env /root/hermes/target/release/hermes /usr/bin/hermes

--- a/ci/release/hermes.Dockerfile
+++ b/ci/release/hermes.Dockerfile
@@ -1,4 +1,3 @@
-# informalsystems/hermes image
 #
 # Used for running hermes in docker containers
 #
@@ -10,19 +9,17 @@ FROM rust:1-buster AS build-env
 ARG TAG
 WORKDIR /root
 
-RUN git clone https://github.com/informalsystems/hermes
-RUN cd hermes && git checkout $TAG && cargo build --release
+RUN git clone -b ${TAG} --depth 1 https://github.com/informalsystems/hermes \
+ && cd hermes \
+ && cargo build --release
 
-
-FROM debian:buster-slim
+FROM ubuntu:rolling
 LABEL maintainer="hello@informal.systems"
-
-RUN apt update && apt install -y libssl-dev
-
 RUN useradd -m hermes -s /bin/bash
 WORKDIR /home/hermes
 USER hermes:hermes
 ENTRYPOINT ["/usr/bin/hermes"]
 
+COPY --chown=0:0 --from=build-env /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libssl.so.1.1
+COPY --chown=0:0 --from=build-env /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
 COPY --chown=0:0 --from=build-env /root/hermes/target/release/hermes /usr/bin/hermes
-COPY --chown=0:0 --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/informalsystems/hermes/issues/2810

## Description

- `ubuntu:rolling` as base image to resolve most of the image vulnerability
- COPY `libssl` and `libcrypto`
- Faster and better git cloning and checkout
- Enable docker caching in github actions
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
