### PR TITLE
Prepend Hermes version CLI output

### DIFF
--- a/crates/relayer-cli/src/application.rs
+++ b/crates/relayer-cli/src/application.rs
@@ -132,6 +132,11 @@ impl Application for CliApp {
             }
         };
 
+        tracing::info!(
+            "Using Hermes version: v{}",
+            clap::crate_version!().to_string()
+        );
+
         self.config.set_once(config);
 
         Ok(())

--- a/crates/relayer-cli/src/application.rs
+++ b/crates/relayer-cli/src/application.rs
@@ -133,8 +133,8 @@ impl Application for CliApp {
         };
 
         tracing::info!(
-            "Using Hermes version: v{}",
-            clap::crate_version!().to_string()
+            "Running Hermes v{}",
+            clap::crate_version!()
         );
 
         self.config.set_once(config);

--- a/crates/relayer-cli/src/application.rs
+++ b/crates/relayer-cli/src/application.rs
@@ -132,10 +132,7 @@ impl Application for CliApp {
             }
         };
 
-        tracing::info!(
-            "Running Hermes v{}",
-            clap::crate_version!()
-        );
+        tracing::info!("Running Hermes v{}", clap::crate_version!());
 
         self.config.set_once(config);
 

--- a/crates/relayer-cli/src/application.rs
+++ b/crates/relayer-cli/src/application.rs
@@ -132,7 +132,7 @@ impl Application for CliApp {
             }
         };
 
-        tracing::info!("Running Hermes v{}", clap::crate_version!());
+        tracing::info!("running Hermes v{}", clap::crate_version!());
 
         self.config.set_once(config);
 

--- a/crates/relayer-cli/src/conclude.rs
+++ b/crates/relayer-cli/src/conclude.rs
@@ -77,7 +77,7 @@ pub fn exit_with(out: Output) -> ! {
             Status::Success => style("SUCCESS").green(),
             Status::Error => style("ERROR").red(),
         };
-        println!("{}: {} {}", clap::crate_version!(), status, out.result);
+        println!("{}(v{}) {}", status, out.version, out.result);
     }
 
     // The return code
@@ -147,6 +147,9 @@ pub struct Output {
 
     /// The result of a command, such as the output from a query or transaction.
     pub result: Result,
+
+    /// The Hermes version
+    version: String,
 }
 
 impl Output {
@@ -155,6 +158,7 @@ impl Output {
         Output {
             status,
             result: Result::Nothing,
+            version: clap::crate_version!().to_string(),
         }
     }
 
@@ -220,6 +224,11 @@ impl Output {
         map.insert(
             "status".to_string(),
             serde_json::to_value(self.status).unwrap(),
+        );
+
+        map.insert(
+            "version".to_string(),
+            serde_json::to_value(self.version).unwrap(),
         );
 
         let value = match self.result {

--- a/crates/relayer-cli/src/conclude.rs
+++ b/crates/relayer-cli/src/conclude.rs
@@ -77,7 +77,7 @@ pub fn exit_with(out: Output) -> ! {
             Status::Success => style("SUCCESS").green(),
             Status::Error => style("ERROR").red(),
         };
-        println!("{}(v{}) {}", status, out.version, out.result);
+        println!("{} {}", status, out.result);
     }
 
     // The return code
@@ -147,9 +147,6 @@ pub struct Output {
 
     /// The result of a command, such as the output from a query or transaction.
     pub result: Result,
-
-    /// The Hermes version
-    version: String,
 }
 
 impl Output {
@@ -158,7 +155,6 @@ impl Output {
         Output {
             status,
             result: Result::Nothing,
-            version: clap::crate_version!().to_string(),
         }
     }
 
@@ -224,11 +220,6 @@ impl Output {
         map.insert(
             "status".to_string(),
             serde_json::to_value(self.status).unwrap(),
-        );
-
-        map.insert(
-            "version".to_string(),
-            serde_json::to_value(self.version).unwrap(),
         );
 
         let value = match self.result {

--- a/crates/relayer-cli/src/conclude.rs
+++ b/crates/relayer-cli/src/conclude.rs
@@ -77,7 +77,7 @@ pub fn exit_with(out: Output) -> ! {
             Status::Success => style("SUCCESS").green(),
             Status::Error => style("ERROR").red(),
         };
-        println!("{} {}", status, out.result);
+        println!("{}: {} {}", clap::crate_version!(), status, out.result);
     }
 
     // The return code


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2887

## Description

Add Hermes version to the output of most CLIs.

The command `hermes version` doesn't output duplicate version:

```
hermes version
hermes 1.1.0+240d50e7b
```
<details>
  <summary>Old solution from commit 240d50e7b38be40e65737d45de9ba85f09d7b82e)</summary>

### Example outputs Old solution

`hermes query channels --chain ibc-1`:

```
2022-11-23T08:43:54.041664Z  INFO ThreadId(01) using default configuration from '/Users/luca/.hermes/config.toml'
SUCCESS(v1.1.0+240d50e7b) [
    PortChannelId {
        channel_id: ChannelId(
            "channel-0",
        ),
        port_id: PortId(
            "transfer",
        ),
    },
]
```

`hermes --json query channels --chain ibc-1`:

```
{"timestamp":"2022-11-23T08:45:06.288261Z","level":"INFO","fields":{"message":"using default configuration from '/Users/luca/.hermes/config.toml'"},"threadId":"ThreadId(1)"}
{"result":[{"channel_id":"channel-0","port_id":"transfer"}],"status":"success","version":"1.1.0+240d50e7b"}
```

`hermes query channels --chain ibc-3`:

```
2022-11-23T08:44:46.793190Z  INFO ThreadId(01) using default configuration from '/Users/luca/.hermes/config.toml'
ERROR(v1.1.0+240d50e7b) missing chain config for 'ibc-3' in configuration file
```
</details>

### Example outputs current solution
`hermes query channels --chain ibc-1`:

```
2022-11-23T11:30:25.861000Z  INFO ThreadId(01) using default configuration from '/Users/luca/.hermes/config.toml'
2022-11-23T11:30:25.862253Z  INFO ThreadId(01) Running Hermes v1.1.0+52742f1db
SUCCESS [
    PortChannelId {
        channel_id: ChannelId(
            "channel-0",
        ),
        port_id: PortId(
            "transfer",
        ),
    },
]
```

`hermes --json query channels --chain ibc-1`:

```
{"timestamp":"2022-11-23T11:30:37.823794Z","level":"INFO","fields":{"message":"using default configuration from '/Users/luca/.hermes/config.toml'"},"threadId":"ThreadId(1)"}
{"timestamp":"2022-11-23T11:30:37.825086Z","level":"INFO","fields":{"message":"Running Hermes v1.1.0+52742f1db"},"threadId":"ThreadId(1)"}
{"result":[{"channel_id":"channel-0","port_id":"transfer"}],"status":"success"}
```

`hermes query channels --chain ibc-3`:

```
2022-11-23T11:30:28.496187Z  INFO ThreadId(01) using default configuration from '/Users/luca/.hermes/config.toml'
2022-11-23T11:30:28.497363Z  INFO ThreadId(01) Running Hermes v1.1.0+52742f1db
ERROR missing chain config for 'ibc-3' in configuration file
```
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
