### PR TITLE
Implement two-way relay context

### DIFF
--- a/crates/relayer-cosmos/src/base/all_for_one/birelay.rs
+++ b/crates/relayer-cosmos/src/base/all_for_one/birelay.rs
@@ -1,0 +1,15 @@
+use ibc_relayer_framework::base::all_for_one::birelay::AfoBaseBiRelay;
+use ibc_relayer_framework::base::relay::types::aliases::{DstChain, SrcChain};
+
+use crate::base::all_for_one::relay::AfoCosmosBaseRelay;
+
+pub trait AfoCosmosBaseBiRelay:
+    AfoBaseBiRelay<AfoRelayAToB = Self::CosmosRelayAToB, AfoRelayBToA = Self::CosmosRelayBToA>
+{
+    type CosmosRelayAToB: AfoCosmosBaseRelay;
+
+    type CosmosRelayBToA: AfoCosmosBaseRelay<
+        CosmosSrcChain = DstChain<Self::CosmosRelayAToB>,
+        CosmosDstChain = SrcChain<Self::CosmosRelayAToB>,
+    >;
+}

--- a/crates/relayer-cosmos/src/base/all_for_one/birelay.rs
+++ b/crates/relayer-cosmos/src/base/all_for_one/birelay.rs
@@ -13,3 +13,17 @@ pub trait AfoCosmosBaseBiRelay:
         CosmosDstChain = SrcChain<Self::CosmosRelayAToB>,
     >;
 }
+
+impl<BiRelay, RelayAToB, RelayBToA> AfoCosmosBaseBiRelay for BiRelay
+where
+    BiRelay: AfoBaseBiRelay<AfoRelayAToB = RelayAToB, AfoRelayBToA = RelayBToA>,
+    RelayAToB: AfoCosmosBaseRelay,
+    RelayBToA: AfoCosmosBaseRelay<
+        CosmosSrcChain = RelayAToB::DstChain,
+        CosmosDstChain = RelayAToB::SrcChain,
+    >,
+{
+    type CosmosRelayAToB = RelayAToB;
+
+    type CosmosRelayBToA = RelayBToA;
+}

--- a/crates/relayer-cosmos/src/base/all_for_one/mod.rs
+++ b/crates/relayer-cosmos/src/base/all_for_one/mod.rs
@@ -3,5 +3,6 @@
 //! API methods that are part of this trait are used to facilitate the
 //! functionality of relayers.
 
+pub mod birelay;
 pub mod chain;
 pub mod relay;

--- a/crates/relayer-cosmos/src/base/all_for_one/relay.rs
+++ b/crates/relayer-cosmos/src/base/all_for_one/relay.rs
@@ -1,26 +1,21 @@
 use ibc_relayer_framework::base::all_for_one::relay::AfoBaseRelay;
-use ibc_relayer_types::core::ics04_channel::packet::Packet;
 
 use crate::base::all_for_one::chain::AfoCosmosBaseChain;
 
 pub trait AfoCosmosBaseRelay:
-    AfoBaseRelay<
-    AfoSrcChain = Self::SrcCosmosChain,
-    AfoDstChain = Self::DstCosmosChain,
-    Packet = Packet,
->
+    AfoBaseRelay<AfoSrcChain = Self::CosmosSrcChain, AfoDstChain = Self::CosmosDstChain>
 {
-    type SrcCosmosChain: AfoCosmosBaseChain<Self::DstCosmosChain>;
+    type CosmosSrcChain: AfoCosmosBaseChain<Self::CosmosDstChain>;
 
-    type DstCosmosChain: AfoCosmosBaseChain<Self::SrcCosmosChain>;
+    type CosmosDstChain: AfoCosmosBaseChain<Self::CosmosSrcChain>;
 }
 
 impl<Relay, SrcChain, DstChain> AfoCosmosBaseRelay for Relay
 where
-    Relay: AfoBaseRelay<AfoSrcChain = SrcChain, AfoDstChain = DstChain, Packet = Packet>,
+    Relay: AfoBaseRelay<AfoSrcChain = SrcChain, AfoDstChain = DstChain>,
     SrcChain: AfoCosmosBaseChain<DstChain>,
     DstChain: AfoCosmosBaseChain<SrcChain>,
 {
-    type SrcCosmosChain = SrcChain;
-    type DstCosmosChain = DstChain;
+    type CosmosSrcChain = SrcChain;
+    type CosmosDstChain = DstChain;
 }

--- a/crates/relayer-cosmos/src/base/instances/context.rs
+++ b/crates/relayer-cosmos/src/base/instances/context.rs
@@ -1,9 +1,11 @@
 use core::marker::PhantomData;
+use ibc_relayer_framework::base::all_for_one::birelay::AfoBaseBiRelay;
 use ibc_relayer_framework::base::chain::traits::types::chain::HasChainTypes;
 use ibc_relayer_framework::base::one_for_all::traits::chain::OfaIbcChainPreset;
 use ibc_relayer_framework::base::one_for_all::traits::relay::OfaRelayPreset;
 use ibc_relayer_framework::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_framework::base::one_for_all::types::relay::OfaRelayWrapper;
+use ibc_relayer_framework::base::relay::types::two_way::TwoWayRelayContext;
 
 use crate::base::all_for_one::chain::AfoCosmosBaseChain;
 use crate::base::all_for_one::relay::AfoCosmosBaseRelay;
@@ -11,6 +13,21 @@ use crate::base::traits::chain::CosmosChain;
 use crate::base::traits::relay::CosmosRelay;
 use crate::base::types::chain::CosmosChainWrapper;
 use crate::base::types::relay::CosmosRelayWrapper;
+
+pub fn birelay_context<RelayAToB, RelayBToA>() -> PhantomData<impl AfoBaseBiRelay>
+where
+    RelayAToB: CosmosRelay,
+    RelayBToA: CosmosRelay<SrcChain = RelayAToB::DstChain, DstChain = RelayAToB::SrcChain>,
+    RelayAToB::Preset: OfaRelayPreset<CosmosRelayWrapper<RelayAToB>>,
+    RelayBToA::Preset: OfaRelayPreset<CosmosRelayWrapper<RelayBToA>>,
+{
+    PhantomData::<
+        TwoWayRelayContext<
+            OfaRelayWrapper<CosmosRelayWrapper<RelayAToB>>,
+            OfaRelayWrapper<CosmosRelayWrapper<RelayBToA>>,
+        >,
+    >
+}
 
 pub fn relay_context<Relay>() -> PhantomData<impl AfoCosmosBaseRelay>
 where

