### PR TITLE
Collate consecutive heights and sequence numbers shown in logs

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer-cli/2847-collate-seqs.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/2847-collate-seqs.md
@@ -1,0 +1,2 @@
+- Collate consecutive heights and sequence numbers shown in logs
+  ([#2847](https://github.com/informalsystems/ibc-rs/issues/2847))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,6 @@ dependencies = [
  "ics23",
  "itertools",
  "modelator",
- "num-traits",
  "primitive-types",
  "prost",
  "safe-regex",

--- a/crates/relayer-cli/src/commands/query/packet.rs
+++ b/crates/relayer-cli/src/commands/query/packet.rs
@@ -8,6 +8,7 @@ mod commitments;
 mod pending;
 mod pending_acks;
 mod pending_sends;
+mod util;
 
 #[derive(Command, Debug, Parser, Runnable)]
 pub enum QueryPacketCmds {

--- a/crates/relayer-cli/src/commands/query/packet/acks.rs
+++ b/crates/relayer-cli/src/commands/query/packet/acks.rs
@@ -1,23 +1,16 @@
 use abscissa_core::clap::Parser;
 use abscissa_core::{Command, Runnable};
-use ibc_relayer_types::core::ics04_channel::packet::Sequence;
-use serde::Serialize;
 
+use ibc_relayer::chain::counterparty::acknowledgements_on_chain;
 use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
-use ibc_relayer_types::Height;
 
 use crate::cli_utils::spawn_chain_counterparty;
 use crate::conclude::Output;
 use crate::error::Error;
 use crate::prelude::*;
-use ibc_relayer::chain::counterparty::acknowledgements_on_chain;
 
-#[derive(Serialize, Debug)]
-struct PacketSeqs {
-    height: Height,
-    seqs: Vec<Sequence>,
-}
+use super::util::PacketSeqs;
 
 #[derive(Clone, Command, Debug, Parser, PartialEq, Eq)]
 pub struct QueryPacketAcknowledgementsCmd {
@@ -72,8 +65,11 @@ impl QueryPacketAcknowledgementsCmd {
 // cargo run --bin hermes -- query packet acknowledgements --chain ibc-0 --port transfer --connection ibconexfer --height 3
 impl Runnable for QueryPacketAcknowledgementsCmd {
     fn run(&self) {
+        use crate::conclude::json;
+
         match self.execute() {
-            Ok(ps) => Output::success(ps).exit(),
+            Ok(p) if json() => Output::success(p).exit(),
+            Ok(p) => Output::success(p.collated()).exit(),
             Err(e) => Output::error(format!("{}", e)).exit(),
         }
     }

--- a/crates/relayer-cli/src/commands/query/packet/commitments.rs
+++ b/crates/relayer-cli/src/commands/query/packet/commitments.rs
@@ -1,22 +1,15 @@
 use abscissa_core::clap::Parser;
 use abscissa_core::{Command, Runnable};
-use ibc_relayer_types::core::ics04_channel::packet::Sequence;
-use serde::Serialize;
 
 use ibc_relayer::chain::counterparty::commitments_on_chain;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
-use ibc_relayer_types::Height;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;
 use crate::error::Error;
 use crate::prelude::*;
 
-#[derive(Serialize, Debug)]
-struct PacketSeqs {
-    height: Height,
-    seqs: Vec<Sequence>,
-}
+use super::util::PacketSeqs;
 
 #[derive(Clone, Command, Debug, Parser, PartialEq, Eq)]
 pub struct QueryPacketCommitmentsCmd {
@@ -67,8 +60,11 @@ impl QueryPacketCommitmentsCmd {
 // cargo run --bin hermes -- query packet commitments --chain ibc-0 --port transfer --channel ibconexfer --height 3
 impl Runnable for QueryPacketCommitmentsCmd {
     fn run(&self) {
+        use crate::conclude::json;
+
         match self.execute() {
-            Ok(p) => Output::success(p).exit(),
+            Ok(p) if json() => Output::success(p).exit(),
+            Ok(p) => Output::success(p.collated()).exit(),
             Err(e) => Output::error(format!("{}", e)).exit(),
         }
     }

--- a/crates/relayer-cli/src/commands/query/packet/pending.rs
+++ b/crates/relayer-cli/src/commands/query/packet/pending.rs
@@ -13,14 +13,25 @@ use crate::conclude::Output;
 use crate::error::Error;
 use crate::prelude::*;
 
+use super::util::CollatedPendingPackets;
+
 /// A structure to display pending packet commitment sequence IDs
 /// at both ends of a channel.
 #[derive(Debug, Serialize)]
-struct Summary {
+struct Summary<P> {
     /// The packets sent on the source chain as identified by the command.
-    src: PendingPackets,
+    src: P,
     /// The packets sent on the counterparty chain.
-    dst: PendingPackets,
+    dst: P,
+}
+
+impl Summary<PendingPackets> {
+    fn collate(self) -> Summary<CollatedPendingPackets> {
+        Summary {
+            src: CollatedPendingPackets::new(self.src),
+            dst: CollatedPendingPackets::new(self.dst),
+        }
+    }
 }
 
 /// This command does the following:
@@ -61,7 +72,7 @@ pub struct QueryPendingPacketsCmd {
 }
 
 impl QueryPendingPacketsCmd {
-    fn execute(&self) -> Result<Summary, Error> {
+    fn execute(&self) -> Result<Summary<PendingPackets>, Error> {
         let config = app_config();
 
         let (chains, chan_conn_cli) = spawn_chain_counterparty::<BaseChainHandle>(
@@ -78,6 +89,7 @@ impl QueryPendingPacketsCmd {
 
         let src_summary = pending_packet_summary(&chains.src, &chains.dst, &chan_conn_cli.channel)
             .map_err(Error::supervisor)?;
+
         let counterparty_channel = channel_on_destination(
             &chan_conn_cli.channel,
             &chan_conn_cli.connection,
@@ -85,8 +97,10 @@ impl QueryPendingPacketsCmd {
         )
         .map_err(Error::supervisor)?
         .ok_or_else(|| Error::missing_counterparty_channel_id(chan_conn_cli.channel))?;
+
         let dst_summary = pending_packet_summary(&chains.dst, &chains.src, &counterparty_channel)
             .map_err(Error::supervisor)?;
+
         Ok(Summary {
             src: src_summary,
             dst: dst_summary,
@@ -96,9 +110,12 @@ impl QueryPendingPacketsCmd {
 
 impl Runnable for QueryPendingPacketsCmd {
     fn run(&self) {
+        use crate::conclude::json;
+
         match self.execute() {
-            Ok(pending) => Output::success(pending).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Ok(summary) if json() => Output::success(summary).exit(),
+            Ok(summary) => Output::success(summary.collate()).exit(),
+            Err(e) => Output::error(e).exit(),
         }
     }
 }

--- a/crates/relayer-cli/src/commands/query/packet/pending_acks.rs
+++ b/crates/relayer-cli/src/commands/query/packet/pending_acks.rs
@@ -4,6 +4,7 @@ use abscissa_core::{Command, Runnable};
 use ibc_relayer::chain::counterparty::unreceived_acknowledgements;
 use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer::path::PathIdentifiers;
+use ibc_relayer::util::collate::CollatedIterExt;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
 
@@ -76,9 +77,12 @@ impl QueryPendingAcksCmd {
 
 impl Runnable for QueryPendingAcksCmd {
     fn run(&self) {
+        use crate::conclude::json;
+
         match self.execute() {
-            Ok(seqs) => Output::success(seqs).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Ok(seqs) if json() => Output::success(seqs).exit(),
+            Ok(seqs) => Output::success(seqs.into_iter().collated().collect::<Vec<_>>()).exit(),
+            Err(e) => Output::error(e).exit(),
         }
     }
 }

--- a/crates/relayer-cli/src/commands/query/packet/pending_sends.rs
+++ b/crates/relayer-cli/src/commands/query/packet/pending_sends.rs
@@ -4,6 +4,7 @@ use abscissa_core::{Command, Runnable};
 use ibc_relayer::chain::counterparty::unreceived_packets;
 use ibc_relayer::chain::handle::BaseChainHandle;
 use ibc_relayer::path::PathIdentifiers;
+use ibc_relayer::util::collate::CollatedIterExt;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
 
@@ -76,9 +77,12 @@ impl QueryPendingSendsCmd {
 
 impl Runnable for QueryPendingSendsCmd {
     fn run(&self) {
+        use crate::conclude::json;
+
         match self.execute() {
-            Ok(seqs) => Output::success(seqs).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            Ok(seqs) if json() => Output::success(seqs).exit(),
+            Ok(seqs) => Output::success(seqs.into_iter().collated().collect::<Vec<_>>()).exit(),
+            Err(e) => Output::error(e).exit(),
         }
     }
 }

--- a/crates/relayer-cli/src/commands/query/packet/util.rs
+++ b/crates/relayer-cli/src/commands/query/packet/util.rs
@@ -1,0 +1,63 @@
+use core::fmt;
+
+use serde::Serialize;
+
+use ibc_relayer::util::collate::{Collated, CollatedIterExt};
+use ibc_relayer_types::core::ics04_channel::packet::Sequence;
+use ibc_relayer_types::Height;
+
+pub use ibc_relayer::chain::counterparty::PendingPackets;
+
+#[derive(Serialize)]
+pub struct CollatedPendingPackets {
+    pub unreceived_packets: Vec<Collated<Sequence>>,
+    pub unreceived_acks: Vec<Collated<Sequence>>,
+}
+
+impl fmt::Debug for CollatedPendingPackets {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingPackets")
+            .field("unreceived_packets", &self.unreceived_packets)
+            .field("unreceived_acks", &self.unreceived_acks)
+            .finish()
+    }
+}
+
+impl CollatedPendingPackets {
+    pub fn new(pending: PendingPackets) -> Self {
+        Self {
+            unreceived_packets: pending.unreceived_packets.into_iter().collated().collect(),
+            unreceived_acks: pending.unreceived_acks.into_iter().collated().collect(),
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct PacketSeqs {
+    pub height: Height,
+    pub seqs: Vec<Sequence>,
+}
+
+impl PacketSeqs {
+    pub fn collated(self) -> CollatedPacketSeqs {
+        CollatedPacketSeqs {
+            height: self.height,
+            seqs: self.seqs.into_iter().collated().collect(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct CollatedPacketSeqs {
+    pub height: Height,
+    pub seqs: Vec<Collated<Sequence>>,
+}
+
+impl fmt::Debug for CollatedPacketSeqs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PacketSeqs")
+            .field("height", &self.height)
+            .field("seqs", &self.seqs)
+            .finish()
+    }
+}

--- a/crates/relayer-types/Cargo.toml
+++ b/crates/relayer-types/Cargo.toml
@@ -41,7 +41,6 @@ safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
 sha2 = { version = "0.10.6", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 uint = { version = "0.9", default-features = false }
 itertools = { version = "0.10.3", default-features = false, features = ["use_alloc"] }

--- a/crates/relayer-types/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/relayer-types/src/clients/ics07_tendermint/client_state.rs
@@ -170,7 +170,7 @@ impl ClientState {
             return Err(Error::not_enough_time_elapsed(current_time, earliest_time));
         }
 
-        let earliest_height = processed_height.add(delay_period_blocks);
+        let earliest_height = processed_height + delay_period_blocks;
         if current_height < earliest_height {
             return Err(Error::not_enough_blocks_elapsed(
                 current_height,

--- a/crates/relayer-types/src/core/ics02_client/height.rs
+++ b/crates/relayer-types/src/core/ics02_client/height.rs
@@ -41,30 +41,12 @@ impl Height {
         self.revision_height
     }
 
-    pub fn add(&self, delta: u64) -> Height {
-        Height {
-            revision_number: self.revision_number,
-            revision_height: self.revision_height + delta,
-        }
+    pub fn increment(self) -> Height {
+        self + 1
     }
 
-    pub fn increment(&self) -> Height {
-        self.add(1)
-    }
-
-    pub fn sub(&self, delta: u64) -> Result<Height, Error> {
-        if self.revision_height <= delta {
-            return Err(Error::invalid_height_result());
-        }
-
-        Ok(Height {
-            revision_number: self.revision_number,
-            revision_height: self.revision_height - delta,
-        })
-    }
-
-    pub fn decrement(&self) -> Result<Height, Error> {
-        self.sub(1)
+    pub fn decrement(self) -> Result<Height, Error> {
+        self - 1
     }
 }
 
@@ -87,6 +69,32 @@ impl Ord for Height {
         } else {
             Ordering::Equal
         }
+    }
+}
+
+impl core::ops::Add<u64> for Height {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self {
+            revision_number: self.revision_number,
+            revision_height: self.revision_height + rhs,
+        }
+    }
+}
+
+impl core::ops::Sub<u64> for Height {
+    type Output = Result<Self, Error>;
+
+    fn sub(self, delta: u64) -> Self::Output {
+        if self.revision_height <= delta {
+            return Err(Error::invalid_height_result());
+        }
+
+        Ok(Height {
+            revision_number: self.revision_number,
+            revision_height: self.revision_height - delta,
+        })
     }
 }
 

--- a/crates/relayer-types/src/core/ics04_channel/packet.rs
+++ b/crates/relayer-types/src/core/ics04_channel/packet.rs
@@ -83,6 +83,22 @@ impl core::fmt::Display for Sequence {
     }
 }
 
+impl core::ops::Add<Self> for Sequence {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl core::ops::Add<u64> for Sequence {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self {
+        Self(self.0 + rhs)
+    }
+}
+
 #[derive(Clone, Default, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Packet {
     pub sequence: Sequence,

--- a/crates/relayer/src/foreign_client.rs
+++ b/crates/relayer/src/foreign_client.rs
@@ -44,7 +44,7 @@ use crate::event::IbcEventWithHeight;
 use crate::light_client::AnyHeader;
 use crate::misbehaviour::MisbehaviourEvidence;
 use crate::telemetry;
-use crate::util::collate::CollateIterExt;
+use crate::util::collate::CollatedIterExt;
 use crate::util::pretty::{PrettyDuration, PrettySlice};
 
 const MAX_MISBEHAVIOUR_CHECK_DURATION: Duration = Duration::from_secs(120);
@@ -1496,7 +1496,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
 
         trace!(
             total = %consensus_state_heights.len(),
-            heights = %consensus_state_heights.iter().copied().collate().format(", "),
+            heights = %consensus_state_heights.iter().copied().collated().format(", "),
             "checking misbehaviour for consensus state heights",
         );
 

--- a/crates/relayer/src/foreign_client.rs
+++ b/crates/relayer/src/foreign_client.rs
@@ -44,6 +44,7 @@ use crate::event::IbcEventWithHeight;
 use crate::light_client::AnyHeader;
 use crate::misbehaviour::MisbehaviourEvidence;
 use crate::telemetry;
+use crate::util::collate::CollateIterExt;
 use crate::util::pretty::{PrettyDuration, PrettySlice};
 
 const MAX_MISBEHAVIOUR_CHECK_DURATION: Duration = Duration::from_secs(120);
@@ -1494,9 +1495,9 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
         };
 
         trace!(
-            "checking misbehaviour for consensus state heights (first 50 shown here, total: {}): {}",
-            consensus_state_heights.len(),
-            consensus_state_heights.iter().take(50).join(", "),
+            total = %consensus_state_heights.len(),
+            heights = %consensus_state_heights.iter().copied().collate().format(", "),
+            "checking misbehaviour for consensus state heights",
         );
 
         let start_time = Instant::now();

--- a/crates/relayer/src/link/operational_data.rs
+++ b/crates/relayer/src/link/operational_data.rs
@@ -1,4 +1,5 @@
 use core::fmt::{Display, Error as FmtError, Formatter};
+use std::ops::Add;
 use std::time::{Duration, Instant};
 
 use ibc_proto::google::protobuf::Any;
@@ -359,6 +360,7 @@ impl ConnectionDelay {
             .update_height
             .expect("processed height not set")
             .add(block_delay);
+
         if latest_height >= acceptable_height {
             0
         } else {

--- a/crates/relayer/src/link/packet_events.rs
+++ b/crates/relayer/src/link/packet_events.rs
@@ -1,5 +1,6 @@
 //! Utility methods for querying packet event data.
 
+use itertools::Itertools;
 use tracing::{info, span, warn, Level};
 
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
@@ -11,10 +12,10 @@ use crate::chain::requests::{Qualified, QueryHeight, QueryPacketEventDataRequest
 use crate::error::Error;
 use crate::event::IbcEventWithHeight;
 use crate::path::PathIdentifiers;
-use crate::util::pretty::PrettySlice;
+use crate::util::collate::CollateIterExt;
 
 /// Limit on how many query results should be expected.
-pub const QUERY_RESULT_LIMIT: usize = 50;
+pub const CHUNK_LENGTH: usize = 50;
 
 /// Returns an iterator on batches of packet events.
 pub fn query_packet_events_with<'a, ChainA, QueryFn>(
@@ -37,39 +38,37 @@ where
     let events_total = sequences.len();
     let mut events_left = events_total;
 
-    sequences
-        .chunks(QUERY_RESULT_LIMIT)
-        .map_while(
-            move |chunk| match query_fn(src_chain, path, chunk, query_height) {
-                Ok(events) => {
-                    events_left -= chunk.len();
+    sequences.chunks(CHUNK_LENGTH).map_while(move |chunk| {
+        match query_fn(src_chain, path, chunk, query_height) {
+            Ok(events) => {
+                events_left -= chunk.len();
 
-                    info!(
-                        events.total = %events_total,
-                        events.left = %events_left,
-                        "pulled packet data for {} events out of {} sequences: {};",
-                        events.len(),
-                        chunk.len(),
-                        PrettySlice(chunk)
-                    );
+                info!(
+                    events.total = %events_total,
+                    events.left = %events_left,
+                    "pulled packet data for {} events out of {} sequences: {};",
+                    events.len(),
+                    chunk.len(),
+                    chunk.iter().copied().collate().format(", "),
+                );
 
-                    // Because we use the first event height to do the client update,
-                    // if the heights of the events differ, we get proof verification failures.
-                    // Therefore we overwrite the events height with the query height,
-                    // ie. the height of the first event.
-                    let events = events
-                        .into_iter()
-                        .map(|ev| ev.with_height(query_height.get()))
-                        .collect();
+                // Because we use the first event height to do the client update,
+                // if the heights of the events differ, we get proof verification failures.
+                // Therefore we overwrite the events height with the query height,
+                // ie. the height of the first event.
+                let events = events
+                    .into_iter()
+                    .map(|ev| ev.with_height(query_height.get()))
+                    .collect();
 
-                    Some(events)
-                }
-                Err(e) => {
-                    warn!("encountered query failure while pulling packet data: {}", e);
-                    None
-                }
-            },
-        )
+                Some(events)
+            }
+            Err(e) => {
+                warn!("encountered query failure while pulling packet data: {}", e);
+                None
+            }
+        }
+    })
 }
 
 fn query_packet_events<ChainA: ChainHandle>(

--- a/crates/relayer/src/link/packet_events.rs
+++ b/crates/relayer/src/link/packet_events.rs
@@ -12,7 +12,7 @@ use crate::chain::requests::{Qualified, QueryHeight, QueryPacketEventDataRequest
 use crate::error::Error;
 use crate::event::IbcEventWithHeight;
 use crate::path::PathIdentifiers;
-use crate::util::collate::CollateIterExt;
+use crate::util::collate::CollatedIterExt;
 
 /// Limit on how many query results should be expected.
 pub const CHUNK_LENGTH: usize = 50;
@@ -49,7 +49,7 @@ where
                     "pulled packet data for {} events out of {} sequences: {};",
                     events.len(),
                     chunk.len(),
-                    chunk.iter().copied().collate().format(", "),
+                    chunk.iter().copied().collated().format(", "),
                 );
 
                 // Because we use the first event height to do the client update,

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -56,7 +56,7 @@ use crate::link::relay_summary::RelaySummary;
 use crate::link::{pending, relay_sender};
 use crate::path::PathIdentifiers;
 use crate::telemetry;
-use crate::util::collate::CollateIterExt;
+use crate::util::collate::CollatedIterExt;
 use crate::util::pretty::PrettyEvents;
 use crate::util::queue::Queue;
 
@@ -1103,7 +1103,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             dst_chain = %self.dst_chain().id(),
             src_chain = %self.src_chain().id(),
             total = sequences.len(),
-            sequences = %sequences.iter().copied().collate().format(", "),
+            sequences = %sequences.iter().copied().collated().format(", "),
             "sequence numbers of unreceived packets to send to the destination chain out of the ones with commitments on the source chain",
         );
 
@@ -1161,7 +1161,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             dst_chain = %self.dst_chain().id(),
             src_chain = %self.src_chain().id(),
             total = sequences.len(),
-            sequences = %sequences.iter().copied().collate().format(", "),
+            sequences = %sequences.iter().copied().collated().format(", "),
             "sequence numbers of ack packets to send to the destination chain out of the ones with acknowledgments on the source chain",
         );
 

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -7,6 +7,21 @@ use ibc_proto::google::protobuf::Any;
 use itertools::Itertools;
 use tracing::{debug, error, info, span, trace, warn, Level};
 
+use ibc_relayer_types::core::ics02_client::events::ClientMisbehaviour as ClientMisbehaviourEvent;
+use ibc_relayer_types::core::ics04_channel::channel::{ChannelEnd, Order, State as ChannelState};
+use ibc_relayer_types::core::ics04_channel::events::{SendPacket, WriteAcknowledgement};
+use ibc_relayer_types::core::ics04_channel::msgs::{
+    acknowledgement::MsgAcknowledgement, chan_close_confirm::MsgChannelCloseConfirm,
+    recv_packet::MsgRecvPacket, timeout::MsgTimeout, timeout_on_close::MsgTimeoutOnClose,
+};
+use ibc_relayer_types::core::ics04_channel::packet::{Packet, PacketMsgType};
+use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+use ibc_relayer_types::events::{IbcEvent, WithBlockDataType};
+use ibc_relayer_types::signer::Signer;
+use ibc_relayer_types::timestamp::Timestamp;
+use ibc_relayer_types::tx_msg::Msg;
+use ibc_relayer_types::Height;
+
 use crate::chain::counterparty::unreceived_acknowledgements;
 use crate::chain::counterparty::unreceived_packets;
 use crate::chain::endpoint::ChainStatus;
@@ -41,29 +56,9 @@ use crate::link::relay_summary::RelaySummary;
 use crate::link::{pending, relay_sender};
 use crate::path::PathIdentifiers;
 use crate::telemetry;
+use crate::util::collate::CollateIterExt;
 use crate::util::pretty::PrettyEvents;
 use crate::util::queue::Queue;
-use ibc_relayer_types::{
-    core::{
-        ics02_client::events::ClientMisbehaviour as ClientMisbehaviourEvent,
-        ics04_channel::{
-            channel::{ChannelEnd, Order, State as ChannelState},
-            events::{SendPacket, WriteAcknowledgement},
-            msgs::{
-                acknowledgement::MsgAcknowledgement, chan_close_confirm::MsgChannelCloseConfirm,
-                recv_packet::MsgRecvPacket, timeout::MsgTimeout,
-                timeout_on_close::MsgTimeoutOnClose,
-            },
-            packet::{Packet, PacketMsgType},
-        },
-        ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
-    },
-    events::{IbcEvent, WithBlockDataType},
-    signer::Signer,
-    timestamp::Timestamp,
-    tx_msg::Msg,
-    Height,
-};
 
 const MAX_RETRIES: usize = 5;
 
@@ -1108,8 +1103,8 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             dst_chain = %self.dst_chain().id(),
             src_chain = %self.src_chain().id(),
             total = sequences.len(),
-            sequences = %sequences.iter().take(10).format(", "),
-            "sequence numbers of unreceived packets to send to the destination chain out of the ones with commitments on the source chain (first 10 shown here)",
+            sequences = %sequences.iter().copied().collate().format(", "),
+            "sequence numbers of unreceived packets to send to the destination chain out of the ones with commitments on the source chain",
         );
 
         // Chunk-up the list of sequence nrs. into smaller parts,
@@ -1166,8 +1161,8 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             dst_chain = %self.dst_chain().id(),
             src_chain = %self.src_chain().id(),
             total = sequences.len(),
-            sequences = %sequences.iter().take(10).format(", "),
-            "sequence numbers of ack packets to send to the destination chain out of the ones with acknowledgments on the source chain (first 10 shown here)",
+            sequences = %sequences.iter().copied().collate().format(", "),
+            "sequence numbers of ack packets to send to the destination chain out of the ones with acknowledgments on the source chain",
         );
 
         // Incrementally process all the available sequence numbers in chunks

--- a/crates/relayer/src/transfer.rs
+++ b/crates/relayer/src/transfer.rs
@@ -1,4 +1,5 @@
 use ibc_relayer_types::signer::SignerError;
+use std::ops::Add;
 use std::str::FromStr;
 
 use core::time::Duration;

--- a/crates/relayer/src/upgrade_chain.rs
+++ b/crates/relayer/src/upgrade_chain.rs
@@ -2,6 +2,7 @@
 #![allow(deprecated)] // TODO(hu55a1n1): remove this when we don't need legacy upgrade support
 
 use core::time::Duration;
+use std::ops::Add;
 
 use bytes::BufMut;
 use flex_error::define_error;

--- a/crates/relayer/src/util.rs
+++ b/crates/relayer/src/util.rs
@@ -1,6 +1,7 @@
 mod block_on;
 pub use block_on::block_on;
 
+pub mod collate;
 pub mod diff;
 pub mod iter;
 pub mod lock;

--- a/crates/relayer/src/util/collate.rs
+++ b/crates/relayer/src/util/collate.rs
@@ -1,0 +1,112 @@
+use std::{fmt, ops::Add};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Collated<T> {
+    pub start: T,
+    pub end: T,
+}
+
+impl<T> Collated<T> {
+    pub fn new(start: T, end: T) -> Self {
+        Self { start, end }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Collated<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}..={}", self.start, self.end)
+    }
+}
+
+pub struct Collate<Iter, Item> {
+    iter: Iter,
+    current: Option<Collated<Item>>,
+}
+
+impl<Iter, Item> Collate<Iter, Item> {
+    pub fn new(iter: Iter) -> Self {
+        Self {
+            iter,
+            current: None,
+        }
+    }
+}
+
+impl<Iter, Item> Iterator for Collate<Iter, Item>
+where
+    Iter: Iterator<Item = Item>,
+    Item: PartialOrd + Add<u64, Output = Item> + Copy,
+{
+    type Item = Collated<Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for item in self.iter.by_ref() {
+            if let Some(current) = self.current.take() {
+                if item == current.end {
+                    self.current = Some(current);
+                } else if item == current.end + 1 {
+                    self.current = Some(Collated::new(current.start, item));
+                } else {
+                    self.current = Some(Collated::new(item, item));
+                    return Some(current);
+                }
+            } else {
+                self.current = Some(Collated::new(item, item));
+            }
+        }
+
+        self.current.take()
+    }
+}
+
+pub fn collate<Iter, Item>(iter: Iter) -> Collate<Iter, Item>
+where
+    Iter: Iterator<Item = Item>,
+    Item: PartialOrd,
+{
+    Collate::new(iter)
+}
+
+pub trait CollateIterExt: Iterator {
+    fn collate(self) -> Collate<Self, Self::Item>
+    where
+        Self: Sized;
+}
+
+impl<T: ?Sized> CollateIterExt for T
+where
+    T: Iterator,
+{
+    fn collate(self) -> Collate<Self, Self::Item>
+    where
+        Self: Sized,
+    {
+        Collate::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple() {
+        let items = vec![
+            1, 2, 3, 10, 10, 10, 11, 11, 20, 30, 31, 31, 32, 33, 35, 40, 40, 40, 40,
+        ];
+
+        let collated = items.into_iter().collate().collect::<Vec<_>>();
+
+        assert_eq!(
+            collated,
+            vec![
+                Collated::new(1, 3),
+                Collated::new(10, 11),
+                Collated::new(20, 20),
+                Collated::new(30, 33),
+                Collated::new(35, 35),
+                Collated::new(40, 40),
+            ]
+        );
+    }
+}

--- a/crates/relayer/src/util/collate.rs
+++ b/crates/relayer/src/util/collate.rs
@@ -1,6 +1,8 @@
 use std::{fmt, ops::Add};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Collated<T> {
     pub start: T,
     pub end: T,
@@ -67,17 +69,17 @@ where
     Collate::new(iter)
 }
 
-pub trait CollateIterExt: Iterator {
-    fn collate(self) -> Collate<Self, Self::Item>
+pub trait CollatedIterExt: Iterator {
+    fn collated(self) -> Collate<Self, Self::Item>
     where
         Self: Sized;
 }
 
-impl<T: ?Sized> CollateIterExt for T
+impl<T: ?Sized> CollatedIterExt for T
 where
     T: Iterator,
 {
-    fn collate(self) -> Collate<Self, Self::Item>
+    fn collated(self) -> Collate<Self, Self::Item>
     where
         Self: Sized,
     {
@@ -95,7 +97,7 @@ mod tests {
             1, 2, 3, 10, 10, 10, 11, 11, 20, 30, 31, 31, 32, 33, 35, 40, 40, 40, 40,
         ];
 
-        let collated = items.into_iter().collate().collect::<Vec<_>>();
+        let collated = items.into_iter().collated().collect::<Vec<_>>();
 
         assert_eq!(
             collated,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2846

## Description

Collate consecutive sequence numbers and heights in logs

For example, where before we would only show the first 50 sequence numbers:

> 2022-11-09T09:49:59.911813Z DEBUG ThreadId(386) worker.batch{chain=ibc-1}:supervisor.handle_batch{chain=ibc-1}:supervisor.process_batch{chain=ibc-1}:worker.packet.cmd{src_chain=ibc-1 src_port=transfer src_channel=channel-5 dst_chain=ibc-0}:schedule_packet_clearing{height=Some(Height { revision: 1, height: 26800 })}:relay_pending_packets{height=Some(Height { revision: 1, height: 26799 })}:build_packet_ack_msgs{query_height=1-26799}: sequence numbers of ack packets to send to the destination chain out of the ones with acknowledgments on the source chain (first 50 shown here) dst_chain=ibc-0 src_chain=ibc-1 total=184 sequences=[1259, 1260, 1261, 1262, 1263, 1264, 1265, 1266, 1267, 1268, 1269, 1270, 1271, 1272, 1273, 1274, 1275, 1276, 1277, 1278, 1279, 1280, 1281, 1282, 1283, 1284, 1285, 1286, 1287, 1288, 1289, 1290, 1291, 1292, 1293, 1294, 1295, 1296, 1297, 1298, 1299, 1300, 1301, 1302, 1303, 1304, 1305, 1306, 1307, 1308]

We now show all sequences numbers where consecutive ones are collated together:

> 2022-11-09T09:49:59.911813Z DEBUG ThreadId(386) worker.batch{chain=ibc-1}:supervisor.handle_batch{chain=ibc-1}:supervisor.process_batch{chain=ibc-1}:worker.packet.cmd{src_chain=ibc-1 src_port=transfer src_channel=channel-5 dst_chain=ibc-0}:schedule_packet_clearing{height=Some(Height { revision: 1, height: 26800 })}:relay_pending_packets{height=Some(Height { revision: 1, height: 26799 })}:build_packet_ack_msgs{query_height=1-26799}: sequence numbers of ack packets to send to the destination chain out of the ones with acknowledgments on the source chain dst_chain=ibc-0 src_chain=ibc-1 total=184 sequences=1259..=1329, 1359..=1439, 1469..=1500

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
