### PR TITLE
Removed unused 'shutdown_workers_for_chain' method

### DIFF
--- a/crates/relayer/src/supervisor/spawn.rs
+++ b/crates/relayer/src/supervisor/spawn.rs
@@ -2,7 +2,7 @@ use tracing::{error, info};
 
 use ibc_relayer_types::core::{
     ics02_client::client_state::ClientState, ics03_connection::connection::IdentifiedConnectionEnd,
-    ics04_channel::channel::State as ChannelState, ics24_host::identifier::ChainId,
+    ics04_channel::channel::State as ChannelState,
 };
 
 use crate::{
@@ -322,13 +322,6 @@ impl<'a, Chain: ChainHandle> SpawnContext<'a, Chain> {
             Ok(true)
         } else {
             Ok(false)
-        }
-    }
-
-    pub fn shutdown_workers_for_chain(&mut self, chain_id: &ChainId) {
-        let affected_workers = self.workers.objects_for_chain(chain_id);
-        for object in affected_workers {
-            self.workers.shutdown_worker(&object);
         }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

The method `shutdown_workers_for_chain` is a remnant of the config reload feature which required shutting down the workers when the config was updated.

This PR removes this method as it is not used anymore.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