--- a/crates/relayer-cosmos/src/base/instances/context.rs
+++ b/crates/relayer-cosmos/src/base/instances/context.rs
@@ -6,6 +6,7 @@ use ibc_relayer_framework::base::one_for_all::traits::relay::OfaRelayPreset;
 use ibc_relayer_framework::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_framework::base::one_for_all::types::relay::OfaRelayWrapper;
 use ibc_relayer_framework::base::relay::types::two_way::TwoWayRelayContext;
+use ibc_relayer_framework::full::relay::impls::auto_relayers::parallel_two_way::ParallelTwoWayAutoRelay;
 
 use crate::base::all_for_one::chain::AfoCosmosBaseChain;
 use crate::base::all_for_one::relay::AfoCosmosBaseRelay;
@@ -23,6 +24,7 @@ where
 {
     PhantomData::<
         TwoWayRelayContext<
+            ParallelTwoWayAutoRelay,
             OfaRelayWrapper<CosmosRelayWrapper<RelayAToB>>,
             OfaRelayWrapper<CosmosRelayWrapper<RelayBToA>>,
         >,

--- a/crates/relayer-cosmos/src/contexts/full/chain.rs
+++ b/crates/relayer-cosmos/src/contexts/full/chain.rs
@@ -10,6 +10,7 @@ use crate::base::traits::chain::CosmosChain;
 use crate::full::traits::chain::CosmosFullChain;
 use crate::full::types::telemetry::CosmosTelemetry;
 
+#[derive(Clone)]
 pub struct FullCosmosChainContext<Handle: ChainHandle> {
     pub handle: Handle,
     pub signer: Signer,

--- a/crates/relayer-cosmos/src/full/all_for_one/birelay.rs
+++ b/crates/relayer-cosmos/src/full/all_for_one/birelay.rs
@@ -1,0 +1,15 @@
+use ibc_relayer_framework::base::relay::types::aliases::{DstChain, SrcChain};
+use ibc_relayer_framework::full::all_for_one::birelay::AfoFullBiRelay;
+
+use crate::full::all_for_one::relay::AfoCosmosFullRelay;
+
+pub trait AfoCosmosFullBiRelay:
+    AfoFullBiRelay<AfoRelayAToB = Self::CosmosRelayAToB, AfoRelayBToA = Self::CosmosRelayBToA>
+{
+    type CosmosRelayAToB: AfoCosmosFullRelay;
+
+    type CosmosRelayBToA: AfoCosmosFullRelay<
+        CosmosSrcChain = DstChain<Self::CosmosRelayAToB>,
+        CosmosDstChain = SrcChain<Self::CosmosRelayAToB>,
+    >;
+}

--- a/crates/relayer-cosmos/src/full/all_for_one/birelay.rs
+++ b/crates/relayer-cosmos/src/full/all_for_one/birelay.rs
@@ -13,3 +13,17 @@ pub trait AfoCosmosFullBiRelay:
         CosmosDstChain = SrcChain<Self::CosmosRelayAToB>,
     >;
 }
+
+impl<BiRelay, RelayAToB, RelayBToA> AfoCosmosFullBiRelay for BiRelay
+where
+    BiRelay: AfoFullBiRelay<AfoRelayAToB = RelayAToB, AfoRelayBToA = RelayBToA>,
+    RelayAToB: AfoCosmosFullRelay,
+    RelayBToA: AfoCosmosFullRelay<
+        CosmosSrcChain = RelayAToB::DstChain,
+        CosmosDstChain = RelayAToB::SrcChain,
+    >,
+{
+    type CosmosRelayAToB = RelayAToB;
+
+    type CosmosRelayBToA = RelayBToA;
+}

--- a/crates/relayer-cosmos/src/full/all_for_one/mod.rs
+++ b/crates/relayer-cosmos/src/full/all_for_one/mod.rs
@@ -1,2 +1,3 @@
+pub mod birelay;
 pub mod chain;
 pub mod relay;

--- a/crates/relayer-cosmos/src/full/all_for_one/relay.rs
+++ b/crates/relayer-cosmos/src/full/all_for_one/relay.rs
@@ -5,14 +5,14 @@ use crate::full::all_for_one::chain::AfoCosmosFullChain;
 
 pub trait AfoCosmosFullRelay:
     AfoFullRelay<
-    AfoSrcFullChain = Self::SrcCosmosFullChain,
-    AfoDstFullChain = Self::DstCosmosFullChain,
+    AfoSrcFullChain = Self::CosmosSrcChain,
+    AfoDstFullChain = Self::CosmosDstChain,
     Packet = Packet,
 >
 {
-    type SrcCosmosFullChain: AfoCosmosFullChain<Self::DstCosmosFullChain>;
+    type CosmosSrcChain: AfoCosmosFullChain<Self::CosmosDstChain>;
 
-    type DstCosmosFullChain: AfoCosmosFullChain<Self::SrcCosmosFullChain>;
+    type CosmosDstChain: AfoCosmosFullChain<Self::CosmosSrcChain>;
 }
 
 impl<Relay, SrcChain, DstChain> AfoCosmosFullRelay for Relay
@@ -21,6 +21,6 @@ where
     SrcChain: AfoCosmosFullChain<DstChain>,
     DstChain: AfoCosmosFullChain<SrcChain>,
 {
-    type SrcCosmosFullChain = SrcChain;
-    type DstCosmosFullChain = DstChain;
+    type CosmosSrcChain = SrcChain;
+    type CosmosDstChain = DstChain;
 }

--- a/crates/relayer-framework/src/base/all_for_one/birelay.rs
+++ b/crates/relayer-framework/src/base/all_for_one/birelay.rs
@@ -1,8 +1,9 @@
 use crate::base::all_for_one::relay::AfoBaseRelay;
+use crate::base::relay::traits::auto_relayer::CanAutoRelay;
 use crate::base::relay::traits::two_way::HasTwoWayRelay;
 
 pub trait AfoBaseBiRelay:
-    HasTwoWayRelay<RelayAToB = Self::AfoRelayAToB, RelayBToA = Self::AfoRelayBToA>
+    CanAutoRelay + HasTwoWayRelay<RelayAToB = Self::AfoRelayAToB, RelayBToA = Self::AfoRelayBToA>
 {
     type AfoRelayAToB: AfoBaseRelay;
 
@@ -16,7 +17,7 @@ impl<BiRelay, RelayAToB, RelayBToA> AfoBaseBiRelay for BiRelay
 where
     RelayAToB: AfoBaseRelay,
     RelayBToA: AfoBaseRelay<AfoSrcChain = RelayAToB::DstChain, AfoDstChain = RelayAToB::SrcChain>,
-    BiRelay: HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
+    BiRelay: CanAutoRelay + HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
 {
     type AfoRelayAToB = RelayAToB;
 

--- a/crates/relayer-framework/src/base/all_for_one/birelay.rs
+++ b/crates/relayer-framework/src/base/all_for_one/birelay.rs
@@ -1,4 +1,3 @@
-use crate::base::all_for_one::chain::AfoBaseChain;
 use crate::base::all_for_one::relay::AfoBaseRelay;
 use crate::base::relay::traits::two_way::HasTwoWayRelay;
 
@@ -13,13 +12,10 @@ pub trait AfoBaseBiRelay:
     >;
 }
 
-impl<BiRelay, ChainA, ChainB, RelayAToB, RelayBToA, PacketAToB, PacketBToA> AfoBaseBiRelay
-    for BiRelay
+impl<BiRelay, RelayAToB, RelayBToA> AfoBaseBiRelay for BiRelay
 where
-    ChainA: AfoBaseChain<ChainB, IncomingPacket = PacketBToA, OutgoingPacket = PacketAToB>,
-    ChainB: AfoBaseChain<ChainA, IncomingPacket = PacketAToB, OutgoingPacket = PacketBToA>,
-    RelayAToB: AfoBaseRelay<AfoSrcChain = ChainA, AfoDstChain = ChainB>,
-    RelayBToA: AfoBaseRelay<AfoSrcChain = ChainB, AfoDstChain = ChainA>,
+    RelayAToB: AfoBaseRelay,
+    RelayBToA: AfoBaseRelay<AfoSrcChain = RelayAToB::DstChain, AfoDstChain = RelayAToB::SrcChain>,
     BiRelay: HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
 {
     type AfoRelayAToB = RelayAToB;

--- a/crates/relayer-framework/src/base/all_for_one/chain.rs
+++ b/crates/relayer-framework/src/base/all_for_one/chain.rs
@@ -1,3 +1,4 @@
+use crate::base::all_for_one::runtime::HasAfoBaseRuntime;
 use crate::base::chain::traits::queries::consensus_state::{
     CanQueryConsensusState, HasConsensusState,
 };
@@ -7,7 +8,9 @@ use crate::base::chain::traits::types::ibc_events::write_ack::HasWriteAcknowledg
 use crate::base::chain::traits::types::packet::HasIbcPacketTypes;
 
 pub trait AfoBaseChain<Counterparty>:
-    HasIbcPacketTypes<Counterparty>
+    Clone
+    + HasAfoBaseRuntime
+    + HasIbcPacketTypes<Counterparty>
     + HasWriteAcknowledgementEvent<Counterparty>
     + HasConsensusState<Counterparty>
     + CanQueryConsensusState<Counterparty>
@@ -33,7 +36,9 @@ where
 impl<Chain, Counterparty> AfoBaseChain<Counterparty> for Chain
 where
     Counterparty: AfoCounterpartyChain<Self>,
-    Chain: HasIbcPacketTypes<Counterparty>
+    Chain: Clone
+        + HasAfoBaseRuntime
+        + HasIbcPacketTypes<Counterparty>
         + HasWriteAcknowledgementEvent<Counterparty>
         + HasConsensusState<Counterparty>
         + CanQueryConsensusState<Counterparty>

--- a/crates/relayer-framework/src/base/all_for_one/mod.rs
+++ b/crates/relayer-framework/src/base/all_for_one/mod.rs
@@ -5,3 +5,4 @@
 pub mod birelay;
 pub mod chain;
 pub mod relay;
+pub mod runtime;

--- a/crates/relayer-framework/src/base/all_for_one/relay.rs
+++ b/crates/relayer-framework/src/base/all_for_one/relay.rs
@@ -1,4 +1,5 @@
 use crate::base::all_for_one::chain::AfoBaseChain;
+use crate::base::all_for_one::runtime::HasAfoBaseRuntime;
 use crate::base::chain::types::aliases::{IncomingPacket, OutgoingPacket};
 use crate::base::relay::traits::auto_relayer::CanAutoRelay;
 use crate::base::relay::traits::event_relayer::CanRelayEvent;
@@ -15,7 +16,9 @@ use crate::base::relay::traits::types::HasRelayTypes;
 /// The functionality that a relay context gains access to once that relay
 /// context implements the `OfaRelayWrapper` trait.
 pub trait AfoBaseRelay:
-    HasRelayTypes<SrcChain = Self::AfoSrcChain, DstChain = Self::AfoDstChain>
+    Clone
+    + HasAfoBaseRuntime
+    + HasRelayTypes<SrcChain = Self::AfoSrcChain, DstChain = Self::AfoDstChain>
     + CanBuildUpdateClientMessage<SourceTarget>
     + CanBuildUpdateClientMessage<DestinationTarget>
     + CanSendIbcMessages<SourceTarget>
@@ -42,7 +45,9 @@ impl<Relay, SrcChain, DstChain, Packet, ReversePacket> AfoBaseRelay for Relay
 where
     SrcChain: AfoBaseChain<DstChain, IncomingPacket = ReversePacket, OutgoingPacket = Packet>,
     DstChain: AfoBaseChain<SrcChain, IncomingPacket = Packet, OutgoingPacket = ReversePacket>,
-    Relay: HasRelayTypes<SrcChain = SrcChain, DstChain = DstChain>
+    Relay: Clone
+        + HasAfoBaseRuntime
+        + HasRelayTypes<SrcChain = SrcChain, DstChain = DstChain>
         + CanBuildUpdateClientMessage<SourceTarget>
         + CanBuildUpdateClientMessage<DestinationTarget>
         + CanSendIbcMessages<SourceTarget>

--- a/crates/relayer-framework/src/base/all_for_one/runtime.rs
+++ b/crates/relayer-framework/src/base/all_for_one/runtime.rs
@@ -1,0 +1,24 @@
+use crate::base::runtime::traits::log::HasBasicLogger;
+use crate::base::runtime::traits::mutex::HasMutex;
+use crate::base::runtime::traits::runtime::HasRuntime;
+use crate::base::runtime::traits::sleep::CanSleep;
+use crate::base::runtime::traits::time::HasTime;
+
+pub trait AfoBaseRuntime: HasBasicLogger + HasMutex + CanSleep + HasTime {}
+
+impl<Runtime> AfoBaseRuntime for Runtime where
+    Runtime: HasBasicLogger + HasMutex + CanSleep + HasTime
+{
+}
+
+pub trait HasAfoBaseRuntime: HasRuntime<Runtime = Self::AfoBaseRuntime> {
+    type AfoBaseRuntime: AfoBaseRuntime;
+}
+
+impl<Context, Runtime> HasAfoBaseRuntime for Context
+where
+    Context: HasRuntime<Runtime = Runtime>,
+    Runtime: AfoBaseRuntime,
+{
+    type AfoBaseRuntime = Runtime;
+}

--- a/crates/relayer-framework/src/base/one_for_all/instances/all_for_one.rs
+++ b/crates/relayer-framework/src/base/one_for_all/instances/all_for_one.rs
@@ -2,7 +2,9 @@
 //! this is where we 'prove' that the types that we want to implement the `all_for_one`
 //! functionality implement the required trait bounds, i.e. `OfaRelayWrapper` or
 //! `OfaChainWrapper`, etc.
+use core::marker::PhantomData;
 
+use crate::base::all_for_one::birelay::AfoBaseBiRelay;
 use crate::base::all_for_one::chain::AfoBaseChain;
 use crate::base::all_for_one::relay::AfoBaseRelay;
 use crate::base::one_for_all::traits::chain::OfaIbcChain;
@@ -11,6 +13,21 @@ use crate::base::one_for_all::traits::relay::OfaBaseRelay;
 use crate::base::one_for_all::traits::relay::OfaRelayPreset;
 use crate::base::one_for_all::types::chain::OfaChainWrapper;
 use crate::base::one_for_all::types::relay::OfaRelayWrapper;
+use crate::base::relay::types::two_way::TwoWayRelayContext;
+
+pub fn afo_birelay_context<RelayAToB, RelayBToA>() -> PhantomData<impl AfoBaseBiRelay>
+where
+    RelayAToB: OfaBaseRelay,
+    RelayBToA: OfaBaseRelay<
+        SrcChain = RelayAToB::DstChain,
+        DstChain = RelayAToB::SrcChain,
+        Error = RelayAToB::Error,
+    >,
+    RelayAToB::Preset: OfaRelayPreset<RelayAToB>,
+    RelayBToA::Preset: OfaRelayPreset<RelayBToA>,
+{
+    PhantomData::<TwoWayRelayContext<OfaRelayWrapper<RelayAToB>, OfaRelayWrapper<RelayBToA>>>
+}
 
 /// Given a relay context `Relay` that implements the `OfaBaseRelay` trait, returns a type
 /// that implements the `AfoBaseRelay`, meaning that this type exposes concrete APIs

--- a/crates/relayer-framework/src/base/one_for_all/instances/all_for_one.rs
+++ b/crates/relayer-framework/src/base/one_for_all/instances/all_for_one.rs
@@ -13,6 +13,7 @@ use crate::base::one_for_all::traits::relay::OfaBaseRelay;
 use crate::base::one_for_all::traits::relay::OfaRelayPreset;
 use crate::base::one_for_all::types::chain::OfaChainWrapper;
 use crate::base::one_for_all::types::relay::OfaRelayWrapper;
+use crate::base::relay::impls::auto_relayers::concurrent_two_way::ConcurrentTwoWayAutoRelay;
 use crate::base::relay::types::two_way::TwoWayRelayContext;
 
 pub fn afo_birelay_context<RelayAToB, RelayBToA>() -> PhantomData<impl AfoBaseBiRelay>
@@ -26,7 +27,13 @@ where
     RelayAToB::Preset: OfaRelayPreset<RelayAToB>,
     RelayBToA::Preset: OfaRelayPreset<RelayBToA>,
 {
-    PhantomData::<TwoWayRelayContext<OfaRelayWrapper<RelayAToB>, OfaRelayWrapper<RelayBToA>>>
+    PhantomData::<
+        TwoWayRelayContext<
+            ConcurrentTwoWayAutoRelay,
+            OfaRelayWrapper<RelayAToB>,
+            OfaRelayWrapper<RelayBToA>,
+        >,
+    >
 }
 
 /// Given a relay context `Relay` that implements the `OfaBaseRelay` trait, returns a type

--- a/crates/relayer-framework/src/base/relay/types/two_way.rs
+++ b/crates/relayer-framework/src/base/relay/types/two_way.rs
@@ -1,26 +1,35 @@
+use async_trait::async_trait;
+use core::fmt::Debug;
+use core::marker::PhantomData;
+
 use crate::base::core::traits::error::HasErrorType;
 use crate::base::core::traits::sync::Async;
+use crate::base::relay::traits::auto_relayer::{AutoRelayer, CanAutoRelay};
 use crate::base::relay::traits::two_way::HasTwoWayRelay;
 use crate::base::relay::traits::types::HasRelayTypes;
-use core::fmt::Debug;
+use crate::std_prelude::*;
 
 #[derive(Clone)]
-pub struct TwoWayRelayContext<RelayAToB, RelayBToA> {
+pub struct TwoWayRelayContext<Relayer, RelayAToB, RelayBToA> {
     pub relay_a_to_b: RelayAToB,
     pub relay_b_to_a: RelayBToA,
+    pub phantom: PhantomData<Relayer>,
 }
 
-impl<RelayAToB, RelayBToA> TwoWayRelayContext<RelayAToB, RelayBToA> {
-    pub fn new(relay_a_to_b: RelayAToB, relay_b_to_a: RelayBToA) -> Self {
+impl<Relayer, RelayAToB, RelayBToA> TwoWayRelayContext<Relayer, RelayAToB, RelayBToA> {
+    pub fn new(_relayer: Relayer, relay_a_to_b: RelayAToB, relay_b_to_a: RelayBToA) -> Self {
         Self {
             relay_a_to_b,
             relay_b_to_a,
+            phantom: PhantomData,
         }
     }
 }
 
-impl<Error, RelayAToB, RelayBToA> HasErrorType for TwoWayRelayContext<RelayAToB, RelayBToA>
+impl<Error, Relayer, RelayAToB, RelayBToA> HasErrorType
+    for TwoWayRelayContext<Relayer, RelayAToB, RelayBToA>
 where
+    Relayer: Async,
     Error: Debug + Async,
     RelayAToB: HasRelayTypes<Error = Error>,
     RelayBToA: HasRelayTypes<Error = Error>,
@@ -28,8 +37,10 @@ where
     type Error = Error;
 }
 
-impl<Error, RelayAToB, RelayBToA> HasTwoWayRelay for TwoWayRelayContext<RelayAToB, RelayBToA>
+impl<Error, Relayer, RelayAToB, RelayBToA> HasTwoWayRelay
+    for TwoWayRelayContext<Relayer, RelayAToB, RelayBToA>
 where
+    Relayer: Async,
     Error: Debug + Async,
     RelayAToB: HasRelayTypes<Error = Error>,
     RelayBToA: HasRelayTypes<
@@ -56,5 +67,18 @@ where
 
     fn error_b_to_a(e: Error) -> Error {
         e
+    }
+}
+
+#[async_trait]
+impl<Relayer, RelayAToB, RelayBToA> CanAutoRelay
+    for TwoWayRelayContext<Relayer, RelayAToB, RelayBToA>
+where
+    Relayer: AutoRelayer<Self>,
+    RelayAToB: Async,
+    RelayBToA: Async,
+{
+    async fn auto_relay(&self) {
+        Relayer::auto_relay(self).await;
     }
 }

--- a/crates/relayer-framework/src/base/relay/types/two_way.rs
+++ b/crates/relayer-framework/src/base/relay/types/two_way.rs
@@ -10,6 +10,15 @@ pub struct TwoWayRelayContext<RelayAToB, RelayBToA> {
     pub relay_b_to_a: RelayBToA,
 }
 
+impl<RelayAToB, RelayBToA> TwoWayRelayContext<RelayAToB, RelayBToA> {
+    pub fn new(relay_a_to_b: RelayAToB, relay_b_to_a: RelayBToA) -> Self {
+        Self {
+            relay_a_to_b,
+            relay_b_to_a,
+        }
+    }
+}
+
 impl<Error, RelayAToB, RelayBToA> HasErrorType for TwoWayRelayContext<RelayAToB, RelayBToA>
 where
     Error: Debug + Async,

--- a/crates/relayer-framework/src/full/all_for_one/birelay.rs
+++ b/crates/relayer-framework/src/full/all_for_one/birelay.rs
@@ -1,8 +1,9 @@
+use crate::base::relay::traits::auto_relayer::CanAutoRelay;
 use crate::base::relay::traits::two_way::HasTwoWayRelay;
 use crate::full::all_for_one::relay::AfoFullRelay;
 
 pub trait AfoFullBiRelay:
-    HasTwoWayRelay<RelayAToB = Self::AfoRelayAToB, RelayBToA = Self::AfoRelayBToA>
+    CanAutoRelay + HasTwoWayRelay<RelayAToB = Self::AfoRelayAToB, RelayBToA = Self::AfoRelayBToA>
 {
     type AfoRelayAToB: AfoFullRelay;
 
@@ -17,7 +18,7 @@ where
     RelayAToB: AfoFullRelay,
     RelayBToA:
         AfoFullRelay<AfoSrcFullChain = RelayAToB::DstChain, AfoDstFullChain = RelayAToB::SrcChain>,
-    BiRelay: HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
+    BiRelay: CanAutoRelay + HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
 {
     type AfoRelayAToB = RelayAToB;
 

--- a/crates/relayer-framework/src/full/all_for_one/birelay.rs
+++ b/crates/relayer-framework/src/full/all_for_one/birelay.rs
@@ -1,0 +1,25 @@
+use crate::base::relay::traits::two_way::HasTwoWayRelay;
+use crate::full::all_for_one::relay::AfoFullRelay;
+
+pub trait AfoFullBiRelay:
+    HasTwoWayRelay<RelayAToB = Self::AfoRelayAToB, RelayBToA = Self::AfoRelayBToA>
+{
+    type AfoRelayAToB: AfoFullRelay;
+
+    type AfoRelayBToA: AfoFullRelay<
+        AfoSrcFullChain = <Self::AfoRelayAToB as AfoFullRelay>::AfoDstFullChain,
+        AfoDstFullChain = <Self::AfoRelayAToB as AfoFullRelay>::AfoSrcFullChain,
+    >;
+}
+
+impl<BiRelay, RelayAToB, RelayBToA> AfoFullBiRelay for BiRelay
+where
+    RelayAToB: AfoFullRelay,
+    RelayBToA:
+        AfoFullRelay<AfoSrcFullChain = RelayAToB::DstChain, AfoDstFullChain = RelayAToB::SrcChain>,
+    BiRelay: HasTwoWayRelay<RelayAToB = RelayAToB, RelayBToA = RelayBToA>,
+{
+    type AfoRelayAToB = RelayAToB;
+
+    type AfoRelayBToA = RelayBToA;
+}

--- a/crates/relayer-framework/src/full/all_for_one/chain.rs
+++ b/crates/relayer-framework/src/full/all_for_one/chain.rs
@@ -1,7 +1,9 @@
 use crate::base::all_for_one::chain::{AfoBaseChain, AfoCounterpartyChain};
+use crate::full::all_for_one::runtime::HasAfoFullRuntime;
 use crate::full::telemetry::traits::telemetry::HasTelemetry;
 
-pub trait AfoFullChain<Counterparty>: AfoBaseChain<Counterparty> + HasTelemetry
+pub trait AfoFullChain<Counterparty>:
+    AfoBaseChain<Counterparty> + HasAfoFullRuntime + HasTelemetry
 where
     Counterparty: AfoCounterpartyChain<Self>,
 {
@@ -9,7 +11,7 @@ where
 
 impl<Chain, Counterparty> AfoFullChain<Counterparty> for Chain
 where
-    Chain: AfoBaseChain<Counterparty> + HasTelemetry,
+    Chain: AfoBaseChain<Counterparty> + HasAfoFullRuntime + HasTelemetry,
     Counterparty: AfoCounterpartyChain<Self>,
 {
 }

--- a/crates/relayer-framework/src/full/all_for_one/mod.rs
+++ b/crates/relayer-framework/src/full/all_for_one/mod.rs
@@ -1,2 +1,3 @@
+pub mod birelay;
 pub mod chain;
 pub mod relay;

--- a/crates/relayer-framework/src/full/all_for_one/mod.rs
+++ b/crates/relayer-framework/src/full/all_for_one/mod.rs
@@ -1,3 +1,4 @@
 pub mod birelay;
 pub mod chain;
 pub mod relay;
+pub mod runtime;

--- a/crates/relayer-framework/src/full/all_for_one/relay.rs
+++ b/crates/relayer-framework/src/full/all_for_one/relay.rs
@@ -2,11 +2,13 @@ use crate::base::all_for_one::relay::AfoBaseRelay;
 use crate::base::chain::types::aliases::{IncomingPacket, OutgoingPacket};
 use crate::base::relay::traits::target::{DestinationTarget, SourceTarget};
 use crate::full::all_for_one::chain::AfoFullChain;
+use crate::full::all_for_one::runtime::HasAfoFullRuntime;
 use crate::full::batch::traits::send_messages_from_batch::CanSendIbcMessagesFromBatchWorker;
 use crate::full::relay::impls::packet_relayers::retry::SupportsPacketRetry;
 
 pub trait AfoFullRelay:
-    AfoBaseRelay<AfoSrcChain = Self::AfoSrcFullChain, AfoDstChain = Self::AfoDstFullChain>
+    HasAfoFullRuntime
+    + AfoBaseRelay<AfoSrcChain = Self::AfoSrcFullChain, AfoDstChain = Self::AfoDstFullChain>
     + CanSendIbcMessagesFromBatchWorker<SourceTarget>
     + CanSendIbcMessagesFromBatchWorker<DestinationTarget>
     + SupportsPacketRetry
@@ -22,7 +24,8 @@ pub trait AfoFullRelay:
 
 impl<Relay, SrcChain, DstChain> AfoFullRelay for Relay
 where
-    Relay: AfoBaseRelay<AfoSrcChain = SrcChain, AfoDstChain = DstChain>
+    Relay: HasAfoFullRuntime
+        + AfoBaseRelay<AfoSrcChain = SrcChain, AfoDstChain = DstChain>
         + CanSendIbcMessagesFromBatchWorker<SourceTarget>
         + CanSendIbcMessagesFromBatchWorker<DestinationTarget>
         + SupportsPacketRetry,

--- a/crates/relayer-framework/src/full/all_for_one/relay.rs
+++ b/crates/relayer-framework/src/full/all_for_one/relay.rs
@@ -1,18 +1,18 @@
 use crate::base::all_for_one::relay::AfoBaseRelay;
 use crate::base::chain::types::aliases::{IncomingPacket, OutgoingPacket};
 use crate::base::relay::traits::target::{DestinationTarget, SourceTarget};
-use crate::base::relay::traits::types::HasRelayTypes;
 use crate::full::all_for_one::chain::AfoFullChain;
 use crate::full::batch::traits::send_messages_from_batch::CanSendIbcMessagesFromBatchWorker;
 use crate::full::relay::impls::packet_relayers::retry::SupportsPacketRetry;
 
 pub trait AfoFullRelay:
-    HasRelayTypes<SrcChain = Self::AfoSrcFullChain, DstChain = Self::AfoDstFullChain>
-    + AfoBaseRelay<AfoSrcChain = Self::AfoSrcFullChain, AfoDstChain = Self::AfoDstFullChain>
+    AfoBaseRelay<AfoSrcChain = Self::AfoSrcFullChain, AfoDstChain = Self::AfoDstFullChain>
     + CanSendIbcMessagesFromBatchWorker<SourceTarget>
     + CanSendIbcMessagesFromBatchWorker<DestinationTarget>
+    + SupportsPacketRetry
 {
     type AfoSrcFullChain: AfoFullChain<Self::AfoDstFullChain>;
+
     type AfoDstFullChain: AfoFullChain<
         Self::AfoSrcFullChain,
         IncomingPacket = OutgoingPacket<Self::AfoSrcChain, Self::AfoDstChain>,
@@ -22,8 +22,7 @@ pub trait AfoFullRelay:
 
 impl<Relay, SrcChain, DstChain> AfoFullRelay for Relay
 where
-    Relay: HasRelayTypes<SrcChain = SrcChain, DstChain = DstChain>
-        + AfoBaseRelay<AfoSrcChain = SrcChain, AfoDstChain = DstChain>
+    Relay: AfoBaseRelay<AfoSrcChain = SrcChain, AfoDstChain = DstChain>
         + CanSendIbcMessagesFromBatchWorker<SourceTarget>
         + CanSendIbcMessagesFromBatchWorker<DestinationTarget>
         + SupportsPacketRetry,

--- a/crates/relayer-framework/src/full/all_for_one/runtime.rs
+++ b/crates/relayer-framework/src/full/all_for_one/runtime.rs
@@ -1,0 +1,26 @@
+use crate::base::all_for_one::runtime::{AfoBaseRuntime, HasAfoBaseRuntime};
+use crate::base::runtime::traits::runtime::HasRuntime;
+use crate::full::runtime::traits::channel::{CanCreateChannels, CanStreamReceiver, CanUseChannels};
+use crate::full::runtime::traits::spawn::HasSpawner;
+
+pub trait AfoFullRuntime:
+    AfoBaseRuntime + HasSpawner + CanCreateChannels + CanStreamReceiver + CanUseChannels
+{
+}
+
+impl<Runtime> AfoFullRuntime for Runtime where
+    Runtime: AfoBaseRuntime + HasSpawner + CanCreateChannels + CanStreamReceiver + CanUseChannels
+{
+}
+
+pub trait HasAfoFullRuntime: HasAfoBaseRuntime<AfoBaseRuntime = Self::AfoFullRuntime> {
+    type AfoFullRuntime: AfoFullRuntime;
+}
+
+impl<Context, Runtime> HasAfoFullRuntime for Context
+where
+    Context: HasRuntime<Runtime = Runtime>,
+    Runtime: AfoFullRuntime,
+{
+    type AfoFullRuntime = Runtime;
+}

--- a/crates/relayer-framework/src/full/one_for_all/impls/runtime/spawn.rs
+++ b/crates/relayer-framework/src/full/one_for_all/impls/runtime/spawn.rs
@@ -2,7 +2,7 @@ use core::future::Future;
 
 use crate::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use crate::full::one_for_all::traits::runtime::OfaFullRuntime;
-use crate::full::runtime::traits::spawn::{HasSpawner, Spawner};
+use crate::full::runtime::traits::spawn::{HasSpawner, Spawner, TaskHandle};
 use crate::std_prelude::*;
 
 impl<Runtime: OfaFullRuntime> HasSpawner for OfaRuntimeWrapper<Runtime> {
@@ -14,7 +14,7 @@ impl<Runtime: OfaFullRuntime> HasSpawner for OfaRuntimeWrapper<Runtime> {
 }
 
 impl<Runtime: OfaFullRuntime> Spawner for OfaRuntimeWrapper<Runtime> {
-    fn spawn<F>(&self, task: F)
+    fn spawn<F>(&self, task: F) -> Box<dyn TaskHandle>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,

--- a/crates/relayer-framework/src/full/one_for_all/traits/runtime.rs
+++ b/crates/relayer-framework/src/full/one_for_all/traits/runtime.rs
@@ -5,6 +5,7 @@ use futures::stream::Stream;
 
 use crate::base::core::traits::sync::Async;
 use crate::base::one_for_all::traits::runtime::OfaBaseRuntime;
+use crate::full::runtime::traits::spawn::TaskHandle;
 use crate::std_prelude::*;
 
 #[async_trait]
@@ -25,7 +26,7 @@ pub trait OfaFullRuntime: OfaBaseRuntime {
     where
         T: Async;
 
-    fn spawn<F>(&self, task: F)
+    fn spawn<F>(&self, task: F) -> Box<dyn TaskHandle>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;

--- a/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_bidirectional.rs
+++ b/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_bidirectional.rs
@@ -23,20 +23,21 @@ where
         let dst_relay = relay.clone();
         let spawner = src_relay.runtime().spawner();
 
-        spawner.spawn(async move {
+        let handle1 = spawner.spawn(async move {
             <InRelayer as AutoRelayerWithTarget<Relay, DestinationTarget>>::auto_relay_with_target(
                 &dst_relay,
             )
             .await;
         });
 
-        spawner.spawn(async move {
+        let handle2 = spawner.spawn(async move {
             <InRelayer as AutoRelayerWithTarget<Relay, SourceTarget>>::auto_relay_with_target(
                 &src_relay,
             )
             .await
         });
 
-        // TODO: implement JoinHandle in HasSpawner
+        handle1.into_future().await;
+        handle2.into_future().await;
     }
 }

--- a/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_event.rs
+++ b/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_event.rs
@@ -32,7 +32,7 @@ where
                         let relay = relay.clone();
                         let spawner = runtime.spawner();
 
-                        spawner.spawn(async move {
+                        let handle = spawner.spawn(async move {
                             let (height, event) = item;
 
                             // Ignore any relaying errors, as the relayer still needs to proceed
@@ -40,6 +40,8 @@ where
                             // TODO: log errors inside EventRelayer
                             let _ = relay.relay_chain_event(&height, &event).await;
                         });
+
+                        handle.into_future().await;
                     })
                     .await;
             } else {

--- a/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_two_way.rs
+++ b/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_two_way.rs
@@ -21,12 +21,15 @@ where
         let relay_b_to_a = birelay.relay_b_to_a().clone();
         let spawner = relay_a_to_b.runtime().spawner();
 
-        spawner.spawn(async move {
+        let handle1 = spawner.spawn(async move {
             BiRelay::RelayAToB::auto_relay(&relay_a_to_b).await;
         });
 
-        spawner.spawn(async move {
+        let handle2 = spawner.spawn(async move {
             BiRelay::RelayBToA::auto_relay(&relay_b_to_a).await;
         });
+
+        handle1.into_future().await;
+        handle2.into_future().await;
     }
 }

--- a/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_two_way.rs
+++ b/crates/relayer-framework/src/full/relay/impls/auto_relayers/parallel_two_way.rs
@@ -6,10 +6,10 @@ use crate::base::runtime::traits::runtime::HasRuntime;
 use crate::full::runtime::traits::spawn::{HasSpawner, Spawner};
 use crate::std_prelude::*;
 
-pub struct ConcurrentTwoWayAutoRelay;
+pub struct ParallelTwoWayAutoRelay;
 
 #[async_trait]
-impl<BiRelay, Runtime> AutoRelayer<BiRelay> for ConcurrentTwoWayAutoRelay
+impl<BiRelay, Runtime> AutoRelayer<BiRelay> for ParallelTwoWayAutoRelay
 where
     BiRelay: HasTwoWayRelay,
     Runtime: HasSpawner,

--- a/crates/relayer-framework/src/full/runtime/traits/spawn.rs
+++ b/crates/relayer-framework/src/full/runtime/traits/spawn.rs
@@ -1,6 +1,9 @@
 use core::future::Future;
+use core::pin::Pin;
+use futures::stream::{self, StreamExt};
 
 use crate::base::core::traits::sync::Async;
+use crate::std_prelude::*;
 
 pub trait HasSpawner: Async {
     type Spawner: Spawner;
@@ -9,8 +12,30 @@ pub trait HasSpawner: Async {
 }
 
 pub trait Spawner: Async {
-    fn spawn<F>(&self, task: F)
+    fn spawn<F>(&self, task: F) -> Box<dyn TaskHandle>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;
+}
+
+pub trait TaskHandle: Send + 'static {
+    fn abort(self: Box<Self>);
+
+    fn into_future(self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+}
+
+impl TaskHandle for Vec<Box<dyn TaskHandle>> {
+    fn abort(self: Box<Self>) {
+        for handle in self.into_iter() {
+            handle.abort();
+        }
+    }
+
+    fn into_future(self: Box<Self>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        Box::pin(async move {
+            stream::iter(self.into_iter())
+                .for_each_concurrent(None, |handle| handle.into_future())
+                .await;
+        })
+    }
 }

--- a/tools/integration-test/src/tests/next/context.rs
+++ b/tools/integration-test/src/tests/next/context.rs
@@ -7,6 +7,7 @@ use ibc_relayer_cosmos::full::types::telemetry::{CosmosTelemetry, TelemetryState
 use ibc_relayer_framework::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_framework::base::relay::types::two_way::TwoWayRelayContext;
 use ibc_relayer_framework::full::one_for_all::types::telemetry::OfaTelemetryWrapper;
+use ibc_relayer_framework::full::relay::impls::auto_relayers::parallel_two_way::ParallelTwoWayAutoRelay;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
 use ibc_test_framework::error::{handle_generic_error, Error};
 use ibc_test_framework::types::binary::chains::ConnectedChains;
@@ -98,7 +99,7 @@ where
         Default::default(),
     );
 
-    let birelay = TwoWayRelayContext::new(relay_a_to_b, relay_b_to_a);
+    let birelay = TwoWayRelayContext::new(ParallelTwoWayAutoRelay, relay_a_to_b, relay_b_to_a);
 
     // Ok(relay_a_to_b)
     Ok(birelay)

--- a/tools/integration-test/src/tests/next/context.rs
+++ b/tools/integration-test/src/tests/next/context.rs
@@ -2,9 +2,11 @@ use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer_cosmos::contexts::full::chain::FullCosmosChainContext;
 use ibc_relayer_cosmos::contexts::full::relay::new_relay_context_with_batch;
+use ibc_relayer_cosmos::full::all_for_one::birelay::AfoCosmosFullBiRelay;
 use ibc_relayer_cosmos::full::all_for_one::relay::AfoCosmosFullRelay;
 use ibc_relayer_cosmos::full::types::telemetry::{CosmosTelemetry, TelemetryState};
 use ibc_relayer_framework::base::one_for_all::types::runtime::OfaRuntimeWrapper;
+use ibc_relayer_framework::base::relay::types::two_way::TwoWayRelayContext;
 use ibc_relayer_framework::full::one_for_all::types::telemetry::OfaTelemetryWrapper;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
 use ibc_test_framework::error::{handle_generic_error, Error};
@@ -15,7 +17,7 @@ use std::collections::HashMap;
 pub fn build_cosmos_relay_context<ChainA, ChainB>(
     chains: &ConnectedChains<ChainA, ChainB>,
     filter: PacketFilter,
-) -> Result<impl AfoCosmosFullRelay, Error>
+) -> Result<impl AfoCosmosFullBiRelay, Error>
 where
     ChainA: ChainHandle,
     ChainB: ChainHandle,
@@ -77,15 +79,28 @@ where
         telemetry,
     );
 
-    let relay = new_relay_context_with_batch(
-        runtime,
-        chain_a,
-        chain_b,
+    let relay_a_to_b = new_relay_context_with_batch(
+        runtime.clone(),
+        chain_a.clone(),
+        chain_b.clone(),
         chains.foreign_clients.client_a_to_b.clone(),
         chains.foreign_clients.client_b_to_a.clone(),
+        filter.clone(),
+        Default::default(),
+    );
+
+    let relay_b_to_a = new_relay_context_with_batch(
+        runtime,
+        chain_b,
+        chain_a,
+        chains.foreign_clients.client_b_to_a.clone(),
+        chains.foreign_clients.client_a_to_b.clone(),
         filter,
         Default::default(),
     );
 
-    Ok(relay)
+    let birelay = TwoWayRelayContext::new(relay_a_to_b, relay_b_to_a);
+
+    // Ok(relay_a_to_b)
+    Ok(birelay)
 }

--- a/tools/integration-test/src/tests/next/context.rs
+++ b/tools/integration-test/src/tests/next/context.rs
@@ -3,7 +3,6 @@ use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer_cosmos::contexts::full::chain::FullCosmosChainContext;
 use ibc_relayer_cosmos::contexts::full::relay::new_relay_context_with_batch;
 use ibc_relayer_cosmos::full::all_for_one::birelay::AfoCosmosFullBiRelay;
-use ibc_relayer_cosmos::full::all_for_one::relay::AfoCosmosFullRelay;
 use ibc_relayer_cosmos::full::types::telemetry::{CosmosTelemetry, TelemetryState};
 use ibc_relayer_framework::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_framework::base::relay::types::two_way::TwoWayRelayContext;

--- a/tools/integration-test/src/tests/next/filter.rs
+++ b/tools/integration-test/src/tests/next/filter.rs
@@ -1,5 +1,6 @@
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer_framework::base::relay::traits::packet_relayer::CanRelayPacket;
+use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
 use ibc_test_framework::util::random::random_u64_range;
@@ -70,7 +71,13 @@ impl BinaryChannelTest for ChannelFilterTest {
 
         info!("running relayer");
 
-        runtime.block_on(async { relay_context.relay_packet(&packet).await.unwrap() });
+        runtime.block_on(async {
+            relay_context
+                .relay_a_to_b()
+                .relay_packet(&packet)
+                .await
+                .unwrap()
+        });
 
         info!("finished running relayer");
 

--- a/tools/integration-test/src/tests/next/timeout_transfer.rs
+++ b/tools/integration-test/src/tests/next/timeout_transfer.rs
@@ -7,6 +7,7 @@
 use ibc_relayer::config::PacketFilter;
 
 use ibc_relayer_framework::base::relay::traits::packet_relayer::CanRelayPacket;
+use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
 use ibc_test_framework::prelude::*;
 use ibc_test_framework::util::random::random_u64_range;
 
@@ -72,7 +73,13 @@ impl BinaryChannelTest for IbcTransferTest {
 
         sleep(Duration::from_secs(5));
 
-        runtime.block_on(async { relay_context.relay_packet(&packet).await.unwrap() });
+        runtime.block_on(async {
+            relay_context
+                .relay_a_to_b()
+                .relay_packet(&packet)
+                .await
+                .unwrap()
+        });
 
         info!("finished running relayer");
 

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -1,6 +1,8 @@
 use ibc_relayer::config::PacketFilter;
 
-use ibc_relayer_framework::base::relay::traits::auto_relayer::CanAutoRelay;
+use ibc_relayer_framework::base::relay::traits::auto_relayer::{AutoRelayer, CanAutoRelay};
+use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
+use ibc_relayer_framework::full::relay::impls::auto_relayers::parallel_two_way::ConcurrentTwoWayAutoRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
 use ibc_test_framework::util::random::random_u64_range;
@@ -35,7 +37,8 @@ impl BinaryChannelTest for IbcTransferTest {
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 
         runtime.spawn(async move {
-            relay_context.auto_relay().await;
+            relay_context.relay_a_to_b().auto_relay().await;
+            // ConcurrentTwoWayAutoRelay::auto_relay(&relay_context).await;
         });
 
         let denom_a = chains.node_a.denom();

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -1,7 +1,6 @@
 use ibc_relayer::config::PacketFilter;
 
-use ibc_relayer_framework::base::relay::traits::auto_relayer::{AutoRelayer, CanAutoRelay};
-use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
+use ibc_relayer_framework::base::relay::traits::auto_relayer::AutoRelayer;
 use ibc_relayer_framework::full::relay::impls::auto_relayers::parallel_two_way::ConcurrentTwoWayAutoRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
@@ -37,8 +36,7 @@ impl BinaryChannelTest for IbcTransferTest {
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 
         runtime.spawn(async move {
-            relay_context.relay_a_to_b().auto_relay().await;
-            // ConcurrentTwoWayAutoRelay::auto_relay(&relay_context).await;
+            ConcurrentTwoWayAutoRelay::auto_relay(&relay_context).await;
         });
 
         let denom_a = chains.node_a.denom();

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -1,7 +1,6 @@
 use ibc_relayer::config::PacketFilter;
 
-use ibc_relayer_framework::base::relay::traits::auto_relayer::AutoRelayer;
-use ibc_relayer_framework::full::relay::impls::auto_relayers::parallel_two_way::ConcurrentTwoWayAutoRelay;
+use ibc_relayer_framework::base::relay::traits::auto_relayer::CanAutoRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
 use ibc_test_framework::util::random::random_u64_range;
@@ -36,7 +35,7 @@ impl BinaryChannelTest for IbcTransferTest {
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 
         runtime.spawn(async move {
-            ConcurrentTwoWayAutoRelay::auto_relay(&relay_context).await;
+            relay_context.auto_relay().await;
         });
 
         let denom_a = chains.node_a.denom();


### PR DESCRIPTION
Closes: #3035

## Description

- Add a `HasTwoWayRelay` trait.
- Add a `TwoWayRelayContext` struct that implements `HasTwoWayRelay`.
- Implement `CanAutoRelay` for `TwoWayRelayContext`.
- Add all-for-one two-way relay traits.
- Refactor other all-for-one traits.
- Create two-way Cosmos relay context inside integration tests.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
