### PR TITLE
Fix comments & telemetry tags

### DIFF
--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -596,7 +596,7 @@ impl CosmosSdkChain {
 
             assert!(
                 response.blocks.len() <= 1,
-                "block_results: unexpected number of blocks"
+                "block_search: unexpected number of blocks"
             );
 
             if let Some(block) = response.blocks.first().map(|first| &first.block) {

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -1683,6 +1683,9 @@ impl ChainEndpoint for CosmosSdkChain {
         crate::telemetry!(query, self.id(), "query_packet_events");
 
         match request.height {
+            // Usage note: `Qualified::Equal` is currently only used in the call hierarchy involving
+            // the CLI methods, namely the CLI for `tx packet-recv` and `tx packet-ack` when the
+            // user passes the flag `packet-data-query-height`.
             Qualified::Equal(_) => self.block_on(query_packets_from_block(
                 self.id(),
                 &self.rpc_client,

--- a/crates/relayer/src/chain/cosmos/query/tx.rs
+++ b/crates/relayer/src/chain/cosmos/query/tx.rs
@@ -255,6 +255,9 @@ fn packet_from_tx_search_response(
         .map(|ibc_event| IbcEventWithHeight::new(ibc_event, height)))
 }
 
+/// Returns the given event wrapped in `Some` if the event data
+/// is consistent with the request parameters.
+/// Returns `None` otherwise.
 pub fn filter_matching_event(
     event: Event,
     request: &QueryPacketEventDataRequest,

--- a/crates/relayer/src/chain/cosmos/query/tx.rs
+++ b/crates/relayer/src/chain/cosmos/query/tx.rs
@@ -139,7 +139,8 @@ pub async fn query_packets_from_txs(
     Ok(result)
 }
 
-/// This function queries packet events from a given block, events matching certain criteria.
+/// This function queries packet events from a block at a specific height.
+/// It returns packet events that match certain criteria (see [`filter_matching_event`]).
 /// It returns at most one packet event for each sequence specified in the request.
 pub async fn query_packets_from_block(
     chain_id: &ChainId,
@@ -147,8 +148,8 @@ pub async fn query_packets_from_block(
     rpc_address: &Url,
     request: &QueryPacketEventDataRequest,
 ) -> Result<Vec<IbcEventWithHeight>, Error> {
-    crate::time!("query_packets_from_txs");
-    crate::telemetry!(query, chain_id, "query_packets_from_txs");
+    crate::time!("query_packets_from_block");
+    crate::telemetry!(query, chain_id, "query_packets_from_block");
 
     let mut result: Vec<IbcEventWithHeight> = vec![];
 

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -415,6 +415,16 @@ pub struct QueryPacketEventDataRequest {
     pub height: Qualified<QueryHeight>,
 }
 
+/// Refines an inner type by assigning it to refer to either a:
+///     - range of values (when using variant `SmallerEqual`), or
+///     - to a specific value (with variant `Equal`).
+///
+/// For example, the inner type is typically a [`QueryHeight`].
+/// In this case, we can capture and handle the two separate cases
+/// that can appear when we want to query for packet event data,
+/// depending on the request: The request might refer to a specific
+/// height (i.e., we want packets from a block _at height_ T), or to
+/// a range of heights (i.e., all packets _up to height_ T).
 #[derive(Clone, Copy, Debug)]
 pub enum Qualified<T> {
     SmallerEqual(T),
@@ -422,6 +432,7 @@ pub enum Qualified<T> {
 }
 
 impl<T> Qualified<T> {
+    /// Access the inner type.
     pub fn get(self) -> T {
         match self {
             Qualified::SmallerEqual(t) => t,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

I was compiling a list of relayer requirements ([ref](https://hedgedoc.informal.systems/FmNN0xuESR2wS1ZoRhuU8g?view) and [diagram](https://app.excalidraw.com/l/4XqkU6POmGI/9jbKsT6mHxf)) and realised that our method that invoke `block_results` RPC in Hermes are poorly documented. Added a couple of comments here and there towards fixing that, and also fixed some logs and telemetry tags that were inconsistent.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
