### PR TITLE
Fix bug where `Subscribe` command would sometimes get dropped in the event monitor

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/3070-listen-fix.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/3070-listen-fix.md
@@ -1,0 +1,4 @@
+- Fix bug where one could sometimes not subscribe to events.
+  This mostly affected the `listen` command but also external
+  consumers of events via the `EventMonitor` interface
+  ([\#3070](https://github.com/informalsystems/hermes/issues/3070))


### PR DESCRIPTION
Closes: #3070 

## Description

By checking whether the event monitor got a `Shutdown` command after processing an event bactch, the event monitor would drop the `Subscribe` command if one had been received instead in the meantime.

By dropping the check, and only shutting down the event monitor after having processed the last received batch, we ensure we do not drop such commands in the future.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
