### PR TITLE
keyring: Clean up secp256k1 signing with other small changes

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/2863-keyring.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/2863-keyring.md
@@ -1,0 +1,5 @@
+- Clean up secp256k1 signing with other small changes
+  - The `k256` library is no longer used; instead, `secp256k1` is used for both Evmos (aka Ethermint) and Cosmos
+  - Move `sign_message` into `KeyEntry` and remove the duplicated functions in `KeyRing` and at the top level
+  - Move `from_seed_file` into `KeyEntry`
+  - Simplify the `get_address` implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "regex",
  "retry",
  "ripemd",
+ "secp256k1",
  "semver",
  "serde",
  "serde_derive",
@@ -3413,6 +3414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
 dependencies = [
  "bitcoin_hashes",
+ "rand",
  "secp256k1-sys",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,12 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,7 +824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
- "zeroize",
 ]
 
 [[package]]
@@ -986,7 +979,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1709,10 +1701,12 @@ dependencies = [
  "bitcoin",
  "bytes",
  "crossbeam-channel 0.5.6",
+ "digest 0.10.5",
  "dirs-next",
  "env_logger",
  "flex-error",
  "futures",
+ "generic-array",
  "hdpath",
  "hex",
  "http",
@@ -1722,7 +1716,6 @@ dependencies = [
  "ibc-relayer-types",
  "ibc-telemetry",
  "itertools",
- "k256",
  "moka",
  "num-bigint",
  "num-rational",
@@ -1730,6 +1723,7 @@ dependencies = [
  "regex",
  "retry",
  "ripemd",
+ "secp256k1",
  "semver",
  "serde",
  "serde_derive",
@@ -2796,16 +2790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,7 +3403,6 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -3431,6 +3414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
 dependencies = [
  "bitcoin_hashes",
+ "rand",
  "secp256k1-sys",
  "serde",
 ]
@@ -3755,16 +3739,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "static_assertions"

--- a/crates/relayer-cli/src/commands/keys/add.rs
+++ b/crates/relayer-cli/src/commands/keys/add.rs
@@ -195,7 +195,7 @@ pub fn add_key(
     check_key_exists(&keyring, key_name, overwrite);
 
     let key_contents = fs::read_to_string(file).map_err(|_| eyre!("error reading the key file"))?;
-    let key = keyring.key_from_seed_file(&key_contents, hd_path)?;
+    let key = KeyEntry::from_seed_file(&key_contents, hd_path)?;
 
     keyring.add_key(key_name, key.clone())?;
     Ok(key)

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -39,7 +39,6 @@ prost = { version = "0.11" }
 tonic = { version = "0.8", features = ["tls", "tls-roots"] }
 futures = "0.3.25"
 crossbeam-channel = "0.5.5"
-k256 = { version = "0.11.5", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
 bitcoin = { version = "0.29.1", features = ["serde"] }
 tiny-bip39 = "1.0.0"
@@ -61,6 +60,9 @@ humantime = "2.1.0"
 regex = "1.5.5"
 moka = "0.9.4"
 uuid = { version = "1.2.1", features = ["v4"] }
+digest = "0.10.5"
+generic-array = "0.14.6"
+secp256k1 = { version = "0.24.1", features = ["rand-std"] }
 
 [dependencies.num-bigint]
 version = "0.4"

--- a/crates/relayer/src/chain/cosmos/batch.rs
+++ b/crates/relayer/src/chain/cosmos/batch.rs
@@ -380,11 +380,9 @@ mod tests {
             "/tests/config/fixtures/relayer-seed.json"
         );
         let seed_file_content = fs::read_to_string(path).unwrap();
-        let keyring = KeyRing::new(keyring::Store::Memory, "cosmos", &chain_id).unwrap();
+        let _keyring = KeyRing::new(keyring::Store::Memory, "cosmos", &chain_id).unwrap();
         let hd_path = COSMOS_HD_PATH.parse().unwrap();
-        let key_entry = keyring
-            .key_from_seed_file(&seed_file_content, &hd_path)
-            .unwrap();
+        let key_entry = KeyEntry::from_seed_file(&seed_file_content, &hd_path).unwrap();
 
         let account = Account {
             address: AccountAddress::new("".to_owned()),

--- a/crates/relayer/src/chain/cosmos/encode.rs
+++ b/crates/relayer/src/chain/cosmos/encode.rs
@@ -16,7 +16,7 @@ use crate::chain::cosmos::types::tx::SignedTx;
 use crate::config::types::Memo;
 use crate::config::AddressType;
 use crate::error::Error;
-use crate::keyring::{sign_message, KeyEntry};
+use crate::keyring::KeyEntry;
 
 pub fn sign_and_encode_tx(
     config: &TxConfig,
@@ -138,7 +138,9 @@ fn encode_sign_doc(
     let mut signdoc_buf = Vec::new();
     prost::Message::encode(&sign_doc, &mut signdoc_buf).unwrap();
 
-    let signed = sign_message(key, signdoc_buf, address_type).map_err(Error::key_base)?;
+    let signed = key
+        .sign_message(&signdoc_buf, address_type)
+        .map_err(Error::key_base)?;
 
     Ok(signed)
 }

--- a/crates/relayer/src/keyring.rs
+++ b/crates/relayer/src/keyring.rs
@@ -106,11 +106,13 @@ impl KeyEntry {
         Self::from_key_file(key_file, hd_path)
     }
 
-    // NOTE: Cosmos does not keep `v` (recovery code) in the `(r, s, v)` tuple
-    // for secp256k1, while Ethereum (and therefore Evmos) does.
+    // NOTE: Neither Cosmos nor Ethermint keep `v` (recovery code) in the
+    // `(r, s, v)` tuple for secp256k1.
     //
-    // Cosmos implementation: https://github.com/cosmos/cosmos-sdk/blob/main/crypto/keys/secp256k1/secp256k1_cgo.go
-    // Evmos docs: https://docs.evmos.org/modules/evm/04_transactions.html
+    // Cosmos: https://github.com/cosmos/cosmos-sdk/blob/main/crypto/keys/secp256k1/secp256k1_cgo.go
+    // Ethermint:
+    // - https://github.com/evmos/ethermint/blob/main/crypto/ethsecp256k1/ethsecp256k1.go
+    // - informalsystems/hermes#2863.
     pub fn sign_message(
         &self,
         message: &[u8],
@@ -127,7 +129,6 @@ impl KeyEntry {
         // so `unwrap` is safe.
         let message = Message::from_slice(&hashed_message).unwrap();
 
-        // TODO: Call `.sign_ecdsa_recoverable` for Evmos.
         Ok(Secp256k1::signing_only()
             .sign_ecdsa(&message, &self.private_key.private_key)
             .serialize_compact()

--- a/crates/relayer/src/keyring.rs
+++ b/crates/relayer/src/keyring.rs
@@ -420,7 +420,7 @@ fn get_address(public_key: &PublicKey, address_type: &AddressType) -> [u8; 20] {
             hashed_key[12..].try_into().unwrap()
         }
         AddressType::Cosmos | AddressType::Ethermint { .. } => {
-            Ripemd160::digest(&Sha256::digest(&public_key.serialize())).into()
+            Ripemd160::digest(Sha256::digest(public_key.serialize())).into()
         }
     }
 }

--- a/crates/relayer/src/keyring.rs
+++ b/crates/relayer/src/keyring.rs
@@ -3,19 +3,20 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
-use bech32::{ToBase32, Variant};
+use bech32::ToBase32;
 use bip39::{Language, Mnemonic, Seed};
 use bitcoin::{
     network::constants::Network,
-    secp256k1::{Message, Secp256k1, SecretKey},
     util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey},
 };
+use digest::Digest;
+use generic_array::{typenum::U32, GenericArray};
 use hdpath::StandardHDPath;
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
-use k256::ecdsa::{signature::Signer as _, Signature, SigningKey};
 use ripemd::Ripemd160;
+use secp256k1::{Message, PublicKey, Secp256k1};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use tiny_keccak::{Hasher, Keccak};
 
 use crate::config::AddressType;
@@ -63,7 +64,7 @@ pub struct KeyFile {
 }
 
 impl KeyEntry {
-    pub fn from_key_file(key_file: KeyFile, hd_path: &HDPath) -> Result<Self, Error> {
+    fn from_key_file(key_file: KeyFile, hd_path: &HDPath) -> Result<Self, Error> {
         // Decode the Bech32-encoded address from the key file
         let keyfile_address_bytes = decode_bech32(&key_file.address)?;
 
@@ -72,7 +73,7 @@ impl KeyEntry {
 
         // Decode the private key from the mnemonic
         let private_key = private_key_from_mnemonic(&key_file.mnemonic, hd_path)?;
-        let derived_pubkey = ExtendedPubKey::from_priv(&Secp256k1::new(), &private_key);
+        let derived_pubkey = ExtendedPubKey::from_priv(&Secp256k1::signing_only(), &private_key);
         let derived_pubkey_bytes = derived_pubkey.to_pub().to_bytes();
         assert!(derived_pubkey_bytes.len() <= keyfile_pubkey_bytes.len());
 
@@ -97,6 +98,40 @@ impl KeyEntry {
                 address: keyfile_address_bytes,
             })
         }
+    }
+
+    /// Get key from seed file
+    pub fn from_seed_file(key_file_content: &str, hd_path: &HDPath) -> Result<Self, Error> {
+        let key_file = serde_json::from_str(key_file_content).map_err(Error::encode)?;
+        Self::from_key_file(key_file, hd_path)
+    }
+
+    // NOTE: Cosmos does not keep `v` (recovery code) in the `(r, s, v)` tuple
+    // for secp256k1, while Ethereum (and therefore Evmos) does.
+    //
+    // Cosmos implementation: https://github.com/cosmos/cosmos-sdk/blob/main/crypto/keys/secp256k1/secp256k1_cgo.go
+    // Evmos docs: https://docs.evmos.org/modules/evm/04_transactions.html
+    pub fn sign_message(
+        &self,
+        message: &[u8],
+        address_type: &AddressType,
+    ) -> Result<Vec<u8>, Error> {
+        let hashed_message: GenericArray<u8, U32> = match address_type {
+            AddressType::Ethermint { ref pk_type } if pk_type.ends_with(".ethsecp256k1.PubKey") => {
+                keccak256_hash(message).into()
+            }
+            AddressType::Cosmos | AddressType::Ethermint { .. } => Sha256::digest(message),
+        };
+
+        // SAFETY: hashed_message is 32 bytes, as expected in `Message::from_slice`,
+        // so `unwrap` is safe.
+        let message = Message::from_slice(&hashed_message).unwrap();
+
+        // TODO: Call `.sign_ecdsa_recoverable` for Evmos.
+        Ok(Secp256k1::signing_only()
+            .sign_ecdsa(&message, &self.private_key.private_key)
+            .serialize_compact()
+            .to_vec())
     }
 }
 
@@ -250,7 +285,7 @@ pub enum Store {
 
 impl Default for Store {
     fn default() -> Self {
-        Store::Test
+        Self::Test
     }
 }
 
@@ -313,36 +348,23 @@ impl KeyRing {
         }
     }
 
-    /// Get key from seed file
-    pub fn key_from_seed_file(
-        &self,
-        key_file_content: &str,
-        hd_path: &HDPath,
-    ) -> Result<KeyEntry, Error> {
-        let key_file: KeyFile = serde_json::from_str(key_file_content).map_err(Error::encode)?;
-
-        KeyEntry::from_key_file(key_file, hd_path)
-    }
-
     /// Add a key entry in the store using a mnemonic.
     pub fn key_from_mnemonic(
         &self,
         mnemonic_words: &str,
         hd_path: &HDPath,
-        at: &AddressType,
+        address_type: &AddressType,
     ) -> Result<KeyEntry, Error> {
-        // Get the private key from the mnemonic
         let private_key = private_key_from_mnemonic(mnemonic_words, hd_path)?;
+        let public_key = ExtendedPubKey::from_priv(&Secp256k1::signing_only(), &private_key);
+        let address = get_address(&public_key.public_key, address_type).to_vec();
 
-        // Get the public Key from the private key
-        let public_key = ExtendedPubKey::from_priv(&Secp256k1::new(), &private_key);
-
-        // Get address from the public Key
-        let address = get_address(public_key, at);
-
-        // Compute Bech32 account
-        let account = bech32::encode(self.account_prefix(), address.to_base32(), Variant::Bech32)
-            .map_err(Error::bech32)?;
+        let account = bech32::encode(
+            self.account_prefix(),
+            address.to_base32(),
+            bech32::Variant::Bech32,
+        )
+        .map_err(Error::bech32)?;
 
         Ok(KeyEntry {
             public_key,
@@ -352,51 +374,10 @@ impl KeyRing {
         })
     }
 
-    /// Sign a message
-    pub fn sign_msg(
-        &self,
-        key_name: &str,
-        msg: Vec<u8>,
-        address_type: &AddressType,
-    ) -> Result<Vec<u8>, Error> {
-        let key = self.get_key(key_name)?;
-
-        sign_message(&key, msg, address_type)
-    }
-
     pub fn account_prefix(&self) -> &str {
         match self {
             KeyRing::Memory(m) => &m.account_prefix,
             KeyRing::Test(d) => &d.account_prefix,
-        }
-    }
-}
-
-/// Sign a message
-pub fn sign_message(
-    key: &KeyEntry,
-    msg: Vec<u8>,
-    address_type: &AddressType,
-) -> Result<Vec<u8>, Error> {
-    let private_key_bytes = key.private_key.to_priv().to_bytes();
-    match address_type {
-        AddressType::Ethermint { ref pk_type } if pk_type.ends_with(".ethsecp256k1.PubKey") => {
-            let hash = keccak256_hash(msg.as_slice());
-            let s = Secp256k1::signing_only();
-            // SAFETY: hash is 32 bytes, as expected in `Message::from_slice` -- see `keccak256_hash`, hence `unwrap`
-            let sign_msg = Message::from_slice(hash.as_slice()).unwrap();
-            let key = SecretKey::from_slice(private_key_bytes.as_slice())
-                .map_err(Error::invalid_key_raw)?;
-            let (_, sig_bytes) = s
-                .sign_ecdsa_recoverable(&sign_msg, &key)
-                .serialize_compact();
-            Ok(sig_bytes.to_vec())
-        }
-        AddressType::Cosmos | AddressType::Ethermint { .. } => {
-            let signing_key =
-                SigningKey::from_bytes(private_key_bytes.as_slice()).map_err(Error::invalid_key)?;
-            let signature: Signature = signing_key.sign(&msg);
-            Ok(signature.as_ref().to_vec())
         }
     }
 }
@@ -416,7 +397,7 @@ fn private_key_from_mnemonic(
 
     let private_key = base_key
         .derive_priv(
-            &Secp256k1::new(),
+            &Secp256k1::signing_only(),
             &standard_path_to_derivation_path(hd_path),
         )
         .map_err(Error::private_key)?;
@@ -425,31 +406,21 @@ fn private_key_from_mnemonic(
 }
 
 /// Return an address from a Public Key
-fn get_address(pk: ExtendedPubKey, at: &AddressType) -> Vec<u8> {
-    match at {
+fn get_address(public_key: &PublicKey, address_type: &AddressType) -> [u8; 20] {
+    match address_type {
         AddressType::Ethermint { ref pk_type } if pk_type.ends_with(".ethsecp256k1.PubKey") => {
-            let public_key = pk.public_key.serialize_uncompressed();
-            // 0x04 is [SECP256K1_TAG_PUBKEY_UNCOMPRESSED](https://github.com/bitcoin-core/secp256k1/blob/d7ec49a6893751f068275cc8ddf4993ef7f31756/include/secp256k1.h#L196)
+            let public_key = public_key.serialize_uncompressed();
+            // 0x04 is `SECP256K1_TAG_PUBKEY_UNCOMPRESSED`:
+            // https://github.com/bitcoin-core/secp256k1/blob/d7ec49a6893751f068275cc8ddf4993ef7f31756/include/secp256k1.h#L196
             debug_assert_eq!(public_key[0], 0x04);
 
-            let output = keccak256_hash(&public_key[1..]);
+            let hashed_key = keccak256_hash(&public_key[1..]);
             // right-most 20-bytes from the 32-byte keccak hash
             // (see https://kobl.one/blog/create-full-ethereum-keypair-and-address/)
-            output[12..].to_vec()
+            hashed_key[12..].try_into().unwrap()
         }
         AddressType::Cosmos | AddressType::Ethermint { .. } => {
-            let mut hasher = Sha256::new();
-            hasher.update(pk.to_pub().to_bytes().as_slice());
-
-            // Read hash digest over the public key bytes & consume hasher
-            let pk_hash = hasher.finalize();
-
-            // Plug the hash result into the next crypto hash function.
-            let mut rip_hasher = Ripemd160::new();
-            rip_hasher.update(pk_hash);
-            let rip_result = rip_hasher.finalize();
-
-            rip_result.to_vec()
+            Ripemd160::digest(&Sha256::digest(&public_key.serialize())).into()
         }
     }
 }
@@ -475,12 +446,12 @@ fn disk_store_path(folder_name: &str) -> Result<PathBuf, Error> {
     Ok(folder)
 }
 
-fn keccak256_hash(bytes: &[u8]) -> Vec<u8> {
+fn keccak256_hash(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Keccak::v256();
     hasher.update(bytes);
-    let mut resp = vec![0u8; 32];
-    hasher.finalize(&mut resp);
-    resp
+    let mut output = [0u8; 32];
+    hasher.finalize(&mut output);
+    output
 }
 
 fn standard_path_to_derivation_path(path: &StandardHDPath) -> DerivationPath {

--- a/tools/test-framework/src/chain/ext/bootstrap.rs
+++ b/tools/test-framework/src/chain/ext/bootstrap.rs
@@ -8,7 +8,7 @@ use std::str;
 use toml;
 use tracing::debug;
 
-use ibc_relayer::keyring::{HDPath, KeyEntry, KeyFile};
+use ibc_relayer::keyring::{HDPath, KeyEntry};
 
 use crate::chain::cli::bootstrap::{
     add_genesis_account, add_genesis_validator, add_wallet, collect_gen_txs, initialize,
@@ -174,9 +174,8 @@ impl ChainBootstrapMethodsExt for ChainDriver {
         let hd_path = HDPath::from_str(self.chain_type.hd_path())
             .map_err(|e| eyre!("failed to create HDPath: {:?}", e))?;
 
-        let key_file: KeyFile = json::from_str(&seed_content).map_err(handle_generic_error)?;
-
-        let key = KeyEntry::from_key_file(key_file, &hd_path).map_err(handle_generic_error)?;
+        let key =
+            KeyEntry::from_seed_file(&seed_content, &hd_path).map_err(handle_generic_error)?;
 
         Ok(Wallet::new(wallet_id.to_string(), wallet_address, key))
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

These changes prep a larger PR for #2851.

## Description

The KeyRing has a few cleanup changes made. In particular, the signing logic has been updated:

- The `k256` library is no longer used; instead, `secp256k1` is used for both Evmos (aka Ethermint) and Cosmos.
- `.sign_ecdsa` is used for both Evmos and Cosmos as in the current implementation for Evmos, the recovery value `v` is just thrown out via `let (_, sig_bytes)`. I'm not super familiar with Evmos but this seems wrong at a glance, so I left a TODO to figure out how to fix this in the future.

This is the most invasive part of the change, so any help with suggesting how we could test that signing works the same before and after would be helpful.

Separately, there are some miscellaneous changes:

- Use `Secp256k1::signing_only()` instead of `Secp256k1::new()` for clarity.
- Move `sign_message` into `KeyEntry` and remove the duplicated functions in `KeyRing` and at the top level.
- Move `from_seed_file` into `KeyEntry`.
- Simplify the `get_address` implementation.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).
