### PR TITLE
test-framework: Remove filtering for tracing modules

### DIFF
--- a/tools/test-framework/src/bootstrap/init.rs
+++ b/tools/test-framework/src/bootstrap/init.rs
@@ -10,8 +10,8 @@ use std::fs;
 use std::sync::Once;
 use tracing_subscriber::{
     self as ts,
-    filter::EnvFilter,
-    layer::{Layer, SubscriberExt},
+    filter::{EnvFilter, LevelFilter},
+    layer::SubscriberExt,
     util::SubscriberInitExt,
 };
 
@@ -82,16 +82,11 @@ fn parse_chain_command_paths(chain_command_path: String) -> Vec<String> {
 */
 pub fn install_logger(with_color: bool) {
     // Use log level INFO by default if RUST_LOG is not set.
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
 
-    let module_filter_fn = ts::filter::filter_fn(|metadata| match metadata.module_path() {
-        Some(path) => path.starts_with("ibc"),
-        None => false,
-    });
-
-    let layer = ts::fmt::layer()
-        .with_ansi(with_color)
-        .with_filter(module_filter_fn);
+    let layer = ts::fmt::layer().with_ansi(with_color);
 
     ts::registry().with(env_filter).with(layer).init();
 }


### PR DESCRIPTION
With a failing test, we might be interested in tracing from other
components, e.g. `tendermint_rpc`.
The default log level of "info" should keep logging from libraries
reasonably quiet, even when the output is not captured
by the test driver.

This brings the `RUST_LOG` environment variable treatment in tune to the documentation in test-framework's `lib.rs`.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
