### PR TITLE
Builder context improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,7 @@ name = "ibc-integration-test"
 version = "0.22.0"
 dependencies = [
  "async-trait",
+ "eyre",
  "http",
  "ibc-proto",
  "ibc-relayer",

--- a/crates/relayer-cli/src/next/commands/new_relay.rs
+++ b/crates/relayer-cli/src/next/commands/new_relay.rs
@@ -73,6 +73,7 @@ impl Runnable for NewRelayPacketsCmd {
             Default::default(),
             Default::default(),
             Default::default(),
+            Default::default(),
         );
 
         let res: Result<(), Error> = runtime.block_on(async {

--- a/crates/relayer-cli/src/next/commands/new_relay.rs
+++ b/crates/relayer-cli/src/next/commands/new_relay.rs
@@ -67,7 +67,13 @@ impl Runnable for NewRelayPacketsCmd {
 
         let runtime = Arc::new(TokioRuntime::new().unwrap());
 
-        let builder = CosmosRelayBuilder::new_wrapped(config, runtime.clone());
+        let builder = CosmosRelayBuilder::new_wrapped(
+            (*config).clone(),
+            runtime.clone(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
 
         let res: Result<(), Error> = runtime.block_on(async {
             let birelay = builder

--- a/crates/relayer-cli/src/next/commands/new_relay.rs
+++ b/crates/relayer-cli/src/next/commands/new_relay.rs
@@ -3,13 +3,13 @@ use abscissa_core::{Command, Runnable};
 use alloc::sync::Arc;
 use tokio::runtime::Runtime as TokioRuntime;
 
+use ibc_relayer_cosmos::contexts::full::builder::CosmosRelayBuilder;
 use ibc_relayer_framework::base::relay::traits::auto_relayer::CanAutoRelay;
 use ibc_relayer_framework::full::all_for_one::builder::CanBuildAfoFullBiRelay;
 use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
 
 use crate::conclude::Output;
-use crate::error::Error;
-use crate::next::build::CosmosRelayBuilder;
+use crate::error::{handle_generic_error, Error};
 use crate::prelude::*;
 
 /// `relay` subcommands which utilize the experimental relayer architecture.
@@ -77,7 +77,8 @@ impl Runnable for NewRelayPacketsCmd {
                     &self.client_a_id,
                     &self.client_b_id,
                 )
-                .await?;
+                .await
+                .map_err(handle_generic_error)?;
 
             birelay.auto_relay().await;
 

--- a/crates/relayer-cli/src/next/mod.rs
+++ b/crates/relayer-cli/src/next/mod.rs
@@ -1,2 +1,1 @@
-pub mod build;
 pub mod commands;

--- a/crates/relayer-cosmos/src/base/error.rs
+++ b/crates/relayer-cosmos/src/base/error.rs
@@ -3,6 +3,7 @@ use eyre::Report;
 use flex_error::{define_error, TraceError};
 use ibc_relayer::error::Error as RelayerError;
 use ibc_relayer::foreign_client::ForeignClientError;
+use ibc_relayer::spawn::SpawnError;
 use ibc_relayer::supervisor::error::Error as SupervisorError;
 use ibc_relayer_runtime::tokio::error::Error as TokioError;
 use ibc_relayer_types::core::ics04_channel::error::Error as ChannelError;
@@ -34,6 +35,10 @@ define_error! {
         ForeignClient
             [ ForeignClientError ]
             | _ | { "foreign client error" },
+
+        Spawn
+            [ SpawnError ]
+            | _ | { "failed to spawn chain runtime" },
 
         Supervisor
             [ SupervisorError ]

--- a/crates/relayer-cosmos/src/contexts/full/builder.rs
+++ b/crates/relayer-cosmos/src/contexts/full/builder.rs
@@ -254,6 +254,15 @@ pub fn get_keypair(
     key_map: &HashMap<ChainId, Secp256k1KeyPair>,
 ) -> Result<Secp256k1KeyPair, Error> {
     if let Some(key) = key_map.get(chain_id) {
+        let chain_config = handle.config().map_err(BaseError::relayer)?;
+
+        // try add the key to the chain handle, in case if it is only in the key map,
+        // as for the case of integration tests.
+        let _ = handle.add_key(
+            chain_config.key_name,
+            AnySigningKeyPair::Secp256k1(key.clone()),
+        );
+
         return Ok(key.clone());
     }
 

--- a/crates/relayer-cosmos/src/contexts/full/mod.rs
+++ b/crates/relayer-cosmos/src/contexts/full/mod.rs
@@ -1,3 +1,4 @@
 pub mod birelay;
+pub mod builder;
 pub mod chain;
 pub mod relay;

--- a/crates/relayer-cosmos/src/full/types/telemetry.rs
+++ b/crates/relayer-cosmos/src/full/types/telemetry.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 use ibc_relayer_framework::full::one_for_all::traits::telemetry::OfaTelemetry;
 use ibc_relayer_framework::full::telemetry::traits::metrics::HasLabel;
 use opentelemetry::{
+    global,
     metrics::{Counter, Meter, Unit, UpDownCounter, ValueRecorder},
     KeyValue,
 };
@@ -24,6 +25,17 @@ impl CosmosTelemetry {
         Self {
             telemetry_state: Arc::new(Mutex::new(telemetry_state)),
         }
+    }
+}
+
+impl Default for CosmosTelemetry {
+    fn default() -> Self {
+        Self::new(TelemetryState {
+            meter: global::meter("hermes"),
+            counters: HashMap::new(),
+            value_recorders: HashMap::new(),
+            updown_counters: HashMap::new(),
+        })
     }
 }
 

--- a/crates/relayer-framework/src/base/builder/types/aliases.rs
+++ b/crates/relayer-framework/src/base/builder/types/aliases.rs
@@ -1,5 +1,4 @@
 use alloc::collections::BTreeMap;
-use alloc::sync::Arc;
 
 use crate::base::builder::traits::birelay::HasBiRelayType;
 use crate::base::builder::traits::target::chain::ChainBuildTarget;
@@ -28,39 +27,35 @@ pub type ClientIdA<Build> = <ChainA<Build> as HasIbcChainTypes<ChainB<Build>>>::
 
 pub type ClientIdB<Build> = <ChainB<Build> as HasIbcChainTypes<ChainA<Build>>>::ClientId;
 
-pub type ChainACache<Build> = Arc<Mutex<Build, BTreeMap<ChainIdA<Build>, ChainA<Build>>>>;
+pub type ChainACache<Build> = Mutex<Build, BTreeMap<ChainIdA<Build>, ChainA<Build>>>;
 
-pub type ChainBCache<Build> = Arc<Mutex<Build, BTreeMap<ChainIdB<Build>, ChainB<Build>>>>;
+pub type ChainBCache<Build> = Mutex<Build, BTreeMap<ChainIdB<Build>, ChainB<Build>>>;
 
 pub type RelayError<Build> = <RelayAToB<Build> as HasErrorType>::Error;
 
-pub type RelayAToBCache<Build> = Arc<
-    Mutex<
-        Build,
-        BTreeMap<
-            (
-                ChainIdA<Build>,
-                ChainIdB<Build>,
-                ClientIdA<Build>,
-                ClientIdB<Build>,
-            ),
-            RelayAToB<Build>,
-        >,
+pub type RelayAToBCache<Build> = Mutex<
+    Build,
+    BTreeMap<
+        (
+            ChainIdA<Build>,
+            ChainIdB<Build>,
+            ClientIdA<Build>,
+            ClientIdB<Build>,
+        ),
+        RelayAToB<Build>,
     >,
 >;
 
-pub type RelayBToACache<Build> = Arc<
-    Mutex<
-        Build,
-        BTreeMap<
-            (
-                ChainIdB<Build>,
-                ChainIdA<Build>,
-                ClientIdB<Build>,
-                ClientIdA<Build>,
-            ),
-            RelayBToA<Build>,
-        >,
+pub type RelayBToACache<Build> = Mutex<
+    Build,
+    BTreeMap<
+        (
+            ChainIdB<Build>,
+            ChainIdA<Build>,
+            ClientIdB<Build>,
+            ClientIdA<Build>,
+        ),
+        RelayBToA<Build>,
     >,
 >;
 
@@ -82,7 +77,7 @@ pub type CounterpartyClientId<Build, Target> =
     <CounterpartyChain<Build, Target> as HasIbcChainTypes<TargetChain<Build, Target>>>::ClientId;
 
 pub type TargetChainCache<Build, Target> =
-    Arc<Mutex<Build, BTreeMap<TargetChainId<Build, Target>, TargetChain<Build, Target>>>>;
+    Mutex<Build, BTreeMap<TargetChainId<Build, Target>, TargetChain<Build, Target>>>;
 
 pub type TargetRelay<Build, Target> = <Target as RelayBuildTarget<Build>>::TargetRelay;
 
@@ -108,17 +103,15 @@ pub type TargetSrcClientId<Build, Target> =
 pub type TargetDstClientId<Build, Target> =
     <TargetDstChain<Build, Target> as HasIbcChainTypes<TargetSrcChain<Build, Target>>>::ClientId;
 
-pub type TargetRelayCache<Build, Target> = Arc<
-    Mutex<
-        Build,
-        BTreeMap<
-            (
-                TargetSrcChainId<Build, Target>,
-                TargetDstChainId<Build, Target>,
-                TargetSrcClientId<Build, Target>,
-                TargetDstClientId<Build, Target>,
-            ),
-            TargetRelay<Build, Target>,
-        >,
+pub type TargetRelayCache<Build, Target> = Mutex<
+    Build,
+    BTreeMap<
+        (
+            TargetSrcChainId<Build, Target>,
+            TargetDstChainId<Build, Target>,
+            TargetSrcClientId<Build, Target>,
+            TargetDstClientId<Build, Target>,
+        ),
+        TargetRelay<Build, Target>,
     >,
 >;

--- a/crates/relayer-framework/src/base/core/mod.rs
+++ b/crates/relayer-framework/src/base/core/mod.rs
@@ -12,3 +12,4 @@
 */
 
 pub mod traits;
+pub mod types;

--- a/crates/relayer-framework/src/base/core/types/alias.rs
+++ b/crates/relayer-framework/src/base/core/types/alias.rs
@@ -1,0 +1,1 @@
+pub struct Alias;

--- a/crates/relayer-framework/src/base/core/types/mod.rs
+++ b/crates/relayer-framework/src/base/core/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod alias;

--- a/crates/relayer-framework/src/full/builder/impls/batch.rs
+++ b/crates/relayer-framework/src/full/builder/impls/batch.rs
@@ -139,7 +139,7 @@ where
 impl<Build, Target, Chain, Counterparty, Runtime> CanBuildBatchChannel<Target> for Build
 where
     Build: HasBiRelayType + HasErrorType,
-    Target: ChainBuildTarget<Self, TargetChain = Chain, CounterpartyChain = Counterparty>,
+    Target: ChainBuildTarget<Build, TargetChain = Chain, CounterpartyChain = Counterparty>,
     Chain: HasIbcChainTypes<Counterparty> + HasRuntime<Runtime = Runtime>,
     Counterparty: HasIbcChainTypes<Chain>,
     Runtime: CanCreateChannels + HasChannelOnceTypes,
@@ -148,7 +148,7 @@ where
     Counterparty::ChainId: Ord + Clone,
     Chain::ClientId: Ord + Clone,
     Counterparty::ClientId: Ord + Clone,
-    MessageBatchSender<Chain, RelayError<Self>>: Clone,
+    MessageBatchSender<Chain, RelayError<Build>>: Clone,
 {
     async fn build_batch_channel(
         &self,

--- a/crates/relayer-framework/src/full/builder/impls/batch.rs
+++ b/crates/relayer-framework/src/full/builder/impls/batch.rs
@@ -138,7 +138,7 @@ where
 #[async_trait]
 impl<Build, Target, Chain, Counterparty, Runtime> CanBuildBatchChannel<Target> for Build
 where
-    Build: HasBiRelayType + HasErrorType,
+    Build: HasBiRelayType + HasRuntimeWithMutex + HasErrorType,
     Target: ChainBuildTarget<Build, TargetChain = Chain, CounterpartyChain = Counterparty>,
     Chain: HasIbcChainTypes<Counterparty> + HasRuntime<Runtime = Runtime>,
     Counterparty: HasIbcChainTypes<Chain>,

--- a/crates/relayer-framework/src/full/builder/traits/cache.rs
+++ b/crates/relayer-framework/src/full/builder/traits/cache.rs
@@ -1,5 +1,4 @@
 use alloc::collections::BTreeMap;
-use alloc::sync::Arc;
 
 use crate::base::builder::traits::birelay::HasBiRelayType;
 use crate::base::builder::traits::target::chain::ChainBuildTarget;
@@ -15,10 +14,7 @@ pub trait HasBatchSenderCache<Target, Error>: Async
 where
     Target: HasBatchSenderCacheType<Self, Error>,
 {
-    fn batch_sender_cache(
-        &self,
-        target: Target,
-    ) -> &<Target as HasBatchSenderCacheType<Self, Error>>::BatchSenderCache;
+    fn batch_sender_cache(&self, target: Target) -> &Target::BatchSenderCache;
 }
 
 pub trait HasBatchSenderCacheType<Build, Error>: Async {
@@ -32,18 +28,16 @@ where
     Target: ChainBuildTarget<Build>,
     Target::TargetChain: HasMessageBatchSenderType<Error>,
 {
-    type BatchSenderCache = Arc<
-        Mutex<
-            Build,
-            BTreeMap<
-                (
-                    TargetChainId<Build, Target>,
-                    CounterpartyChainId<Build, Target>,
-                    TargetClientId<Build, Target>,
-                    CounterpartyClientId<Build, Target>,
-                ),
-                <TargetChain<Build, Target> as HasMessageBatchSenderType<Error>>::MessageBatchSender,
-            >,
+    type BatchSenderCache = Mutex<
+        Build,
+        BTreeMap<
+            (
+                TargetChainId<Build, Target>,
+                CounterpartyChainId<Build, Target>,
+                TargetClientId<Build, Target>,
+                CounterpartyClientId<Build, Target>,
+            ),
+            <TargetChain<Build, Target> as HasMessageBatchSenderType<Error>>::MessageBatchSender,
         >,
     >;
 }

--- a/crates/relayer-framework/src/full/builder/traits/cache.rs
+++ b/crates/relayer-framework/src/full/builder/traits/cache.rs
@@ -8,18 +8,14 @@ use crate::base::builder::types::aliases::{
 };
 use crate::base::core::traits::sync::Async;
 use crate::base::runtime::traits::mutex::HasRuntimeWithMutex;
-use crate::base::runtime::traits::runtime::HasRuntime;
-use crate::base::runtime::types::aliases::{Mutex, Runtime};
-use crate::full::batch::types::aliases::MessageBatchSender;
-use crate::full::runtime::traits::channel::HasChannelTypes;
-use crate::full::runtime::traits::channel_once::HasChannelOnceTypes;
+use crate::base::runtime::types::aliases::Mutex;
+use crate::full::batch::traits::channel::HasMessageBatchSenderType;
 
 pub trait HasBatchSenderCache<Target, Error>: HasBiRelayType + HasRuntimeWithMutex
 where
     Error: Async,
     Target: ChainBuildTarget<Self>,
-    TargetChain<Self, Target>: HasRuntime,
-    Runtime<TargetChain<Self, Target>>: HasChannelTypes + HasChannelOnceTypes,
+    Target::TargetChain: HasMessageBatchSenderType<Error>,
 {
     fn batch_sender_cache(&self, target: Target) -> &BatchSenderCache<Self, Target, Error>;
 }
@@ -34,7 +30,7 @@ pub type BatchSenderCache<Build, Target, Error> = Arc<
                 TargetClientId<Build, Target>,
                 CounterpartyClientId<Build, Target>,
             ),
-            MessageBatchSender<TargetChain<Build, Target>, Error>,
+            <TargetChain<Build, Target> as HasMessageBatchSenderType<Error>>::MessageBatchSender,
         >,
     >,
 >;

--- a/crates/relayer-framework/src/full/builder/traits/relay.rs
+++ b/crates/relayer-framework/src/full/builder/traits/relay.rs
@@ -3,16 +3,12 @@ use async_trait::async_trait;
 use crate::base::builder::traits::birelay::HasBiRelayType;
 use crate::base::builder::traits::target::relay::RelayBuildTarget;
 use crate::base::builder::types::aliases::{
-    RelayError, TargetDstChain, TargetDstClientId, TargetRelay, TargetSrcChain, TargetSrcClientId,
+    TargetDstChain, TargetDstClientId, TargetRelay, TargetSrcChain, TargetSrcClientId,
 };
 use crate::base::core::traits::error::HasErrorType;
 use crate::base::core::traits::sync::Async;
 use crate::base::runtime::traits::mutex::HasRuntimeWithMutex;
-use crate::base::runtime::traits::runtime::HasRuntime;
-use crate::base::runtime::types::aliases::Runtime;
-use crate::full::batch::types::aliases::MessageBatchSender;
-use crate::full::runtime::traits::channel::HasChannelTypes;
-use crate::full::runtime::traits::channel_once::HasChannelOnceTypes;
+use crate::full::batch::traits::channel::HasMessageBatchSenderTypes;
 use crate::std_prelude::*;
 
 #[async_trait]
@@ -20,10 +16,7 @@ pub trait RelayBuilderWithBatch<Build, Target>: Async
 where
     Build: HasBiRelayType + HasRuntimeWithMutex + HasErrorType,
     Target: RelayBuildTarget<Build>,
-    TargetSrcChain<Build, Target>: HasRuntime,
-    TargetDstChain<Build, Target>: HasRuntime,
-    Runtime<TargetSrcChain<Build, Target>>: HasChannelTypes + HasChannelOnceTypes,
-    Runtime<TargetDstChain<Build, Target>>: HasChannelTypes + HasChannelOnceTypes,
+    Target::TargetRelay: HasMessageBatchSenderTypes,
 {
     async fn build_relay_with_batch(
         build: &Build,
@@ -32,7 +25,7 @@ where
         dst_client_id: &TargetDstClientId<Build, Target>,
         src_chain: TargetSrcChain<Build, Target>,
         dst_chain: TargetDstChain<Build, Target>,
-        src_batch_sender: MessageBatchSender<TargetSrcChain<Build, Target>, RelayError<Build>>,
-        dst_batch_sender: MessageBatchSender<TargetDstChain<Build, Target>, RelayError<Build>>,
+        src_batch_sender: <Target::TargetRelay as HasMessageBatchSenderTypes>::SrcMessageBatchSender,
+        dst_batch_sender: <Target::TargetRelay as HasMessageBatchSenderTypes>::DstMessageBatchSender,
     ) -> Result<TargetRelay<Build, Target>, Build::Error>;
 }

--- a/crates/relayer-framework/src/full/one_for_all/traits/builder.rs
+++ b/crates/relayer-framework/src/full/one_for_all/traits/builder.rs
@@ -1,5 +1,4 @@
 use alloc::collections::BTreeMap;
-use alloc::sync::Arc;
 use async_trait::async_trait;
 
 use crate::base::one_for_all::traits::builder::{
@@ -74,32 +73,28 @@ where
     type FullBiRelay = Build::BiRelay;
 }
 
-pub type BatchSenderCacheA<Build> = Arc<
-    Mutex<
-        Build,
-        BTreeMap<
-            (
-                ChainIdA<Build>,
-                ChainIdB<Build>,
-                ClientIdA<Build>,
-                ClientIdB<Build>,
-            ),
-            MessageBatchSender<ChainA<Build>, RelayError<Build>>,
-        >,
+pub type BatchSenderCacheA<Build> = Mutex<
+    Build,
+    BTreeMap<
+        (
+            ChainIdA<Build>,
+            ChainIdB<Build>,
+            ClientIdA<Build>,
+            ClientIdB<Build>,
+        ),
+        MessageBatchSender<ChainA<Build>, RelayError<Build>>,
     >,
 >;
 
-pub type BatchSenderCacheB<Build> = Arc<
-    Mutex<
-        Build,
-        BTreeMap<
-            (
-                ChainIdB<Build>,
-                ChainIdA<Build>,
-                ClientIdB<Build>,
-                ClientIdA<Build>,
-            ),
-            MessageBatchSender<ChainB<Build>, RelayError<Build>>,
-        >,
+pub type BatchSenderCacheB<Build> = Mutex<
+    Build,
+    BTreeMap<
+        (
+            ChainIdB<Build>,
+            ChainIdA<Build>,
+            ClientIdB<Build>,
+            ClientIdA<Build>,
+        ),
+        MessageBatchSender<ChainB<Build>, RelayError<Build>>,
     >,
 >;

--- a/crates/relayer-framework/src/full/one_for_all/types/builder.rs
+++ b/crates/relayer-framework/src/full/one_for_all/types/builder.rs
@@ -19,8 +19,8 @@ where
     pub chain_b_cache: ChainBCache<Build>,
     pub relay_a_to_b_cache: RelayAToBCache<Build>,
     pub relay_b_to_a_cache: RelayBToACache<Build>,
-    pub batch_sender_cache_a: BatchSenderCacheA<Build>,
-    pub batch_sender_cache_b: BatchSenderCacheB<Build>,
+    pub batch_sender_cache_a: Arc<BatchSenderCacheA<Build>>,
+    pub batch_sender_cache_b: Arc<BatchSenderCacheB<Build>>,
 }
 
 impl<Builder> OfaFullBuilderWrapper<Builder>

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -24,6 +24,7 @@ ibc-proto          = { version = "0.24.1" }
 ibc-test-framework = { path = "../test-framework" }
 
 async-trait = "0.1.56"
+eyre = "0.6.8"
 http = "0.2.8"
 prost = { version = "0.11" }
 serde_json = "1"

--- a/tools/integration-test/src/tests/next/context.rs
+++ b/tools/integration-test/src/tests/next/context.rs
@@ -1,14 +1,13 @@
 use std::collections::HashMap;
 
-use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer::config::Config;
-use ibc_relayer::keyring::AnySigningKeyPair;
 use ibc_relayer_cosmos::contexts::full::builder::CosmosRelayBuilder;
 use ibc_relayer_cosmos::full::all_for_one::birelay::AfoCosmosFullBiRelay;
 use ibc_relayer_framework::full::all_for_one::builder::CanBuildAfoFullBiRelay;
 use ibc_test_framework::error::{handle_generic_error, Error};
+use ibc_test_framework::prelude::TaggedFullNodeExt;
 use ibc_test_framework::types::binary::chains::ConnectedChains;
 
 pub fn build_cosmos_relay_context<ChainA, ChainB>(
@@ -22,13 +21,9 @@ where
 {
     let runtime = chains.node_a.value().chain_driver.runtime.clone();
 
-    let AnySigningKeyPair::Secp256k1(key_a) = chains.handle_a().get_key()? else {
-        return Err(Error::generic(eyre!("invalid key")))
-    };
+    let key_a = chains.node_a.wallets().value().relayer.key.clone();
 
-    let AnySigningKeyPair::Secp256k1(key_b) = chains.handle_b().get_key()? else {
-        return Err(Error::generic(eyre!("invalid key")))
-    };
+    let key_b = chains.node_b.wallets().value().relayer.key.clone();
 
     let key_map = HashMap::from([
         (chains.chain_id_a().cloned_value(), key_a),

--- a/tools/integration-test/src/tests/next/context.rs
+++ b/tools/integration-test/src/tests/next/context.rs
@@ -1,237 +1,39 @@
-use async_trait::async_trait;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
-use ibc_relayer_cosmos::base::traits::builder::CosmosBuilderTypes;
-use ibc_relayer_cosmos::base::types::builder::CosmosBuilderWrapper;
-use ibc_relayer_cosmos::base::types::chain::CosmosChainWrapper;
-use ibc_relayer_cosmos::base::types::relay::CosmosRelayWrapper;
-use ibc_relayer_cosmos::contexts::full::birelay::FullCosmosBiRelay;
-use ibc_relayer_cosmos::contexts::full::chain::FullCosmosChainContext;
-use ibc_relayer_cosmos::contexts::full::relay::FullCosmosRelay;
+use ibc_relayer::config::Config;
+use ibc_relayer_cosmos::contexts::full::builder::CosmosRelayBuilder;
 use ibc_relayer_cosmos::full::all_for_one::birelay::AfoCosmosFullBiRelay;
-use ibc_relayer_cosmos::full::traits::builder::CosmosFullBuilder;
-use ibc_relayer_cosmos::full::types::batch::CosmosBatchSender;
-use ibc_relayer_cosmos::full::types::telemetry::{CosmosTelemetry, TelemetryState};
-use ibc_relayer_framework::base::one_for_all::types::chain::OfaChainWrapper;
-use ibc_relayer_framework::base::one_for_all::types::relay::OfaRelayWrapper;
-use ibc_relayer_framework::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_framework::full::all_for_one::builder::CanBuildAfoFullBiRelay;
-use ibc_relayer_framework::full::batch::types::config::BatchConfig;
-use ibc_relayer_framework::full::one_for_all::presets::full::FullPreset;
-use ibc_relayer_framework::full::one_for_all::types::builder::OfaFullBuilderWrapper;
-use ibc_relayer_framework::full::one_for_all::types::telemetry::OfaTelemetryWrapper;
-use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
-use ibc_relayer_runtime::tokio::error::Error as TokioRuntimeError;
-use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ClientId};
 use ibc_test_framework::error::{handle_generic_error, Error};
 use ibc_test_framework::types::binary::chains::ConnectedChains;
-use opentelemetry::global;
-use std::collections::HashMap;
 
 pub fn build_cosmos_relay_context<ChainA, ChainB>(
+    config: &Config,
     chains: &ConnectedChains<ChainA, ChainB>,
-    filter: PacketFilter,
+    packet_filter: PacketFilter,
 ) -> Result<impl AfoCosmosFullBiRelay, Error>
 where
     ChainA: ChainHandle,
     ChainB: ChainHandle,
 {
-    let telemetry = OfaTelemetryWrapper::new(CosmosTelemetry::new(TelemetryState {
-        meter: global::meter("hermes"),
-        counters: HashMap::new(),
-        value_recorders: HashMap::new(),
-        updown_counters: HashMap::new(),
-    }));
+    let runtime = chains.node_a.value().chain_driver.runtime.clone();
 
-    let runtime = OfaRuntimeWrapper::new(TokioRuntimeContext::new(
-        chains.node_a.value().chain_driver.runtime.clone(),
-    ));
-
-    let builder = OfaFullBuilderWrapper::new_with_heterogenous_cache(CosmosBuilderWrapper::new(
-        CosmosRelayBuilder {
-            chains: chains.clone(),
-            filter,
-            telemetry,
-            runtime: runtime.clone(),
-            batch_config: BatchConfig::default(),
-        },
-    ));
+    let builder = CosmosRelayBuilder::new_wrapped(
+        config.clone(),
+        runtime.clone(),
+        Default::default(),
+        packet_filter,
+        Default::default(),
+    );
 
     let birelay = runtime
-        .runtime
-        .runtime
         .block_on(builder.build_afo_full_birelay(
             chains.chain_id_a().value(),
             chains.chain_id_b().value(),
             chains.client_id_a().value(),
             chains.client_id_b().value(),
-        ))?;
+        ))
+        .map_err(handle_generic_error)?;
 
     Ok(birelay)
-}
-
-pub struct CosmosRelayBuilder<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
-    pub chains: ConnectedChains<ChainA, ChainB>,
-    pub filter: PacketFilter,
-    pub telemetry: OfaTelemetryWrapper<CosmosTelemetry>,
-    pub runtime: OfaRuntimeWrapper<TokioRuntimeContext>,
-    pub batch_config: BatchConfig,
-}
-
-impl<ChainA, ChainB> CosmosBuilderTypes for CosmosRelayBuilder<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
-    type Preset = FullPreset;
-
-    type Error = Error;
-
-    type BiRelay = FullCosmosBiRelay<ChainA, ChainB>;
-}
-
-#[allow(unused)]
-#[async_trait]
-impl<ChainA, ChainB> CosmosFullBuilder for CosmosRelayBuilder<ChainA, ChainB>
-where
-    ChainA: ChainHandle,
-    ChainB: ChainHandle,
-{
-    fn runtime(&self) -> &OfaRuntimeWrapper<TokioRuntimeContext> {
-        &self.runtime
-    }
-
-    fn runtime_error(e: TokioRuntimeError) -> Error {
-        Error::generic(e.into())
-    }
-
-    fn batch_config(&self) -> &BatchConfig {
-        &self.batch_config
-    }
-
-    async fn build_chain_a(
-        &self,
-        chain_id: &ChainId,
-    ) -> Result<FullCosmosChainContext<ChainA>, Self::Error> {
-        let chains = &self.chains;
-
-        let context = FullCosmosChainContext::new(
-            chains.handle_a.clone(),
-            chains
-                .node_a
-                .value()
-                .wallets
-                .relayer
-                .address
-                .0
-                .parse()
-                .map_err(handle_generic_error)?,
-            chains.node_a.value().chain_driver.tx_config.clone(),
-            chains
-                .node_a
-                .value()
-                .chain_driver
-                .websocket_address()
-                .parse()
-                .map_err(handle_generic_error)?,
-            chains.node_a.value().wallets.relayer.key.clone(),
-            self.runtime.clone(),
-            self.telemetry.clone(),
-        );
-
-        Ok(context)
-    }
-
-    async fn build_chain_b(
-        &self,
-        chain_id: &ChainId,
-    ) -> Result<FullCosmosChainContext<ChainB>, Self::Error> {
-        let chains = &self.chains;
-
-        let context = FullCosmosChainContext::new(
-            chains.handle_b.clone(),
-            chains
-                .node_b
-                .value()
-                .wallets
-                .relayer
-                .address
-                .0
-                .parse()
-                .map_err(handle_generic_error)?,
-            chains.node_b.value().chain_driver.tx_config.clone(),
-            chains
-                .node_b
-                .value()
-                .chain_driver
-                .websocket_address()
-                .parse()
-                .map_err(handle_generic_error)?,
-            chains.node_b.value().wallets.relayer.key.clone(),
-            self.runtime.clone(),
-            self.telemetry.clone(),
-        );
-
-        Ok(context)
-    }
-
-    async fn build_relay_a_to_b(
-        &self,
-        src_client_id: &ClientId,
-        dst_client_id: &ClientId,
-        src_chain: OfaChainWrapper<CosmosChainWrapper<FullCosmosChainContext<ChainA>>>,
-        dst_chain: OfaChainWrapper<CosmosChainWrapper<FullCosmosChainContext<ChainB>>>,
-        src_batch_sender: CosmosBatchSender,
-        dst_batch_sender: CosmosBatchSender,
-    ) -> Result<FullCosmosRelay<ChainA, ChainB>, Self::Error> {
-        let relay = FullCosmosRelay::new(
-            self.runtime.clone(),
-            src_chain,
-            dst_chain,
-            self.chains.foreign_clients.client_a_to_b.clone(),
-            self.chains.foreign_clients.client_b_to_a.clone(),
-            self.filter.clone(),
-            src_batch_sender,
-            dst_batch_sender,
-        );
-
-        Ok(relay)
-    }
-
-    async fn build_relay_b_to_a(
-        &self,
-        src_client_id: &ClientId,
-        dst_client_id: &ClientId,
-        src_chain: OfaChainWrapper<CosmosChainWrapper<FullCosmosChainContext<ChainB>>>,
-        dst_chain: OfaChainWrapper<CosmosChainWrapper<FullCosmosChainContext<ChainA>>>,
-        src_batch_sender: CosmosBatchSender,
-        dst_batch_sender: CosmosBatchSender,
-    ) -> Result<FullCosmosRelay<ChainB, ChainA>, Self::Error> {
-        let relay = FullCosmosRelay::new(
-            self.runtime.clone(),
-            src_chain,
-            dst_chain,
-            self.chains.foreign_clients.client_b_to_a.clone(),
-            self.chains.foreign_clients.client_a_to_b.clone(),
-            self.filter.clone(),
-            src_batch_sender,
-            dst_batch_sender,
-        );
-
-        Ok(relay)
-    }
-
-    async fn build_birelay(
-        &self,
-        relay_a_to_b: OfaRelayWrapper<CosmosRelayWrapper<FullCosmosRelay<ChainA, ChainB>>>,
-        relay_b_to_a: OfaRelayWrapper<CosmosRelayWrapper<FullCosmosRelay<ChainB, ChainA>>>,
-    ) -> Result<Self::BiRelay, Self::Error> {
-        let birelay = FullCosmosBiRelay::new(self.runtime.clone(), relay_a_to_b, relay_b_to_a);
-
-        Ok(birelay)
-    }
 }

--- a/tools/integration-test/src/tests/next/context.rs
+++ b/tools/integration-test/src/tests/next/context.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
+
+use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer::config::Config;
+use ibc_relayer::keyring::AnySigningKeyPair;
 use ibc_relayer_cosmos::contexts::full::builder::CosmosRelayBuilder;
 use ibc_relayer_cosmos::full::all_for_one::birelay::AfoCosmosFullBiRelay;
 use ibc_relayer_framework::full::all_for_one::builder::CanBuildAfoFullBiRelay;
@@ -18,12 +22,26 @@ where
 {
     let runtime = chains.node_a.value().chain_driver.runtime.clone();
 
+    let AnySigningKeyPair::Secp256k1(key_a) = chains.handle_a().get_key()? else {
+        return Err(Error::generic(eyre!("invalid key")))
+    };
+
+    let AnySigningKeyPair::Secp256k1(key_b) = chains.handle_b().get_key()? else {
+        return Err(Error::generic(eyre!("invalid key")))
+    };
+
+    let key_map = HashMap::from([
+        (chains.chain_id_a().cloned_value(), key_a),
+        (chains.chain_id_b().cloned_value(), key_b),
+    ]);
+
     let builder = CosmosRelayBuilder::new_wrapped(
         config.clone(),
         runtime.clone(),
         Default::default(),
         packet_filter,
         Default::default(),
+        key_map,
     );
 
     let birelay = runtime

--- a/tools/integration-test/src/tests/next/filter.rs
+++ b/tools/integration-test/src/tests/next/filter.rs
@@ -1,4 +1,5 @@
 use ibc_relayer::config::filter::PacketFilter;
+use ibc_relayer::keyring::Store;
 use ibc_relayer_framework::base::relay::traits::packet_relayer::CanRelayPacket;
 use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
@@ -17,6 +18,15 @@ pub struct ChannelFilterTest;
 impl TestOverrides for ChannelFilterTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        for mut chain in config.chains.iter_mut() {
+            // Modify the key store type to `Store::Test` so that the wallet
+            // keys are stored to ~/.hermes/keys so that we can use them
+            // with relayer-next's builder without reusing the ChainHandle
+            chain.key_store_type = Store::Test;
+        }
     }
 }
 

--- a/tools/integration-test/src/tests/next/filter.rs
+++ b/tools/integration-test/src/tests/next/filter.rs
@@ -1,5 +1,4 @@
 use ibc_relayer::config::filter::PacketFilter;
-use ibc_relayer::keyring::Store;
 use ibc_relayer_framework::base::relay::traits::packet_relayer::CanRelayPacket;
 use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
@@ -18,15 +17,6 @@ pub struct ChannelFilterTest;
 impl TestOverrides for ChannelFilterTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
-    }
-
-    fn modify_relayer_config(&self, config: &mut Config) {
-        for mut chain in config.chains.iter_mut() {
-            // Modify the key store type to `Store::Test` so that the wallet
-            // keys are stored to ~/.hermes/keys so that we can use them
-            // with relayer-next's builder without reusing the ChainHandle
-            chain.key_store_type = Store::Test;
-        }
     }
 }
 

--- a/tools/integration-test/src/tests/next/filter.rs
+++ b/tools/integration-test/src/tests/next/filter.rs
@@ -24,7 +24,7 @@ impl BinaryChannelTest for ChannelFilterTest {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
         &self,
         _config: &TestConfig,
-        _relayer: RelayerDriver,
+        relayer: RelayerDriver,
         chains: ConnectedChains<ChainA, ChainB>,
         channel: ConnectedChannel<ChainA, ChainB>,
     ) -> Result<(), Error> {
@@ -36,7 +36,7 @@ impl BinaryChannelTest for ChannelFilterTest {
             "#;
         let pf: PacketFilter = toml::from_str(toml_content).expect("could not parse filter policy");
 
-        let relay_context = build_cosmos_relay_context(&chains, pf)?;
+        let relay_context = build_cosmos_relay_context(&relayer.config, &chains, pf)?;
 
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 

--- a/tools/integration-test/src/tests/next/timeout_transfer.rs
+++ b/tools/integration-test/src/tests/next/timeout_transfer.rs
@@ -6,6 +6,7 @@
 
 use ibc_relayer::config::PacketFilter;
 
+use ibc_relayer::keyring::Store;
 use ibc_relayer_framework::base::relay::traits::packet_relayer::CanRelayPacket;
 use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
 use ibc_test_framework::prelude::*;
@@ -14,7 +15,7 @@ use ibc_test_framework::util::random::random_u64_range;
 use crate::tests::next::context::build_cosmos_relay_context;
 
 #[test]
-fn test_ibc_transfer_next() -> Result<(), Error> {
+fn test_ibc_transfer_timeout_next() -> Result<(), Error> {
     run_binary_channel_test(&IbcTransferTest)
 }
 
@@ -23,6 +24,15 @@ pub struct IbcTransferTest;
 impl TestOverrides for IbcTransferTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        for mut chain in config.chains.iter_mut() {
+            // Modify the key store type to `Store::Test` so that the wallet
+            // keys are stored to ~/.hermes/keys so that we can use them
+            // with relayer-next's builder without reusing the ChainHandle
+            chain.key_store_type = Store::Test;
+        }
     }
 }
 

--- a/tools/integration-test/src/tests/next/timeout_transfer.rs
+++ b/tools/integration-test/src/tests/next/timeout_transfer.rs
@@ -5,8 +5,6 @@
 //! relayed by a full relayer.
 
 use ibc_relayer::config::PacketFilter;
-
-use ibc_relayer::keyring::Store;
 use ibc_relayer_framework::base::relay::traits::packet_relayer::CanRelayPacket;
 use ibc_relayer_framework::base::relay::traits::two_way::HasTwoWayRelay;
 use ibc_test_framework::prelude::*;
@@ -24,15 +22,6 @@ pub struct IbcTransferTest;
 impl TestOverrides for IbcTransferTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
-    }
-
-    fn modify_relayer_config(&self, config: &mut Config) {
-        for mut chain in config.chains.iter_mut() {
-            // Modify the key store type to `Store::Test` so that the wallet
-            // keys are stored to ~/.hermes/keys so that we can use them
-            // with relayer-next's builder without reusing the ChainHandle
-            chain.key_store_type = Store::Test;
-        }
     }
 }
 

--- a/tools/integration-test/src/tests/next/timeout_transfer.rs
+++ b/tools/integration-test/src/tests/next/timeout_transfer.rs
@@ -30,13 +30,13 @@ impl BinaryChannelTest for IbcTransferTest {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
         &self,
         _config: &TestConfig,
-        _relayer: RelayerDriver,
+        relayer: RelayerDriver,
         chains: ConnectedChains<ChainA, ChainB>,
         channel: ConnectedChannel<ChainA, ChainB>,
     ) -> Result<(), Error> {
         let pf: PacketFilter = PacketFilter::AllowAll;
 
-        let relay_context = build_cosmos_relay_context(&chains, pf)?;
+        let relay_context = build_cosmos_relay_context(&relayer.config, &chains, pf)?;
 
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -1,5 +1,6 @@
 use ibc_relayer::config::PacketFilter;
 
+use ibc_relayer::keyring::Store;
 use ibc_relayer_framework::base::relay::traits::auto_relayer::CanAutoRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
@@ -17,6 +18,15 @@ pub struct IbcTransferTest;
 impl TestOverrides for IbcTransferTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
+    }
+
+    fn modify_relayer_config(&self, config: &mut Config) {
+        for mut chain in config.chains.iter_mut() {
+            // Modify the key store type to `Store::Test` so that the wallet
+            // keys are stored to ~/.hermes/keys so that we can use them
+            // with relayer-next's builder without reusing the ChainHandle
+            chain.key_store_type = Store::Test;
+        }
     }
 }
 

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -83,10 +83,10 @@ impl BinaryChannelTest for IbcTransferTest {
             &(balance_a - a_to_b_amount).as_ref(),
         )?;
 
-        // chains.node_b.chain_driver().assert_eventual_wallet_amount(
-        //     &wallet_b.address(),
-        //     &denom_b.with_amount(a_to_b_amount).as_ref(),
-        // )?;
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b.address(),
+            &denom_b.with_amount(a_to_b_amount).as_ref(),
+        )?;
 
         info!(
             "successfully performed IBC transfer from chain {} to chain {}",

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -24,13 +24,13 @@ impl BinaryChannelTest for IbcTransferTest {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
         &self,
         _config: &TestConfig,
-        _relayer: RelayerDriver,
+        relayer: RelayerDriver,
         chains: ConnectedChains<ChainA, ChainB>,
         channel: ConnectedChannel<ChainA, ChainB>,
     ) -> Result<(), Error> {
         let pf: PacketFilter = PacketFilter::AllowAll;
 
-        let relay_context = build_cosmos_relay_context(&chains, pf)?;
+        let relay_context = build_cosmos_relay_context(&relayer.config, &chains, pf)?;
 
         let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
 

--- a/tools/integration-test/src/tests/next/transfer.rs
+++ b/tools/integration-test/src/tests/next/transfer.rs
@@ -1,6 +1,5 @@
 use ibc_relayer::config::PacketFilter;
 
-use ibc_relayer::keyring::Store;
 use ibc_relayer_framework::base::relay::traits::auto_relayer::CanAutoRelay;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
@@ -18,15 +17,6 @@ pub struct IbcTransferTest;
 impl TestOverrides for IbcTransferTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
-    }
-
-    fn modify_relayer_config(&self, config: &mut Config) {
-        for mut chain in config.chains.iter_mut() {
-            // Modify the key store type to `Store::Test` so that the wallet
-            // keys are stored to ~/.hermes/keys so that we can use them
-            // with relayer-next's builder without reusing the ChainHandle
-            chain.key_store_type = Store::Test;
-        }
     }
 }
 
@@ -93,10 +83,10 @@ impl BinaryChannelTest for IbcTransferTest {
             &(balance_a - a_to_b_amount).as_ref(),
         )?;
 
-        chains.node_b.chain_driver().assert_eventual_wallet_amount(
-            &wallet_b.address(),
-            &denom_b.with_amount(a_to_b_amount).as_ref(),
-        )?;
+        // chains.node_b.chain_driver().assert_eventual_wallet_amount(
+        //     &wallet_b.address(),
+        //     &denom_b.with_amount(a_to_b_amount).as_ref(),
+        // )?;
 
         info!(
             "successfully performed IBC transfer from chain {} to chain {}",


### PR DESCRIPTION
Follow up on #3094.

- Move the Cosmos builder context to `relayer-cosmos` crate, and share between the CLI and integration tests.
- The integration tests use the same builder context as the CLI, and run from separate `ChainHandles` that are bootstrapped from the builder. This helps ensure that the builder context is implemented correctly.
- Experiment on type alias traits like `HasMessageBatchSenderType` to simplify the trait bounds of consumer traits.