### PR TITLE
Remove `query_consensus_states` from the `ChainEndpoint` trait

### DIFF
--- a/.changelog/unreleased/breaking-changes/ibc-relayer/2001-consensus-state-heights.md
+++ b/.changelog/unreleased/breaking-changes/ibc-relayer/2001-consensus-state-heights.md
@@ -1,0 +1,4 @@
+- Remove `query_consensus_states` from the `ChainEndpoint` trait
+  ([#2001](https://github.com/informalsystems/hermes/issues/2001))
+- The `query consensus state` command now only list heights and its `--heights-only` option was removed
+  ([#2001](https://github.com/informalsystems/hermes/issues/2001))

--- a/crates/relayer-cli/src/commands/query/client.rs
+++ b/crates/relayer-cli/src/commands/query/client.rs
@@ -5,7 +5,7 @@ use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::chain::requests::{
     IncludeProof, PageRequest, QueryClientConnectionsRequest, QueryClientEventRequest,
     QueryClientStateRequest, QueryConsensusStateHeightsRequest, QueryConsensusStateRequest,
-    QueryConsensusStatesRequest, QueryHeight, QueryTxRequest,
+    QueryHeight, QueryTxRequest,
 };
 
 use ibc_relayer_types::core::ics02_client::client_state::ClientState;
@@ -102,9 +102,6 @@ pub struct QueryClientConsensusCmd {
     )]
     consensus_height: Option<u64>,
 
-    #[clap(long = "heights-only", help = "Show only consensus heights")]
-    heights_only: bool,
-
     #[clap(
         long = "height",
         value_name = "HEIGHT",
@@ -161,7 +158,7 @@ impl Runnable for QueryClientConsensusCmd {
                 Ok(cs) => Output::success(cs).exit(),
                 Err(e) => Output::error(e).exit(),
             }
-        } else if self.heights_only {
+        } else {
             let res = chain.query_consensus_state_heights(QueryConsensusStateHeightsRequest {
                 client_id: self.client_id.clone(),
                 pagination: Some(PageRequest::all()),
@@ -169,16 +166,6 @@ impl Runnable for QueryClientConsensusCmd {
 
             match res {
                 Ok(heights) => Output::success(heights).exit(),
-                Err(e) => Output::error(e).exit(),
-            }
-        } else {
-            let res = chain.query_consensus_states(QueryConsensusStatesRequest {
-                client_id: self.client_id.clone(),
-                pagination: Some(PageRequest::all()),
-            });
-
-            match res {
-                Ok(states) => Output::success(states).exit(),
                 Err(e) => Output::error(e).exit(),
             }
         }
@@ -388,7 +375,6 @@ mod tests {
                 chain_id: ChainId::from_string("chain_id"),
                 client_id: ClientId::from_str("client_id").unwrap(),
                 consensus_height: None,
-                heights_only: false,
                 height: None
             },
             QueryClientConsensusCmd::parse_from([
@@ -408,7 +394,6 @@ mod tests {
                 chain_id: ChainId::from_string("chain_id"),
                 client_id: ClientId::from_str("client_id").unwrap(),
                 consensus_height: Some(42),
-                heights_only: false,
                 height: None
             },
             QueryClientConsensusCmd::parse_from([
@@ -430,7 +415,6 @@ mod tests {
                 chain_id: ChainId::from_string("chain_id"),
                 client_id: ClientId::from_str("client_id").unwrap(),
                 consensus_height: None,
-                heights_only: false,
                 height: Some(42)
             },
             QueryClientConsensusCmd::parse_from([
@@ -441,27 +425,6 @@ mod tests {
                 "client_id",
                 "--height",
                 "42"
-            ])
-        )
-    }
-
-    #[test]
-    fn test_query_client_consensus_heights_only() {
-        assert_eq!(
-            QueryClientConsensusCmd {
-                chain_id: ChainId::from_string("chain_id"),
-                client_id: ClientId::from_str("client_id").unwrap(),
-                consensus_height: None,
-                heights_only: true,
-                height: None
-            },
-            QueryClientConsensusCmd::parse_from([
-                "test",
-                "--chain",
-                "chain_id",
-                "--client",
-                "client_id",
-                "--heights-only"
             ])
         )
     }

--- a/crates/relayer/src/chain/cosmos/query.rs
+++ b/crates/relayer/src/chain/cosmos/query.rs
@@ -16,6 +16,7 @@ use crate::error::Error;
 
 pub mod account;
 pub mod balance;
+pub mod consensus_state;
 pub mod custom;
 pub mod denom_trace;
 pub mod fee;

--- a/crates/relayer/src/chain/cosmos/query/consensus_state.rs
+++ b/crates/relayer/src/chain/cosmos/query/consensus_state.rs
@@ -1,0 +1,116 @@
+use http::Uri;
+use tracing::warn;
+
+use ibc_relayer_types::{core::ics24_host::identifier::ChainId, Height};
+
+use crate::{
+    chain::requests::{QueryConsensusStateHeightsRequest, QueryConsensusStatesRequest},
+    consensus_state::AnyConsensusStateWithHeight,
+    error::Error,
+    util::pretty::{PrettyConsensusStateWithHeight, PrettyHeight},
+};
+
+pub async fn query_consensus_state_heights(
+    chain_id: &ChainId,
+    grpc_addr: &Uri,
+    request: QueryConsensusStateHeightsRequest,
+) -> Result<Vec<Height>, Error> {
+    crate::time!("query_consensus_state_heights");
+    crate::telemetry!(query, chain_id, "query_consensus_state_heights");
+
+    // Helper function to diagnose if the QueryConsensusStateHeightsRequest is unsupported
+    // by matching on the error details.
+    fn is_unsupported(status: &tonic::Status) -> bool {
+        if status.code() != tonic::Code::Unimplemented {
+            return false;
+        }
+
+        status
+            .message()
+            .contains("unknown method ConsensusStateHeights")
+    }
+
+    let mut client =
+        ibc_proto::ibc::core::client::v1::query_client::QueryClient::connect(grpc_addr.clone())
+            .await
+            .map_err(Error::grpc_transport)?;
+
+    let grpc_request = tonic::Request::new(request.clone().into());
+    let grpc_response = client.consensus_state_heights(grpc_request).await;
+
+    if let Err(ref e) = grpc_response {
+        if is_unsupported(e) {
+            warn!("QueryConsensusStateHeights is not supported by the chain, falling back on QueryConsensusStates");
+
+            let states = query_consensus_states(
+                chain_id,
+                grpc_addr,
+                QueryConsensusStatesRequest {
+                    client_id: request.client_id,
+                    pagination: request.pagination,
+                },
+            )
+            .await?;
+
+            return Ok(states.into_iter().map(|cs| cs.height).collect());
+        }
+    }
+
+    let response = grpc_response.map_err(Error::grpc_status)?.into_inner();
+
+    let heights: Vec<_> = response
+        .consensus_state_heights
+        .into_iter()
+        .filter_map(|h| {
+            Height::try_from(h.clone())
+                .map_err(|e| {
+                    warn!(
+                        "failed to parse consensus state height {}. Error: {}",
+                        PrettyHeight(&h),
+                        e
+                    )
+                })
+                .ok()
+        })
+        .collect();
+
+    Ok(heights)
+}
+
+pub async fn query_consensus_states(
+    chain_id: &ChainId,
+    grpc_addr: &Uri,
+    request: QueryConsensusStatesRequest,
+) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
+    crate::time!("query_consensus_states");
+    crate::telemetry!(query, chain_id, "query_consensus_states");
+
+    let mut client =
+        ibc_proto::ibc::core::client::v1::query_client::QueryClient::connect(grpc_addr.clone())
+            .await
+            .map_err(Error::grpc_transport)?;
+
+    let response = client
+        .consensus_states(tonic::Request::new(request.into()))
+        .await
+        .map_err(Error::grpc_status)?
+        .into_inner();
+
+    let consensus_states: Vec<_> = response
+        .consensus_states
+        .into_iter()
+        .filter_map(|cs| {
+            AnyConsensusStateWithHeight::try_from(cs.clone())
+                .map_err(|e| {
+                    warn!(
+                        "failed to parse consensus state {}. Error: {}",
+                        PrettyConsensusStateWithHeight(&cs),
+                        e
+                    )
+                })
+                .ok()
+        })
+        .collect();
+
+    Ok(consensus_states)
+}

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -36,7 +36,7 @@ use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
 use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
 use crate::error::{Error, QUERY_PROOF_EXPECT_MSG};
 use crate::event::IbcEventWithHeight;
@@ -209,12 +209,6 @@ pub trait ChainEndpoint: Sized {
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
     ) -> Result<(AnyConsensusState, Option<MerkleProof>), Error>;
-
-    /// Query all the consensus states for a given client.
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error>;
 
     /// Query the heights of every consensus state for a given client.
     fn query_consensus_state_heights(

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -29,7 +29,7 @@ use crate::{
     client_state::{AnyClientState, IdentifiedAnyClientState},
     config::ChainConfig,
     connection::ConnectionMsgType,
-    consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight},
+    consensus_state::AnyConsensusState,
     denom::DenomTrace,
     error::Error,
     event::{
@@ -216,11 +216,6 @@ pub enum ChainRequest {
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
         reply_to: ReplyTo<(AnyConsensusState, Option<MerkleProof>)>,
-    },
-
-    QueryConsensusStates {
-        request: QueryConsensusStatesRequest,
-        reply_to: ReplyTo<Vec<AnyConsensusStateWithHeight>>,
     },
 
     QueryConsensusStateHeights {
@@ -457,12 +452,6 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
         request: QueryConsensusStateRequest,
         include_proof: IncludeProof,
     ) -> Result<(AnyConsensusState, Option<MerkleProof>), Error>;
-
-    /// Query all the consensus states for a given client.
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error>;
 
     /// Query the heights of every consensus state for a given client.
     fn query_consensus_state_heights(

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -27,7 +27,7 @@ use crate::{
     client_state::{AnyClientState, IdentifiedAnyClientState},
     config::ChainConfig,
     connection::ConnectionMsgType,
-    consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight},
+    consensus_state::AnyConsensusState,
     denom::DenomTrace,
     error::Error,
     event::IbcEventWithHeight,
@@ -201,13 +201,6 @@ impl ChainHandle for BaseChainHandle {
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.send(|reply_to| ChainRequest::QueryConsensusStateHeights { request, reply_to })
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.send(|reply_to| ChainRequest::QueryConsensusStates { request, reply_to })
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/chain/handle/cache.rs
+++ b/crates/relayer/src/chain/handle/cache.rs
@@ -29,7 +29,7 @@ use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
 use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
 use crate::error::Error;
 use crate::event::IbcEventWithHeight;
@@ -208,13 +208,6 @@ impl<Handle: ChainHandle> ChainHandle for CachingChainHandle<Handle> {
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.inner().query_consensus_state_heights(request)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.inner().query_consensus_states(request)
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/chain/handle/counting.rs
+++ b/crates/relayer/src/chain/handle/counting.rs
@@ -31,7 +31,7 @@ use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
 use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
-use crate::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
 use crate::error::Error;
 use crate::event::IbcEventWithHeight;
@@ -214,14 +214,6 @@ impl<Handle: ChainHandle> ChainHandle for CountingChainHandle<Handle> {
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.inner().query_consensus_state_heights(request)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.inc_metric("query_consensus_states");
-        self.inner().query_consensus_states(request)
     }
 
     fn query_consensus_state(

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -31,7 +31,7 @@ use crate::{
     client_state::{AnyClientState, IdentifiedAnyClientState},
     config::ChainConfig,
     connection::ConnectionMsgType,
-    consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight},
+    consensus_state::AnyConsensusState,
     denom::DenomTrace,
     error::Error,
     event::IbcEventWithHeight,
@@ -241,10 +241,6 @@ where
 
                         ChainRequest::QueryConsensusStateHeights { request, reply_to } => {
                             self.query_consensus_state_heights(request, reply_to)?
-                        },
-
-                        ChainRequest::QueryConsensusStates { request, reply_to } => {
-                            self.query_consensus_states(request, reply_to)?
                         },
 
                         ChainRequest::QueryConsensusState { request, include_proof, reply_to } => {
@@ -575,15 +571,6 @@ where
     ) -> Result<(), Error> {
         let heights = self.chain.query_consensus_state_heights(request);
         reply_to.send(heights).map_err(Error::send)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-        reply_to: ReplyTo<Vec<AnyConsensusStateWithHeight>>,
-    ) -> Result<(), Error> {
-        let consensus_states = self.chain.query_consensus_states(request);
-        reply_to.send(consensus_states).map_err(Error::send)
     }
 
     fn query_consensus_state(

--- a/tools/integration-test/src/tests/consensus_states.rs
+++ b/tools/integration-test/src/tests/consensus_states.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use ibc_relayer::chain::requests::{
-    PageRequest, QueryConsensusStateHeightsRequest, QueryConsensusStatesRequest,
+    PageRequest,
+    QueryConsensusStateHeightsRequest, // QueryConsensusStatesRequest,
 };
 
 use ibc_test_framework::prelude::*;
@@ -37,14 +38,14 @@ impl BinaryChainTest for ConsensusStateHeights {
             }
         }
 
-        let states = chains
-            .handle_b()
-            .query_consensus_states(QueryConsensusStatesRequest {
-                client_id: (*chains.client_id_b().value()).clone(),
-                pagination: Some(PageRequest::all()),
-            })?;
+        // let states = chains
+        //     .handle_b()
+        //     .query_consensus_states(QueryConsensusStatesRequest {
+        //         client_id: (*chains.client_id_b().value()).clone(),
+        //         pagination: Some(PageRequest::all()),
+        //     })?;
 
-        assert_eq!(states.len(), CONSENSUS_STATES_COUNT);
+        // assert_eq!(states.len(), CONSENSUS_STATES_COUNT);
 
         let heights =
             chains
@@ -56,12 +57,12 @@ impl BinaryChainTest for ConsensusStateHeights {
 
         assert_eq!(heights.len(), CONSENSUS_STATES_COUNT);
 
-        states
-            .into_iter()
-            .zip(heights.into_iter())
-            .for_each(|(state, height)| {
-                assert_eq!(state.height, height);
-            });
+        // states
+        //     .into_iter()
+        //     .zip(heights.into_iter())
+        //     .for_each(|(state, height)| {
+        //         assert_eq!(state.height, height);
+        //     });
 
         Ok(())
     }

--- a/tools/test-framework/src/relayer/chain.rs
+++ b/tools/test-framework/src/relayer/chain.rs
@@ -32,7 +32,7 @@ use ibc_relayer::chain::tracking::TrackedMsgs;
 use ibc_relayer::client_state::{AnyClientState, IdentifiedAnyClientState};
 use ibc_relayer::config::ChainConfig;
 use ibc_relayer::connection::ConnectionMsgType;
-use ibc_relayer::consensus_state::{AnyConsensusState, AnyConsensusStateWithHeight};
+use ibc_relayer::consensus_state::AnyConsensusState;
 use ibc_relayer::denom::DenomTrace;
 use ibc_relayer::error::Error;
 use ibc_relayer::event::IbcEventWithHeight;
@@ -157,13 +157,6 @@ where
         request: QueryConsensusStateHeightsRequest,
     ) -> Result<Vec<Height>, Error> {
         self.value().query_consensus_state_heights(request)
-    }
-
-    fn query_consensus_states(
-        &self,
-        request: QueryConsensusStatesRequest,
-    ) -> Result<Vec<AnyConsensusStateWithHeight>, Error> {
-        self.value().query_consensus_states(request)
     }
 
     fn query_consensus_state(


### PR DESCRIPTION
See https://github.com/informalsystems/hermes/pull/2950#discussion_r1064227528

## Description

- [x] Remove `query_consensus_states` from the `ChainEndpoint` trait
- [x] `query consensus state`: only list heights and remove `--heights-only` option


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
