### PR TITLE
Fetch consensus state heights using `QueryConsensusStateHeights`

### DIFF
--- a/.changelog/unreleased/breaking-changes/ibc-relayer/2001-consensus-state-heights.md
+++ b/.changelog/unreleased/breaking-changes/ibc-relayer/2001-consensus-state-heights.md
@@ -1,0 +1,4 @@
+- Remove `query_consensus_states` from the `ChainEndpoint` trait
+  ([#2001](https://github.com/informalsystems/hermes/issues/2001))
+- The `query consensus state` command now only list heights and its `--heights-only` option was removed
+  ([#2001](https://github.com/informalsystems/hermes/issues/2001))

--- a/.changelog/unreleased/improvements/ibc-relayer/2001-consensus-state-heights.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/2001-consensus-state-heights.md
@@ -1,0 +1,4 @@
+- Fetch consensus state heights using the more efficient
+  `QueryConsensusStateHeights` gRPC query instead of fetching all the consensus
+  states themselves using `QueryConsensusStates` and extracting the heights from
+  the result. ([#2001](https://github.com/informalsystems/ibc-rs/issues/2001))

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   integration-test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         with:
           max_attempts: 3
-          timeout_minutes: 120
+          timeout_minutes: 45
           command: |
             nix shell .#python .#${{ matrix.chain.package }} -c cargo \
               test -p ibc-integration-test --no-fail-fast -- \

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   integration-test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         with:
           max_attempts: 3
-          timeout_minutes: 45
+          timeout_minutes: 120
           command: |
             nix shell .#python .#${{ matrix.chain.package }} -c cargo \
               test -p ibc-integration-test --no-fail-fast -- \

--- a/crates/relayer-cli/src/commands/query/client.rs
+++ b/crates/relayer-cli/src/commands/query/client.rs
@@ -5,7 +5,7 @@ use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::chain::requests::{
     IncludeProof, PageRequest, QueryClientConnectionsRequest, QueryClientEventRequest,
     QueryClientStateRequest, QueryConsensusStateHeightsRequest, QueryConsensusStateRequest,
-    QueryConsensusStatesRequest, QueryHeight, QueryTxRequest,
+    QueryHeight, QueryTxRequest,
 };
 
 use ibc_relayer_types::core::ics02_client::client_state::ClientState;
@@ -102,9 +102,6 @@ pub struct QueryClientConsensusCmd {
     )]
     consensus_height: Option<u64>,
 
-    #[clap(long = "heights-only", help = "Show only consensus heights")]
-    heights_only: bool,
-
     #[clap(
         long = "height",
         value_name = "HEIGHT",
@@ -161,7 +158,7 @@ impl Runnable for QueryClientConsensusCmd {
                 Ok(cs) => Output::success(cs).exit(),
                 Err(e) => Output::error(e).exit(),
             }
-        } else if self.heights_only {
+        } else {
             let res = chain.query_consensus_state_heights(QueryConsensusStateHeightsRequest {
                 client_id: self.client_id.clone(),
                 pagination: Some(PageRequest::all()),
@@ -169,16 +166,6 @@ impl Runnable for QueryClientConsensusCmd {
 
             match res {
                 Ok(heights) => Output::success(heights).exit(),
-                Err(e) => Output::error(e).exit(),
-            }
-        } else {
-            let res = chain.query_consensus_states(QueryConsensusStatesRequest {
-                client_id: self.client_id.clone(),
-                pagination: Some(PageRequest::all()),
-            });
-
-            match res {
-                Ok(states) => Output::success(states).exit(),
                 Err(e) => Output::error(e).exit(),
             }
         }
@@ -388,7 +375,6 @@ mod tests {
                 chain_id: ChainId::from_string("chain_id"),
                 client_id: ClientId::from_str("client_id").unwrap(),
                 consensus_height: None,
-                heights_only: false,
                 height: None
             },
             QueryClientConsensusCmd::parse_from([
@@ -408,7 +394,6 @@ mod tests {
                 chain_id: ChainId::from_string("chain_id"),
                 client_id: ClientId::from_str("client_id").unwrap(),
                 consensus_height: Some(42),
-                heights_only: false,
                 height: None
             },
             QueryClientConsensusCmd::parse_from([
@@ -430,7 +415,6 @@ mod tests {
                 chain_id: ChainId::from_string("chain_id"),
                 client_id: ClientId::from_str("client_id").unwrap(),
                 consensus_height: None,
-                heights_only: false,
                 height: Some(42)
             },
             QueryClientConsensusCmd::parse_from([
@@ -441,27 +425,6 @@ mod tests {
                 "client_id",
                 "--height",
                 "42"
-            ])
-        )
-    }
-
-    #[test]
-    fn test_query_client_consensus_heights_only() {
-        assert_eq!(
-            QueryClientConsensusCmd {
-                chain_id: ChainId::from_string("chain_id"),
-                client_id: ClientId::from_str("client_id").unwrap(),
-                consensus_height: None,
-                heights_only: true,
-                height: None
-            },
-            QueryClientConsensusCmd::parse_from([
-                "test",
-                "--chain",
-                "chain_id",
-                "--client",
-                "client_id",
-                "--heights-only"
             ])
         )
     }

--- a/crates/relayer-cli/src/commands/query/client.rs
+++ b/crates/relayer-cli/src/commands/query/client.rs
@@ -164,7 +164,7 @@ impl Runnable for QueryClientConsensusCmd {
         } else if self.heights_only {
             let res = chain.query_consensus_state_heights(QueryConsensusStateHeightsRequest {
                 client_id: self.client_id.clone(),
-                pagination: Some(PageRequest::all()),
+                pagination: Some(PageRequest::all().reversed()),
             });
 
             match res {
@@ -174,7 +174,7 @@ impl Runnable for QueryClientConsensusCmd {
         } else {
             let res = chain.query_consensus_states(QueryConsensusStatesRequest {
                 client_id: self.client_id.clone(),
-                pagination: Some(PageRequest::all()),
+                pagination: Some(PageRequest::all().reversed()),
             });
 
             match res {

--- a/crates/relayer-cli/src/commands/query/client.rs
+++ b/crates/relayer-cli/src/commands/query/client.rs
@@ -164,7 +164,7 @@ impl Runnable for QueryClientConsensusCmd {
         } else if self.heights_only {
             let res = chain.query_consensus_state_heights(QueryConsensusStateHeightsRequest {
                 client_id: self.client_id.clone(),
-                pagination: Some(PageRequest::all().reversed()),
+                pagination: Some(PageRequest::all()),
             });
 
             match res {
@@ -174,7 +174,7 @@ impl Runnable for QueryClientConsensusCmd {
         } else {
             let res = chain.query_consensus_states(QueryConsensusStatesRequest {
                 client_id: self.client_id.clone(),
-                pagination: Some(PageRequest::all().reversed()),
+                pagination: Some(PageRequest::all()),
             });
 
             match res {

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -1121,7 +1121,7 @@ impl ChainEndpoint for CosmosSdkChain {
 
         let response = grpc_response.map_err(Error::grpc_status)?.into_inner();
 
-        let mut heights: Vec<_> = response
+        let heights: Vec<_> = response
             .consensus_state_heights
             .into_iter()
             .filter_map(|h| {
@@ -1136,9 +1136,6 @@ impl ChainEndpoint for CosmosSdkChain {
                     .ok()
             })
             .collect();
-
-        // FIXME: This should be left up to the caller, via the pagination parameter
-        heights.sort_by_key(|&h| core::cmp::Reverse(h));
 
         Ok(heights)
     }
@@ -1164,7 +1161,7 @@ impl ChainEndpoint for CosmosSdkChain {
             .map_err(Error::grpc_status)?
             .into_inner();
 
-        let mut consensus_states: Vec<_> = response
+        let consensus_states: Vec<_> = response
             .consensus_states
             .into_iter()
             .filter_map(|cs| {
@@ -1179,9 +1176,6 @@ impl ChainEndpoint for CosmosSdkChain {
                     .ok()
             })
             .collect();
-
-        // FIXME: This should be left up to the caller, via the pagination parameter
-        consensus_states.sort_by_key(|cs| core::cmp::Reverse(cs.height));
 
         Ok(consensus_states)
     }

--- a/crates/relayer/src/chain/cosmos/query.rs
+++ b/crates/relayer/src/chain/cosmos/query.rs
@@ -16,6 +16,7 @@ use crate::error::Error;
 
 pub mod account;
 pub mod balance;
+pub mod consensus_state;
 pub mod custom;
 pub mod denom_trace;
 pub mod fee;

--- a/crates/relayer/src/chain/cosmos/query/consensus_state.rs
+++ b/crates/relayer/src/chain/cosmos/query/consensus_state.rs
@@ -1,0 +1,116 @@
+use http::Uri;
+use tracing::warn;
+
+use ibc_relayer_types::{core::ics24_host::identifier::ChainId, Height};
+
+use crate::{
+    chain::requests::{QueryConsensusStateHeightsRequest, QueryConsensusStatesRequest},
+    consensus_state::AnyConsensusStateWithHeight,
+    error::Error,
+    util::pretty::{PrettyConsensusStateWithHeight, PrettyHeight},
+};
+
+pub async fn query_consensus_state_heights(
+    chain_id: &ChainId,
+    grpc_addr: &Uri,
+    request: QueryConsensusStateHeightsRequest,
+) -> Result<Vec<Height>, Error> {
+    crate::time!("query_consensus_state_heights");
+    crate::telemetry!(query, chain_id, "query_consensus_state_heights");
+
+    // Helper function to diagnose if the QueryConsensusStateHeightsRequest is unsupported
+    // by matching on the error details.
+    fn is_unsupported(status: &tonic::Status) -> bool {
+        if status.code() != tonic::Code::Unimplemented {
+            return false;
+        }
+
+        status
+            .message()
+            .contains("unknown method ConsensusStateHeights")
+    }
+
+    let mut client =
+        ibc_proto::ibc::core::client::v1::query_client::QueryClient::connect(grpc_addr.clone())
+            .await
+            .map_err(Error::grpc_transport)?;
+
+    let grpc_request = tonic::Request::new(request.clone().into());
+    let grpc_response = client.consensus_state_heights(grpc_request).await;
+
+    if let Err(ref e) = grpc_response {
+        if is_unsupported(e) {
+            warn!("QueryConsensusStateHeights is not supported by the chain, falling back on QueryConsensusStates");
+
+            let states = query_consensus_states(
+                chain_id,
+                grpc_addr,
+                QueryConsensusStatesRequest {
+                    client_id: request.client_id,
+                    pagination: request.pagination,
+                },
+            )
+            .await?;
+
+            return Ok(states.into_iter().map(|cs| cs.height).collect());
+        }
+    }
+
+    let response = grpc_response.map_err(Error::grpc_status)?.into_inner();
+
+    let heights: Vec<_> = response
+        .consensus_state_heights
+        .into_iter()
+        .filter_map(|h| {
+            Height::try_from(h.clone())
+                .map_err(|e| {
+                    warn!(
+                        "failed to parse consensus state height {}. Error: {}",
+                        PrettyHeight(&h),
+                        e
+                    )
+                })
+                .ok()
+        })
+        .collect();
+
+    Ok(heights)
+}
+
+pub async fn query_consensus_states(
+    chain_id: &ChainId,
+    grpc_addr: &Uri,
+    request: QueryConsensusStatesRequest,
+) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
+    crate::time!("query_consensus_states");
+    crate::telemetry!(query, chain_id, "query_consensus_states");
+
+    let mut client =
+        ibc_proto::ibc::core::client::v1::query_client::QueryClient::connect(grpc_addr.clone())
+            .await
+            .map_err(Error::grpc_transport)?;
+
+    let response = client
+        .consensus_states(tonic::Request::new(request.into()))
+        .await
+        .map_err(Error::grpc_status)?
+        .into_inner();
+
+    let consensus_states: Vec<_> = response
+        .consensus_states
+        .into_iter()
+        .filter_map(|cs| {
+            AnyConsensusStateWithHeight::try_from(cs.clone())
+                .map_err(|e| {
+                    warn!(
+                        "failed to parse consensus state {}. Error: {}",
+                        PrettyConsensusStateWithHeight(&cs),
+                        e
+                    )
+                })
+                .ok()
+        })
+        .collect();
+
+    Ok(consensus_states)
+}

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -36,7 +36,7 @@ use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
 use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
 use crate::error::{Error, QUERY_PROOF_EXPECT_MSG};
 use crate::event::IbcEventWithHeight;
@@ -209,12 +209,6 @@ pub trait ChainEndpoint: Sized {
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
     ) -> Result<(AnyConsensusState, Option<MerkleProof>), Error>;
-
-    /// Query all the consensus states for a given client.
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error>;
 
     /// Query the heights of every consensus state for a given client.
     fn query_consensus_state_heights(

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -203,20 +203,24 @@ pub trait ChainEndpoint: Sized {
         include_proof: IncludeProof,
     ) -> Result<(AnyClientState, Option<MerkleProof>), Error>;
 
-    /// Performs a query to retrieve the consensus state for a specified height
-    /// `consensus_height` that the specified light client stores.
+    /// Query the consensus state at the specified height for a given client.
     fn query_consensus_state(
         &self,
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
     ) -> Result<(AnyConsensusState, Option<MerkleProof>), Error>;
 
-    /// Performs a query to retrieve all the consensus states that the specified
-    /// light client stores.
+    /// Query all the consensus states for a given client.
     fn query_consensus_states(
         &self,
         request: QueryConsensusStatesRequest,
     ) -> Result<Vec<AnyConsensusStateWithHeight>, Error>;
+
+    /// Query the heights of every consensus state for a given client.
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+    ) -> Result<Vec<ICSHeight>, Error>;
 
     fn query_upgraded_client_state(
         &self,

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -223,6 +223,11 @@ pub enum ChainRequest {
         reply_to: ReplyTo<Vec<AnyConsensusStateWithHeight>>,
     },
 
+    QueryConsensusStateHeights {
+        request: QueryConsensusStateHeightsRequest,
+        reply_to: ReplyTo<Vec<Height>>,
+    },
+
     QueryUpgradedClientState {
         request: QueryUpgradedClientStateRequest,
         reply_to: ReplyTo<(AnyClientState, MerkleProof)>,
@@ -446,20 +451,24 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
         request: QueryClientConnectionsRequest,
     ) -> Result<Vec<ConnectionId>, Error>;
 
-    /// Performs a query to retrieve the consensus state for a specified height
-    /// `consensus_height` that the specified light client stores.
+    /// Query the consensus state at the specified height for a given client.
     fn query_consensus_state(
         &self,
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
     ) -> Result<(AnyConsensusState, Option<MerkleProof>), Error>;
 
-    /// Performs a query to retrieve all the consensus states that the specified
-    /// light client stores.
+    /// Query all the consensus states for a given client.
     fn query_consensus_states(
         &self,
         request: QueryConsensusStatesRequest,
     ) -> Result<Vec<AnyConsensusStateWithHeight>, Error>;
+
+    /// Query the heights of every consensus state for a given client.
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+    ) -> Result<Vec<Height>, Error>;
 
     fn query_upgraded_client_state(
         &self,

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -29,7 +29,7 @@ use crate::{
     client_state::{AnyClientState, IdentifiedAnyClientState},
     config::ChainConfig,
     connection::ConnectionMsgType,
-    consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight},
+    consensus_state::AnyConsensusState,
     denom::DenomTrace,
     error::Error,
     event::{
@@ -216,11 +216,6 @@ pub enum ChainRequest {
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
         reply_to: ReplyTo<(AnyConsensusState, Option<MerkleProof>)>,
-    },
-
-    QueryConsensusStates {
-        request: QueryConsensusStatesRequest,
-        reply_to: ReplyTo<Vec<AnyConsensusStateWithHeight>>,
     },
 
     QueryConsensusStateHeights {
@@ -457,12 +452,6 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
     ) -> Result<(AnyConsensusState, Option<MerkleProof>), Error>;
-
-    /// Query all the consensus states for a given client.
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error>;
 
     /// Query the heights of every consensus state for a given client.
     fn query_consensus_state_heights(

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -27,7 +27,7 @@ use crate::{
     client_state::{AnyClientState, IdentifiedAnyClientState},
     config::ChainConfig,
     connection::ConnectionMsgType,
-    consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight},
+    consensus_state::AnyConsensusState,
     denom::DenomTrace,
     error::Error,
     event::IbcEventWithHeight,
@@ -201,13 +201,6 @@ impl ChainHandle for BaseChainHandle {
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.send(|reply_to| ChainRequest::QueryConsensusStateHeights { request, reply_to })
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.send(|reply_to| ChainRequest::QueryConsensusStates { request, reply_to })
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -196,6 +196,13 @@ impl ChainHandle for BaseChainHandle {
         self.send(|reply_to| ChainRequest::QueryClientConnections { request, reply_to })
     }
 
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+    ) -> Result<Vec<Height>, Error> {
+        self.send(|reply_to| ChainRequest::QueryConsensusStateHeights { request, reply_to })
+    }
+
     fn query_consensus_states(
         &self,
         request: QueryConsensusStatesRequest,

--- a/crates/relayer/src/chain/handle/cache.rs
+++ b/crates/relayer/src/chain/handle/cache.rs
@@ -2,24 +2,22 @@ use core::fmt::{Display, Error as FmtError, Formatter};
 use crossbeam_channel as channel;
 use tracing::Span;
 
+use ibc_relayer_types::applications::ics31_icq::response::CrossChainQueryResponse;
 use ibc_relayer_types::core::ics02_client::events::UpdateClient;
+use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
 use ibc_relayer_types::core::ics03_connection::connection::IdentifiedConnectionEnd;
+use ibc_relayer_types::core::ics03_connection::version::Version;
+use ibc_relayer_types::core::ics04_channel::channel::ChannelEnd;
 use ibc_relayer_types::core::ics04_channel::channel::IdentifiedChannelEnd;
 use ibc_relayer_types::core::ics04_channel::packet::{PacketMsgType, Sequence};
+use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc_relayer_types::core::ics23_commitment::merkle::MerkleProof;
-use ibc_relayer_types::{
-    applications::ics31_icq::response::CrossChainQueryResponse,
-    core::ics03_connection::connection::ConnectionEnd,
-    core::ics03_connection::version::Version,
-    core::ics04_channel::channel::ChannelEnd,
-    core::ics23_commitment::commitment::CommitmentPrefix,
-    core::ics24_host::identifier::{
-        ChainId, ChannelId, ClientId, ConnectionId, PortChannelId, PortId,
-    },
-    proofs::Proofs,
-    signer::Signer,
-    Height,
+use ibc_relayer_types::core::ics24_host::identifier::{
+    ChainId, ChannelId, ClientId, ConnectionId, PortChannelId, PortId,
 };
+use ibc_relayer_types::proofs::Proofs;
+use ibc_relayer_types::signer::Signer;
+use ibc_relayer_types::Height;
 
 use crate::account::Balance;
 use crate::cache::{Cache, CacheStatus};
@@ -203,6 +201,13 @@ impl<Handle: ChainHandle> ChainHandle for CachingChainHandle<Handle> {
         request: QueryClientConnectionsRequest,
     ) -> Result<Vec<ConnectionId>, Error> {
         self.inner().query_client_connections(request)
+    }
+
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+    ) -> Result<Vec<Height>, Error> {
+        self.inner().query_consensus_state_heights(request)
     }
 
     fn query_consensus_states(

--- a/crates/relayer/src/chain/handle/cache.rs
+++ b/crates/relayer/src/chain/handle/cache.rs
@@ -29,7 +29,7 @@ use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
 use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
 use crate::error::Error;
 use crate::event::IbcEventWithHeight;
@@ -208,13 +208,6 @@ impl<Handle: ChainHandle> ChainHandle for CachingChainHandle<Handle> {
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.inner().query_consensus_state_heights(request)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.inner().query_consensus_states(request)
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/chain/handle/counting.rs
+++ b/crates/relayer/src/chain/handle/counting.rs
@@ -31,7 +31,7 @@ use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
 use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
 use crate::error::Error;
 use crate::event::IbcEventWithHeight;
@@ -214,14 +214,6 @@ impl<Handle: ChainHandle> ChainHandle for CountingChainHandle<Handle> {
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.inner().query_consensus_state_heights(request)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.inc_metric("query_consensus_states");
-        self.inner().query_consensus_states(request)
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/chain/handle/counting.rs
+++ b/crates/relayer/src/chain/handle/counting.rs
@@ -5,6 +5,23 @@ use std::sync::{Arc, RwLock, RwLockReadGuard};
 use crossbeam_channel as channel;
 use tracing::{debug, Span};
 
+use ibc_relayer_types::applications::ics31_icq::response::CrossChainQueryResponse;
+use ibc_relayer_types::core::ics02_client::events::UpdateClient;
+use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
+use ibc_relayer_types::core::ics03_connection::connection::IdentifiedConnectionEnd;
+use ibc_relayer_types::core::ics03_connection::version::Version;
+use ibc_relayer_types::core::ics04_channel::channel::ChannelEnd;
+use ibc_relayer_types::core::ics04_channel::channel::IdentifiedChannelEnd;
+use ibc_relayer_types::core::ics04_channel::packet::{PacketMsgType, Sequence};
+use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
+use ibc_relayer_types::core::ics23_commitment::merkle::MerkleProof;
+use ibc_relayer_types::core::ics24_host::identifier::{
+    ChainId, ChannelId, ClientId, ConnectionId, PortId,
+};
+use ibc_relayer_types::proofs::Proofs;
+use ibc_relayer_types::signer::Signer;
+use ibc_relayer_types::Height;
+
 use crate::account::Balance;
 use crate::chain::client::ClientSettings;
 use crate::chain::endpoint::{ChainStatus, HealthCheck};
@@ -22,22 +39,6 @@ use crate::keyring::AnySigningKeyPair;
 use crate::light_client::AnyHeader;
 use crate::misbehaviour::MisbehaviourEvidence;
 use crate::util::lock::LockExt;
-use ibc_relayer_types::core::ics02_client::events::UpdateClient;
-use ibc_relayer_types::core::ics03_connection::connection::IdentifiedConnectionEnd;
-use ibc_relayer_types::core::ics04_channel::channel::IdentifiedChannelEnd;
-use ibc_relayer_types::core::ics04_channel::packet::{PacketMsgType, Sequence};
-use ibc_relayer_types::core::ics23_commitment::merkle::MerkleProof;
-use ibc_relayer_types::{
-    applications::ics31_icq::response::CrossChainQueryResponse,
-    core::ics03_connection::connection::ConnectionEnd,
-    core::ics03_connection::version::Version,
-    core::ics04_channel::channel::ChannelEnd,
-    core::ics23_commitment::commitment::CommitmentPrefix,
-    core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId},
-    proofs::Proofs,
-    signer::Signer,
-    Height,
-};
 
 #[derive(Debug, Clone)]
 pub struct CountingChainHandle<Handle> {
@@ -206,6 +207,13 @@ impl<Handle: ChainHandle> ChainHandle for CountingChainHandle<Handle> {
     ) -> Result<Vec<ConnectionId>, Error> {
         self.inc_metric("query_client_connections");
         self.inner().query_client_connections(request)
+    }
+
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+    ) -> Result<Vec<Height>, Error> {
+        self.inner().query_consensus_state_heights(request)
     }
 
     fn query_consensus_states(

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -115,11 +115,6 @@ impl PageRequest {
             ..Default::default()
         }
     }
-
-    pub fn reversed(mut self) -> Self {
-        self.reverse = true;
-        self
-    }
 }
 
 impl From<PageRequest> for RawPageRequest {

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -15,6 +15,7 @@ use ibc_proto::ibc::core::channel::v1::{
 };
 use ibc_proto::ibc::core::client::v1::{
     QueryClientStatesRequest as RawQueryClientStatesRequest,
+    QueryConsensusStateHeightsRequest as RawQueryConsensusStateHeightsRequest,
     QueryConsensusStatesRequest as RawQueryConsensusStatesRequest,
 };
 use ibc_proto::ibc::core::connection::v1::{
@@ -108,11 +109,16 @@ pub struct PageRequest {
 }
 
 impl PageRequest {
-    pub fn all() -> PageRequest {
+    pub fn all() -> Self {
         PageRequest {
             limit: u64::MAX,
             ..Default::default()
         }
+    }
+
+    pub fn reversed(mut self) -> Self {
+        self.reverse = true;
+        self
     }
 }
 
@@ -175,6 +181,21 @@ pub struct QueryConsensusStatesRequest {
 impl From<QueryConsensusStatesRequest> for RawQueryConsensusStatesRequest {
     fn from(request: QueryConsensusStatesRequest) -> Self {
         RawQueryConsensusStatesRequest {
+            client_id: request.client_id.to_string(),
+            pagination: request.pagination.map(|pagination| pagination.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryConsensusStateHeightsRequest {
+    pub client_id: ClientId,
+    pub pagination: Option<PageRequest>,
+}
+
+impl From<QueryConsensusStateHeightsRequest> for RawQueryConsensusStateHeightsRequest {
+    fn from(request: QueryConsensusStateHeightsRequest) -> Self {
+        RawQueryConsensusStateHeightsRequest {
             client_id: request.client_id.to_string(),
             pagination: request.pagination.map(|pagination| pagination.into()),
         }

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -110,8 +110,11 @@ pub struct PageRequest {
 
 impl PageRequest {
     pub fn all() -> Self {
+        // Note: do not use u64::MAX as the limit, as it may have unintended consequences
+        // See https://github.com/informalsystems/hermes/pull/2950#issuecomment-1373733744
+
         PageRequest {
-            limit: u64::MAX,
+            limit: u32::MAX as u64,
             ..Default::default()
         }
     }

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -239,6 +239,10 @@ where
                             self.query_client_state(request, include_proof, reply_to)?
                         },
 
+                        ChainRequest::QueryConsensusStateHeights { request, reply_to } => {
+                            self.query_consensus_state_heights(request, reply_to)?
+                        },
+
                         ChainRequest::QueryConsensusStates { request, reply_to } => {
                             self.query_consensus_states(request, reply_to)?
                         },
@@ -562,6 +566,15 @@ where
         let result = self.chain.query_upgraded_client_state(request);
 
         reply_to.send(result).map_err(Error::send)
+    }
+
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+        reply_to: ReplyTo<Vec<Height>>,
+    ) -> Result<(), Error> {
+        let heights = self.chain.query_consensus_state_heights(request);
+        reply_to.send(heights).map_err(Error::send)
     }
 
     fn query_consensus_states(

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -31,7 +31,7 @@ use crate::{
     client_state::{AnyClientState, IdentifiedAnyClientState},
     config::ChainConfig,
     connection::ConnectionMsgType,
-    consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight},
+    consensus_state::AnyConsensusState,
     denom::DenomTrace,
     error::Error,
     event::IbcEventWithHeight,
@@ -241,10 +241,6 @@ where
 
                         ChainRequest::QueryConsensusStateHeights { request, reply_to } => {
                             self.query_consensus_state_heights(request, reply_to)?
-                        },
-
-                        ChainRequest::QueryConsensusStates { request, reply_to } => {
-                            self.query_consensus_states(request, reply_to)?
                         },
 
                         ChainRequest::QueryConsensusState { request, include_proof, reply_to } => {
@@ -575,15 +571,6 @@ where
     ) -> Result<(), Error> {
         let heights = self.chain.query_consensus_state_heights(request);
         reply_to.send(heights).map_err(Error::send)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-        reply_to: ReplyTo<Vec<AnyConsensusStateWithHeight>>,
-    ) -> Result<(), Error> {
-        let consensus_states = self.chain.query_consensus_states(request);
-        reply_to.send(consensus_states).map_err(Error::send)
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/foreign_client.rs
+++ b/crates/relayer/src/foreign_client.rs
@@ -1355,7 +1355,14 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
                 ForeignClientError::client_query(self.id().clone(), self.src_chain.id(), e)
             })?;
 
-        // This is necessary because specifiying `.reversed()` on `PageRequest` results in a empty response.
+        // This is necessary because the results are sorted in lexicographic order instead of
+        // numeric order, and we cannot therefore rely on setting the `reverse = true` in the
+        // `PageRequest` setting. Since we are asking for all states anyway, we can sort them
+        // by height ourselves.
+        //
+        // For more context, see:
+        // - https://github.com/informalsystems/hermes/pull/2950#issuecomment-1373733744
+        // - https://github.com/cosmos/ibc-go/issues/1399
         consensus_states.sort_by_key(|a| core::cmp::Reverse(a.height));
 
         Ok(consensus_states)
@@ -1412,7 +1419,14 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
                 ForeignClientError::client_query(self.id().clone(), self.src_chain.id(), e)
             })?;
 
-        // This is necessary because specifiying `.reversed()` on `PageRequest` results in a empty response.
+        // This is necessary because the results are sorted in lexicographic order instead of
+        // numeric order, and we cannot therefore rely on setting the `reverse = true` in the
+        // `PageRequest` setting. Since we are asking for all heights anyway, we can sort them
+        // ourselves.
+        //
+        // For more context, see:
+        // - https://github.com/informalsystems/hermes/pull/2950#issuecomment-1373733744
+        // - https://github.com/cosmos/ibc-go/issues/1399
         heights.sort_by_key(|&h| core::cmp::Reverse(h));
 
         Ok(heights)

--- a/crates/relayer/src/foreign_client.rs
+++ b/crates/relayer/src/foreign_client.rs
@@ -34,7 +34,7 @@ use crate::chain::handle::ChainHandle;
 use crate::chain::requests::*;
 use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::AnyClientState;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::error::Error as RelayerError;
 use crate::event::IbcEventWithHeight;
 use crate::light_client::AnyHeader;

--- a/crates/relayer/src/foreign_client.rs
+++ b/crates/relayer/src/foreign_client.rs
@@ -1333,41 +1333,6 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
         Ok(Some(update))
     }
 
-    /// Retrieves all consensus states for this client and sorts them in descending height
-    /// order. If consensus states are not pruned on chain, then last consensus state is the one
-    /// installed by the `CreateClient` operation.
-    #[instrument(
-        name = "foreign_client.fetch_consensus_states",
-        level = "error",
-        skip_all,
-        fields(client = %self)
-    )]
-    fn fetch_consensus_states(
-        &self,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, ForeignClientError> {
-        let mut consensus_states = self
-            .dst_chain
-            .query_consensus_states(QueryConsensusStatesRequest {
-                client_id: self.id.clone(),
-                pagination: Some(PageRequest::all()),
-            })
-            .map_err(|e| {
-                ForeignClientError::client_query(self.id().clone(), self.src_chain.id(), e)
-            })?;
-
-        // This is necessary because the results are sorted in lexicographic order instead of
-        // numeric order, and we cannot therefore rely on setting the `reverse = true` in the
-        // `PageRequest` setting. Since we are asking for all states anyway, we can sort them
-        // by height ourselves.
-        //
-        // For more context, see:
-        // - https://github.com/informalsystems/hermes/pull/2950#issuecomment-1373733744
-        // - https://github.com/cosmos/ibc-go/issues/1399
-        consensus_states.sort_by_key(|a| core::cmp::Reverse(a.height));
-
-        Ok(consensus_states)
-    }
-
     /// Returns the consensus state at `height` or error if not found.
     #[instrument(
         name = "foreign_client.fetch_consensus_state",

--- a/crates/relayer/src/foreign_client.rs
+++ b/crates/relayer/src/foreign_client.rs
@@ -1349,13 +1349,13 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
             .dst_chain
             .query_consensus_states(QueryConsensusStatesRequest {
                 client_id: self.id.clone(),
-                pagination: Some(PageRequest::all().reversed()),
+                pagination: Some(PageRequest::all()),
             })
             .map_err(|e| {
                 ForeignClientError::client_query(self.id().clone(), self.src_chain.id(), e)
             })?;
 
-        // TODO: Check that this is unnecessary
+        // This is necessary because specifiying `.reversed()` on `PageRequest` results in a empty response.
         consensus_states.sort_by_key(|a| core::cmp::Reverse(a.height));
 
         Ok(consensus_states)
@@ -1406,13 +1406,13 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
             .dst_chain
             .query_consensus_state_heights(QueryConsensusStateHeightsRequest {
                 client_id: self.id.clone(),
-                pagination: Some(PageRequest::all().reversed()),
+                pagination: Some(PageRequest::all()),
             })
             .map_err(|e| {
                 ForeignClientError::client_query(self.id().clone(), self.src_chain.id(), e)
             })?;
 
-        // TODO: Check that this is unnecessary
+        // This is necessary because specifiying `.reversed()` on `PageRequest` results in a empty response.
         heights.sort_by_key(|&h| core::cmp::Reverse(h));
 
         Ok(heights)

--- a/docs/architecture/adr-010-unified-cli-arguments-hermes.md
+++ b/docs/architecture/adr-010-unified-cli-arguments-hermes.md
@@ -101,7 +101,7 @@ __Client__
     * Optional: `[--height <HEIGHT>]`
 
 * `query client consensus --chain <CHAIN_ID> --client <CLIENT_ID>`
-    * Optional: `[--consensus-height <CONSENSUS_HEIGHT>] [--height <HEIGHT>] [--heights-only]`
+    * Optional: `[--consensus-height <CONSENSUS_HEIGHT>] [--height <HEIGHT>]`
 
 * `query client header --chain <CHAIN_ID> --client <CLIENT_ID> --consensus-height <CONSENSUS_HEIGHT>`
     * Optional: `[--height <HEIGHT>]`

--- a/guide/src/documentation/commands/queries/client.md
+++ b/guide/src/documentation/commands/queries/client.md
@@ -124,7 +124,7 @@ __Example__
 Query the states of client `07-tendermint-0` on `ibc-0`:
 
 ```shell
-{{#template ../../../templates/commands/hermes/query/client/consensus_1.md CHAIN_ID=ibc-0 CLIENT_ID=07-tendermint-0 OPTIONS= --heights-only}}
+{{#template ../../../templates/commands/hermes/query/client/consensus_1.md CHAIN_ID=ibc-0 CLIENT_ID=07-tendermint-0}}
 ```
 
 ```json

--- a/guide/src/templates/help_templates/query/client/consensus.md
+++ b/guide/src/templates/help_templates/query/client/consensus.md
@@ -14,9 +14,6 @@ OPTIONS:
         --height <HEIGHT>
             The chain height context to be used, applicable only to a specific height
 
-        --heights-only
-            Show only consensus heights
-
 REQUIRED:
         --chain <CHAIN_ID>      Identifier of the chain to query
         --client <CLIENT_ID>    Identifier of the client to query

--- a/tools/integration-test/src/tests/consensus_states.rs
+++ b/tools/integration-test/src/tests/consensus_states.rs
@@ -1,0 +1,68 @@
+use std::time::Duration;
+
+use ibc_relayer::chain::requests::{
+    PageRequest, QueryConsensusStateHeightsRequest, QueryConsensusStatesRequest,
+};
+
+use ibc_test_framework::prelude::*;
+
+#[test]
+fn test_consensus_state_heights() -> Result<(), Error> {
+    run_binary_chain_test(&ConsensusStateHeights)
+}
+
+struct ConsensusStateHeights;
+
+impl TestOverrides for ConsensusStateHeights {}
+
+impl BinaryChainTest for ConsensusStateHeights {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        _relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        const UPDATES_COUNT: usize = 4;
+        const CONSENSUS_STATES_COUNT: usize = UPDATES_COUNT + 1;
+
+        let client = &chains.foreign_clients.client_a_to_b;
+
+        for i in 1..=UPDATES_COUNT {
+            eprintln!("updating client ({i}/{UPDATES_COUNT})...");
+
+            client.update().map_err(Error::foreign_client)?;
+
+            if i != UPDATES_COUNT {
+                std::thread::sleep(Duration::from_secs(5));
+            }
+        }
+
+        let states = chains
+            .handle_b()
+            .query_consensus_states(QueryConsensusStatesRequest {
+                client_id: (*chains.client_id_b().value()).clone(),
+                pagination: Some(PageRequest::all()),
+            })?;
+
+        assert_eq!(states.len(), CONSENSUS_STATES_COUNT);
+
+        let heights =
+            chains
+                .handle_b()
+                .query_consensus_state_heights(QueryConsensusStateHeightsRequest {
+                    client_id: (*chains.client_id_b().value()).clone(),
+                    pagination: Some(PageRequest::all()),
+                })?;
+
+        assert_eq!(heights.len(), CONSENSUS_STATES_COUNT);
+
+        states
+            .into_iter()
+            .zip(heights.into_iter())
+            .for_each(|(state, height)| {
+                assert_eq!(state.height, height);
+            });
+
+        Ok(())
+    }
+}

--- a/tools/integration-test/src/tests/consensus_states.rs
+++ b/tools/integration-test/src/tests/consensus_states.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
-use ibc_relayer::chain::requests::{
-    PageRequest, QueryConsensusStateHeightsRequest, QueryConsensusStatesRequest,
+use ibc_relayer::chain::{
+    cosmos::query::consensus_state::query_consensus_states,
+    requests::{PageRequest, QueryConsensusStateHeightsRequest, QueryConsensusStatesRequest},
 };
 
 use ibc_test_framework::prelude::*;
@@ -28,23 +29,12 @@ impl BinaryChainTest for ConsensusStateHeights {
         let client = &chains.foreign_clients.client_a_to_b;
 
         for i in 1..=UPDATES_COUNT {
-            eprintln!("updating client ({i}/{UPDATES_COUNT})...");
-
             client.update().map_err(Error::foreign_client)?;
 
             if i != UPDATES_COUNT {
                 std::thread::sleep(Duration::from_secs(5));
             }
         }
-
-        let states = chains
-            .handle_b()
-            .query_consensus_states(QueryConsensusStatesRequest {
-                client_id: (*chains.client_id_b().value()).clone(),
-                pagination: Some(PageRequest::all()),
-            })?;
-
-        assert_eq!(states.len(), CONSENSUS_STATES_COUNT);
 
         let heights =
             chains
@@ -54,14 +44,52 @@ impl BinaryChainTest for ConsensusStateHeights {
                     pagination: Some(PageRequest::all()),
                 })?;
 
-        assert_eq!(heights.len(), CONSENSUS_STATES_COUNT);
+        assert_eq(
+            "did not find the expected amount of consensus state heights",
+            &heights.len(),
+            &CONSENSUS_STATES_COUNT,
+        )?;
+
+        let grpc_address = chains
+            .node_b
+            .value()
+            .chain_driver
+            .grpc_address()
+            .as_str()
+            .parse()
+            .unwrap();
+
+        let states =
+            chains
+                .node_b
+                .value()
+                .chain_driver
+                .runtime
+                .block_on(query_consensus_states(
+                    chains.node_b.chain_id().value(),
+                    &grpc_address,
+                    QueryConsensusStatesRequest {
+                        client_id: (*chains.client_id_b().value()).clone(),
+                        pagination: Some(PageRequest::all()),
+                    },
+                ))?;
+
+        assert_eq(
+            "did not find the expected number of consensus states",
+            &states.len(),
+            &CONSENSUS_STATES_COUNT,
+        )?;
 
         states
             .into_iter()
             .zip(heights.into_iter())
-            .for_each(|(state, height)| {
-                assert_eq!(state.height, height);
-            });
+            .try_for_each(|(state, height)| {
+                assert_eq(
+                    "did not find matching height for each consensus state",
+                    &state.height,
+                    &height,
+                )
+            })?;
 
         Ok(())
     }

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -12,6 +12,7 @@ pub mod client_refresh;
 pub mod client_settings;
 pub mod client_upgrade;
 pub mod connection_delay;
+pub mod consensus_states;
 pub mod denom_trace;
 pub mod error_events;
 pub mod execute_schedule;

--- a/tools/test-framework/src/error.rs
+++ b/tools/test-framework/src/error.rs
@@ -1,15 +1,19 @@
 //! Error type used for the tests.
 
 use core::convert::{From, Into};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+
 use eyre::Report;
 use flex_error::{define_error, TraceError};
+
+use ibc_relayer::channel::error::ChannelError;
 use ibc_relayer::connection::ConnectionError;
 use ibc_relayer::error::Error as RelayerError;
+use ibc_relayer::foreign_client::ForeignClientError;
 use ibc_relayer::link::error::LinkError;
 use ibc_relayer::supervisor::error::Error as SupervisorError;
 use ibc_relayer::transfer::TransferError;
-use ibc_relayer::{channel::error::ChannelError, upgrade_chain::UpgradeChainError};
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use ibc_relayer::upgrade_chain::UpgradeChainError;
 
 define_error! {
     Error {
@@ -70,6 +74,10 @@ define_error! {
         UpgradeChain
             [ UpgradeChainError ]
             | _ | { "upgrade chain error" },
+
+        ForeignClient
+            [ ForeignClientError ]
+            | _ | { "foreign client error" },
 
         QueryClient
             | _ | { "error querying client" },

--- a/tools/test-framework/src/relayer/chain.rs
+++ b/tools/test-framework/src/relayer/chain.rs
@@ -32,7 +32,7 @@ use ibc_relayer::chain::tracking::TrackedMsgs;
 use ibc_relayer::client_state::{AnyClientState, IdentifiedAnyClientState};
 use ibc_relayer::config::ChainConfig;
 use ibc_relayer::connection::ConnectionMsgType;
-use ibc_relayer::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use ibc_relayer::consensus_state::AnyConsensusState;
 use ibc_relayer::denom::DenomTrace;
 use ibc_relayer::error::Error;
 use ibc_relayer::event::IbcEventWithHeight;
@@ -157,13 +157,6 @@ where
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.value().query_consensus_state_heights(request)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.value().query_consensus_states(request)
     }
 
     fn query_consensus_state(

--- a/tools/test-framework/src/relayer/chain.rs
+++ b/tools/test-framework/src/relayer/chain.rs
@@ -27,18 +27,7 @@ use ibc_relayer::account::Balance;
 use ibc_relayer::chain::client::ClientSettings;
 use ibc_relayer::chain::endpoint::{ChainStatus, HealthCheck};
 use ibc_relayer::chain::handle::{ChainHandle, ChainRequest, Subscription};
-use ibc_relayer::chain::requests::{
-    CrossChainQueryRequest, IncludeProof, QueryChannelClientStateRequest, QueryChannelRequest,
-    QueryChannelsRequest, QueryClientConnectionsRequest, QueryClientStateRequest,
-    QueryClientStatesRequest, QueryConnectionChannelsRequest, QueryConnectionRequest,
-    QueryConnectionsRequest, QueryConsensusStateRequest, QueryConsensusStatesRequest,
-    QueryHostConsensusStateRequest, QueryNextSequenceReceiveRequest,
-    QueryPacketAcknowledgementRequest, QueryPacketAcknowledgementsRequest,
-    QueryPacketCommitmentRequest, QueryPacketCommitmentsRequest, QueryPacketEventDataRequest,
-    QueryPacketReceiptRequest, QueryTxRequest, QueryUnreceivedAcksRequest,
-    QueryUnreceivedPacketsRequest, QueryUpgradedClientStateRequest,
-    QueryUpgradedConsensusStateRequest,
-};
+use ibc_relayer::chain::requests::*;
 use ibc_relayer::chain::tracking::TrackedMsgs;
 use ibc_relayer::client_state::{AnyClientState, IdentifiedAnyClientState};
 use ibc_relayer::config::ChainConfig;
@@ -52,22 +41,20 @@ use ibc_relayer::light_client::AnyHeader;
 use ibc_relayer::misbehaviour::MisbehaviourEvidence;
 use ibc_relayer_types::applications::ics31_icq::response::CrossChainQueryResponse;
 use ibc_relayer_types::core::ics02_client::events::UpdateClient;
+use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
 use ibc_relayer_types::core::ics03_connection::connection::IdentifiedConnectionEnd;
+use ibc_relayer_types::core::ics03_connection::version::Version;
+use ibc_relayer_types::core::ics04_channel::channel::ChannelEnd;
 use ibc_relayer_types::core::ics04_channel::channel::IdentifiedChannelEnd;
 use ibc_relayer_types::core::ics04_channel::packet::{PacketMsgType, Sequence};
+use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc_relayer_types::core::ics23_commitment::merkle::MerkleProof;
-use ibc_relayer_types::{
-    core::ics03_connection::connection::ConnectionEnd,
-    core::ics03_connection::version::Version,
-    core::ics04_channel::channel::ChannelEnd,
-    core::ics23_commitment::commitment::CommitmentPrefix,
-    core::ics24_host::identifier::ChainId,
-    core::ics24_host::identifier::ChannelId,
-    core::ics24_host::identifier::{ClientId, ConnectionId, PortId},
-    proofs::Proofs,
-    signer::Signer,
-    Height,
-};
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
+use ibc_relayer_types::core::ics24_host::identifier::ChannelId;
+use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId, PortId};
+use ibc_relayer_types::proofs::Proofs;
+use ibc_relayer_types::signer::Signer;
+use ibc_relayer_types::Height;
 
 use crate::types::tagged::*;
 
@@ -163,6 +150,13 @@ where
         request: QueryClientConnectionsRequest,
     ) -> Result<Vec<ConnectionId>, Error> {
         self.value().query_client_connections(request)
+    }
+
+    fn query_consensus_state_heights(
+        &self,
+        request: QueryConsensusStateHeightsRequest,
+    ) -> Result<Vec<Height>, Error> {
+        self.value().query_consensus_state_heights(request)
     }
 
     fn query_consensus_states(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2001

## Description

Fetch consensus state heights using the more efficient `QueryConsensusStateHeights` gRPC query instead of fetching all the consensus states themselves using `QueryConsensusStates` and extracting the heights from the result.

## TODO

- [x] Remove the sorting of the results in a few places (indicated with `TODO`s in the code)
- [x] Do we need deal with the case where `QueryConsensusStateHeights` is unsupported, and fallback on `QueryConsensusStates`?

## Note

This request is available in the following IBC-Go versions:
- `>=` [v3.1.0](https://github.com/cosmos/ibc-go/releases/tag/v3.1.0)
- `>=` [v2.3.0](https://github.com/cosmos/ibc-go/releases/tag/v2.3.0)
- `>=` [v1.5.0](https://github.com/cosmos/ibc-go/releases/tag/v1.5.0)

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
