### PR TITLE
Remove unused or redundant dependencies, found via `cargo-machete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,25 +1660,19 @@ dependencies = [
  "serde_json",
  "tendermint-rpc",
  "tokio",
- "toml",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "ibc-integration-test"
 version = "0.20.0"
 dependencies = [
- "ibc-proto",
  "ibc-relayer",
- "ibc-relayer-cli",
  "ibc-relayer-types",
  "ibc-test-framework",
  "serde",
  "serde_json",
  "tempfile",
- "tendermint",
- "tendermint-rpc",
  "time 0.3.17",
  "toml",
 ]
@@ -1741,7 +1735,6 @@ dependencies = [
  "tendermint",
  "tendermint-light-client",
  "tendermint-light-client-verifier",
- "tendermint-proto",
  "tendermint-rpc",
  "tendermint-testgen",
  "test-log",
@@ -1772,11 +1765,9 @@ dependencies = [
  "eyre",
  "flex-error",
  "futures",
- "hex",
  "http",
  "humantime",
  "ibc-chain-registry",
- "ibc-proto",
  "ibc-relayer",
  "ibc-relayer-rest",
  "ibc-relayer-types",
@@ -1786,17 +1777,13 @@ dependencies = [
  "oneline-eyre",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "signal-hook",
  "subtle-encoding",
  "tendermint",
- "tendermint-light-client",
  "tendermint-light-client-verifier",
- "tendermint-proto",
  "tendermint-rpc",
  "tokio",
- "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1830,14 +1817,12 @@ dependencies = [
  "ics23",
  "itertools",
  "modelator",
- "num-traits",
  "primitive-types",
  "prost",
  "safe-regex",
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.6",
  "subtle-encoding",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -1855,7 +1840,6 @@ dependencies = [
 name = "ibc-telemetry"
 version = "0.20.0"
 dependencies = [
- "crossbeam-channel 0.5.6",
  "dashmap",
  "ibc-relayer-types",
  "moka",
@@ -1865,14 +1849,12 @@ dependencies = [
  "prometheus",
  "rouille",
  "tendermint",
- "uuid 1.2.1",
 ]
 
 [[package]]
 name = "ibc-test-framework"
 version = "0.20.0"
 dependencies = [
- "async-trait",
  "color-eyre",
  "crossbeam-channel 0.5.6",
  "eyre",
@@ -1884,7 +1866,6 @@ dependencies = [
  "ibc-relayer-cli",
  "ibc-relayer-types",
  "itertools",
- "prost",
  "rand",
  "semver",
  "serde",
@@ -1892,11 +1873,9 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.6",
  "subtle-encoding",
- "tendermint",
  "tendermint-rpc",
  "tokio",
  "toml",
- "tonic",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/chain-registry/Cargo.toml
+++ b/crates/chain-registry/Cargo.toml
@@ -23,8 +23,6 @@ reqwest     = { version = "0.11.12", features = ["rustls-tls", "json"], default-
 serde       = "1.0.145"
 serde_json  = "1"
 tokio       = "1.17.0"
-toml        = "0.5.8"
-url         = "2.3.1"
 tracing     = "0.1.36"
 
 [dependencies.tendermint-rpc]

--- a/crates/relayer-cli/Cargo.toml
+++ b/crates/relayer-cli/Cargo.toml
@@ -28,7 +28,6 @@ rest-server = ["ibc-relayer-rest"]
 [dependencies]
 ibc-relayer-types  = { version = "0.20.0", path = "../relayer-types", features = ["std", "clock"] }
 ibc-relayer        = { version = "0.20.0", path = "../relayer" }
-ibc-proto          = { version = "0.21.0" }
 ibc-telemetry      = { version = "0.20.0", path = "../telemetry", optional = true }
 ibc-relayer-rest   = { version = "0.20.0", path = "../relayer-rest", optional = true }
 ibc-chain-registry = { version = "0.1.0" , path = "../chain-registry" }
@@ -44,24 +43,18 @@ dirs-next                = "2.0.0"
 eyre                     = "0.6.8"
 flex-error               = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 futures                  = "0.3.25"
-hex                      = "0.4"
 http                     = "0.2"
 humantime                = "2.1"
 itertools                = "0.10.5"
 oneline-eyre             = "0.1"
 regex                    = "1.6.0"
 serde                    = { version = "1.0", features = ["serde_derive"] }
-serde_derive             = "1.0.116"
 serde_json               = "1"
 signal-hook              = "0.3.14"
 subtle-encoding          = "0.5"
 tokio                    = { version = "1.0", features = ["full"] }
-toml                     = "0.5.9"
 tracing                  = "0.1.36"
 tracing-subscriber       = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-
-[dependencies.tendermint-proto]
-version = "=0.25.0"
 
 [dependencies.tendermint]
 version = "=0.25.0"
@@ -70,10 +63,6 @@ features = ["secp256k1"]
 [dependencies.tendermint-rpc]
 version = "=0.25.0"
 features = ["http-client", "websocket-client"]
-
-[dependencies.tendermint-light-client]
-version = "=0.25.0"
-features = ["unstable"]
 
 [dependencies.tendermint-light-client-verifier]
 version = "=0.25.0"

--- a/crates/relayer-types/Cargo.toml
+++ b/crates/relayer-types/Cargo.toml
@@ -34,14 +34,11 @@ serde_derive = { version = "1.0.104", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1", default-features = false }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"] }
-tracing = { version = "0.1.36", default-features = false }
 prost = { version = "0.11", default-features = false }
 bytes = { version = "1.2.1", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 uint = { version = "0.9", default-features = false }
 itertools = { version = "0.10.3", default-features = false, features = ["use_alloc"] }
@@ -67,9 +64,9 @@ default-features = false
 
 [dev-dependencies]
 env_logger = "0.9.1"
+tracing = { version = "0.1.36", default-features = false }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
 modelator = "0.4.2"
-sha2 = { version = "0.10.6" }
 tendermint-rpc = { version = "=0.25.0", features = ["http-client", "websocket-client"] }
 tendermint-testgen = { version = "=0.25.0" } # Needed for generating (synthetic) light blocks.

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -87,9 +87,6 @@ features = ["rpc-client", "secp256k1", "unstable"]
 version = "=0.25.0"
 default-features = false
 
-[dependencies.tendermint-proto]
-version = "=0.25.0"
-
 [dev-dependencies]
 ibc-relayer-types = { version = "0.20.0", path = "../relayer-types", features = ["mocks"] }
 serial_test = "0.9.0"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -15,14 +15,12 @@ description  = """
 [dependencies]
 ibc-relayer-types = { version = "0.20.0", path = "../relayer-types" }
 
-crossbeam-channel        = "0.5.5"
 once_cell                = "1.16.0"
 opentelemetry            = { version = "0.18.0", features = ["metrics"] }
 opentelemetry-prometheus = "0.11.0"
 prometheus               = "0.13.2"
 rouille                  = "3.6.1"
 moka                     = "0.9.4"
-uuid                     = { version = "1.2.1", features = ["v4"] }
 dashmap                  = "5.4.0"
 
 [dependencies.tendermint]

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -16,11 +16,7 @@ description = """
 [dependencies]
 ibc-relayer-types  = { path = "../../crates/relayer-types" }
 ibc-relayer        = { path = "../../crates/relayer" }
-ibc-relayer-cli    = { path = "../../crates/relayer-cli" }
-ibc-proto          = { version = "0.21.0" }
 ibc-test-framework = { path = "../test-framework" }
-tendermint         = { version = "=0.25.0" }
-tendermint-rpc     = { version = "=0.25.0", features = ["http-client", "websocket-client"] }
 
 serde_json = "1"
 time = "0.3"

--- a/tools/test-framework/Cargo.toml
+++ b/tools/test-framework/Cargo.toml
@@ -18,10 +18,8 @@ ibc-relayer-types = { version = "=0.20.0",     path = "../../crates/relayer-type
 ibc-relayer       = { version = "=0.20.0",     path = "../../crates/relayer" }
 ibc-relayer-cli   = { version = "=1.1.0",      path = "../../crates/relayer-cli" }
 ibc-proto         = { version = "=0.21.0" }
-tendermint        = { version = "=0.25.0" }
 tendermint-rpc    = { version = "=0.25.0", features = ["http-client", "websocket-client"] }
 
-async-trait = "0.1.57"
 http = "0.2.8"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.36"
@@ -40,5 +38,3 @@ sha2 = "0.10.6"
 crossbeam-channel = "0.5.5"
 semver = "1.0.14"
 flex-error = "0.4.4"
-prost = { version = "0.11" }
-tonic = { version = "0.8", features = ["tls", "tls-roots"] }


### PR DESCRIPTION
Unfortunately, looking at the `Cargo.lock` diff, it does not seem to remove anything from the transitive dependency graph for the workspace. But it still cuts down on some dependencies when some of the crates are used individually.