### PR TITLE
test-framework: No passing `RUST_LOG` to chain config

### DIFF
--- a/tools/test-framework/src/bootstrap/single.rs
+++ b/tools/test-framework/src/bootstrap/single.rs
@@ -83,7 +83,7 @@ pub fn bootstrap_single_node(
 
     chain_driver.collect_gen_txs()?;
 
-    let log_level = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+    let log_level = std::env::var("CHAIN_LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
 
     chain_driver.update_chain_config("config.toml", |config| {
         config::set_log_level(config, &log_level)?;

--- a/tools/test-framework/src/lib.rs
+++ b/tools/test-framework/src/lib.rs
@@ -20,7 +20,9 @@
 //!     example_test
 //! ```
 //!
-//! The environment variable RUST_LOG controls the log level. The RUST_BACKTRACE variable
+//! The environment variable `RUST_LOG` controls log filtering for Hermes and,
+//! besides the global log level, can be used to pass more elaborate directives
+//! for the tracing framework. The `RUST_BACKTRACE` variable
 //! displays a backtrace when errors occur in a test. The test flag `--test-threads=1` is
 //! set so that tests are run serially (this makes it easier to follow what is going on
 //! via the log output). Take a look at the [`TestConfig`](crate::types::config::TestConfig)


### PR DESCRIPTION
Fixes #3114

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
