### PR TITLE
Replace `expect` calls in Chain Endpoint

### DIFF
--- a/crates/relayer/src/error.rs
+++ b/crates/relayer/src/error.rs
@@ -564,7 +564,10 @@ define_error! {
             { key_type: KeyType }
             |e| {
                 format!("Invalid key type {} for the current chain", e.key_type)
-            }
+            },
+
+        QueriedProofNotFound
+            |_| { "Requested proof with query but no proof was returned." },
     }
 }
 
@@ -674,9 +677,6 @@ fn parse_sequences_in_mismatch_error_message(message: &str) -> Option<(u64, u64)
         },
     }
 }
-
-pub const QUERY_PROOF_EXPECT_MSG: &str =
-    "Internal error. Requested proof with query but no proof was returned.";
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3082 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->
Removes the `expect` calls in `relayer/chain/endpoint` and replaces them with an error variant. 

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
