### PR TITLE
Fix CI and update Cachix and install Nix actions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -115,7 +115,7 @@ jobs:
               --nocapture --test-threads=2
 
   multi-chains-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     if: github.ref == 'refs/heads/master'
     timeout-minutes: 60
     strategy:
@@ -226,7 +226,7 @@ jobs:
               --nocapture --test-threads=2
 
   ordered-channel-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
@@ -258,7 +258,7 @@ jobs:
             --nocapture --test-threads=1 test_ordered_channel
 
   ica-filter-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v15
@@ -290,7 +290,7 @@ jobs:
             --nocapture --test-threads=1 test_ica_filter
 
   ics29-fee-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     strategy:
       fail-fast: false
       matrix:
@@ -333,7 +333,7 @@ jobs:
             --nocapture --test-threads=1 fee::
 
   forward-packet:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     strategy:
       fail-fast: false
       matrix:
@@ -376,7 +376,7 @@ jobs:
             --nocapture --test-threads=1 forward::
 
   model-based-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -81,13 +81,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v15
+      - uses: cachix/install-nix-action@v18
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1
@@ -198,7 +198,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1
@@ -236,7 +236,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1
@@ -267,7 +267,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1
@@ -309,7 +309,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1
@@ -352,7 +352,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1
@@ -390,7 +390,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: cosmos
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
CI seems to be broken with the old version of Cachix actions using deprecated features.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
