### PR TITLE
Improve min gas price error message

### DIFF
--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -2005,8 +2005,9 @@ fn do_health_check(chain: &CosmosSdkChain) -> Result<(), Error> {
         if !found_matching_denom {
             warn!(
                 "Chain '{}' has no minimum gas price of denomination '{}' 
-                that is strictly less than the `gas_price` configured in 
-                Hermes' config.toml",
+                that is strictly less than the `gas_price` specified for
+                that chain in the Hermes configuration.
+                This is usually a sign of misconfiguration, please check your chain and Hermes configurations",
                 chain_id, relayer_gas_price.denom
             );
         }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3159 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->
Improves the error messaging around when a chain isn't configured with a min gas price that is strictly less than the `gas_price` field in Hermes' `config.toml`.

The error has been split into two separate errors: one that detects and notifies when either a chain or Hermes has been misconfigured such that no gas price has been provided, and one where gas prices are configured but none are strictly less than the configured Hermes gas price. 

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
