### PR TITLE
Implement packet lock for packet relayer synchronization

### DIFF
--- a/crates/relayer-all-in-one/src/base/one_for_all/impls/relay/packet_relayers/lock.rs
+++ b/crates/relayer-all-in-one/src/base/one_for_all/impls/relay/packet_relayers/lock.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+use ibc_relayer_components::relay::traits::packet_relayers::lock::HasPacketLock;
+
+use crate::base::one_for_all::traits::relay::OfaBaseRelay;
+use crate::base::one_for_all::types::relay::OfaRelayWrapper;
+use crate::std_prelude::*;
+
+#[async_trait]
+impl<Relay> HasPacketLock for OfaRelayWrapper<Relay>
+where
+    Relay: OfaBaseRelay,
+{
+    type PacketLock<'a> = Relay::PacketLock<'a>;
+
+    async fn try_acquire_packet_lock<'a>(
+        &'a self,
+        packet: &'a Self::Packet,
+    ) -> Option<Self::PacketLock<'a>> {
+        self.relay.try_acquire_packet_lock(packet).await
+    }
+}

--- a/crates/relayer-all-in-one/src/base/one_for_all/impls/relay/packet_relayers/mod.rs
+++ b/crates/relayer-all-in-one/src/base/one_for_all/impls/relay/packet_relayers/mod.rs
@@ -1,4 +1,5 @@
 pub mod ack;
 pub mod base;
+pub mod lock;
 pub mod receive;
 pub mod timeout_unordered;

--- a/crates/relayer-all-in-one/src/base/one_for_all/presets/min.rs
+++ b/crates/relayer-all-in-one/src/base/one_for_all/presets/min.rs
@@ -5,6 +5,7 @@ use ibc_relayer_components::relay::impls::message_senders::chain_sender::SendIbc
 use ibc_relayer_components::relay::impls::message_senders::update_client::SendIbcMessagesWithUpdateClient;
 use ibc_relayer_components::relay::impls::packet_filters::allow_all::AllowAll;
 use ibc_relayer_components::relay::impls::packet_relayers::general::full_relay::FullCycleRelayer;
+use ibc_relayer_components::relay::impls::packet_relayers::general::lock::LockPacketRelayer;
 use ibc_relayer_components::relay::impls::packet_relayers::general::log::LoggerRelayer;
 
 use crate::base::one_for_all::impls::chain::queries::consensus_state::SendConsensusStateQueryToOfa;
@@ -18,7 +19,7 @@ pub type ConsensusStateQuerier = SendConsensusStateQueryToOfa;
 
 pub type AutoRelayer = ConcurrentBidirectionalRelayer<ConcurrentEventSubscriptionRelayer>;
 
-pub type PacketRelayer = LoggerRelayer<FullCycleRelayer>;
+pub type PacketRelayer = LockPacketRelayer<LoggerRelayer<FullCycleRelayer>>;
 
 pub type PacketFilter = AllowAll;
 

--- a/crates/relayer-all-in-one/src/base/one_for_all/traits/relay.rs
+++ b/crates/relayer-all-in-one/src/base/one_for_all/traits/relay.rs
@@ -49,6 +49,8 @@ pub trait OfaRelayTypes: Async {
         IncomingPacket = Self::Packet,
         OutgoingPacket = <Self::SrcChain as OfaIbcChain<Self::DstChain>>::IncomingPacket,
     >;
+
+    type PacketLock<'a>: Send;
 }
 
 #[async_trait]
@@ -102,6 +104,11 @@ pub trait OfaBaseRelay: OfaRelayTypes {
         &self,
         height: &<Self::SrcChain as OfaChainTypes>::Height,
     ) -> Result<Vec<<Self::DstChain as OfaChainTypes>::Message>, Self::Error>;
+
+    async fn try_acquire_packet_lock<'a>(
+        &'a self,
+        packet: &'a Self::Packet,
+    ) -> Option<Self::PacketLock<'a>>;
 }
 
 pub trait OfaRelayPreset<Relay>:

--- a/crates/relayer-all-in-one/src/extra/one_for_all/presets/full.rs
+++ b/crates/relayer-all-in-one/src/extra/one_for_all/presets/full.rs
@@ -2,6 +2,7 @@ use ibc_relayer_components::relay::impls::message_senders::chain_sender::SendIbc
 use ibc_relayer_components::relay::impls::message_senders::update_client::SendIbcMessagesWithUpdateClient;
 use ibc_relayer_components::relay::impls::packet_relayers::general::filter_relayer::FilterRelayer;
 use ibc_relayer_components::relay::impls::packet_relayers::general::full_relay::FullCycleRelayer;
+use ibc_relayer_components::relay::impls::packet_relayers::general::lock::LockPacketRelayer;
 use ibc_relayer_components::relay::impls::packet_relayers::general::log::LoggerRelayer;
 use ibc_relayer_components_extra::batch::impls::message_sender::SendMessagesToBatchWorker;
 use ibc_relayer_components_extra::relay::impls::auto_relayers::parallel_bidirectional::ParallelBidirectionalRelayer;
@@ -23,11 +24,11 @@ pub type ConsensusStateQuerier = ConsensusStateTelemetryQuerier<SendConsensusSta
 
 pub type AutoRelayer = ParallelBidirectionalRelayer<ParallelEventSubscriptionRelayer>;
 
-pub type PacketRelayer = LoggerRelayer<FilterRelayer<RetryRelayer<FullCycleRelayer>>>;
+pub type PacketRelayer =
+    LockPacketRelayer<LoggerRelayer<FilterRelayer<RetryRelayer<FullCycleRelayer>>>>;
 
 pub type PacketFilter = FilterPacketFromOfa;
 
-// pub type IbcMessageSender = SendIbcMessagesWithUpdateClient<SendIbcMessagesToChain>;
 pub type IbcMessageSender = SendMessagesToBatchWorker;
 
 pub type IbcMessageSenderForBatchWorker = SendIbcMessagesWithUpdateClient<SendIbcMessagesToChain>;

--- a/crates/relayer-components/src/relay/impls/packet_relayers/general/lock.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/general/lock.rs
@@ -1,0 +1,26 @@
+use core::marker::PhantomData;
+
+use async_trait::async_trait;
+
+use crate::relay::traits::packet_relayer::PacketRelayer;
+use crate::relay::traits::packet_relayers::lock::HasPacketLock;
+use crate::relay::traits::types::HasRelayTypes;
+use crate::std_prelude::*;
+
+pub struct LockPacketRelayer<InRelayer>(pub PhantomData<InRelayer>);
+
+#[async_trait]
+impl<Relay, InRelayer> PacketRelayer<Relay> for LockPacketRelayer<InRelayer>
+where
+    Relay: HasRelayTypes + HasPacketLock,
+    InRelayer: PacketRelayer<Relay>,
+{
+    async fn relay_packet(relay: &Relay, packet: &Relay::Packet) -> Result<(), Relay::Error> {
+        let m_lock = relay.try_acquire_packet_lock(packet).await;
+
+        match m_lock {
+            Some(_lock) => InRelayer::relay_packet(relay, packet).await,
+            None => Ok(()),
+        }
+    }
+}

--- a/crates/relayer-components/src/relay/impls/packet_relayers/general/lock.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/general/lock.rs
@@ -4,15 +4,21 @@ use async_trait::async_trait;
 
 use crate::relay::traits::packet_relayer::PacketRelayer;
 use crate::relay::traits::packet_relayers::lock::HasPacketLock;
-use crate::relay::traits::types::HasRelayTypes;
 use crate::std_prelude::*;
 
+/**
+   Call the inner relayer only if the packet lock provided by [`HasPacketLock`]
+   is acquired.
+
+   This is to avoid race condition where multiple packet relayers try to
+   relay the same packet at the same time.
+*/
 pub struct LockPacketRelayer<InRelayer>(pub PhantomData<InRelayer>);
 
 #[async_trait]
 impl<Relay, InRelayer> PacketRelayer<Relay> for LockPacketRelayer<InRelayer>
 where
-    Relay: HasRelayTypes + HasPacketLock,
+    Relay: HasPacketLock,
     InRelayer: PacketRelayer<Relay>,
 {
     async fn relay_packet(relay: &Relay, packet: &Relay::Packet) -> Result<(), Relay::Error> {

--- a/crates/relayer-components/src/relay/impls/packet_relayers/general/lock.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/general/lock.rs
@@ -2,6 +2,9 @@ use core::marker::PhantomData;
 
 use async_trait::async_trait;
 
+use crate::logger::traits::level::HasBaseLogLevels;
+use crate::relay::traits::logs::logger::CanLogRelay;
+use crate::relay::traits::logs::packet::CanLogRelayPacket;
 use crate::relay::traits::packet_relayer::PacketRelayer;
 use crate::relay::traits::packet_relayers::lock::HasPacketLock;
 use crate::std_prelude::*;
@@ -18,7 +21,7 @@ pub struct LockPacketRelayer<InRelayer>(pub PhantomData<InRelayer>);
 #[async_trait]
 impl<Relay, InRelayer> PacketRelayer<Relay> for LockPacketRelayer<InRelayer>
 where
-    Relay: HasPacketLock,
+    Relay: HasPacketLock + CanLogRelay + CanLogRelayPacket,
     InRelayer: PacketRelayer<Relay>,
 {
     async fn relay_packet(relay: &Relay, packet: &Relay::Packet) -> Result<(), Relay::Error> {
@@ -26,7 +29,17 @@ where
 
         match m_lock {
             Some(_lock) => InRelayer::relay_packet(relay, packet).await,
-            None => Ok(()),
+            None => {
+                relay.log_relay(
+                    Relay::Logger::LEVEL_TRACE,
+                    "skip relaying packet, as another packet relayer has acquired the packet lock",
+                    |log| {
+                        log.field("packet", Relay::log_packet(packet));
+                    },
+                );
+
+                Ok(())
+            }
         }
     }
 }

--- a/crates/relayer-components/src/relay/impls/packet_relayers/general/mod.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/general/mod.rs
@@ -1,3 +1,4 @@
 pub mod filter_relayer;
 pub mod full_relay;
+pub mod lock;
 pub mod log;

--- a/crates/relayer-components/src/relay/traits/packet_relayers/lock.rs
+++ b/crates/relayer-components/src/relay/traits/packet_relayers/lock.rs
@@ -1,7 +1,14 @@
+use async_trait::async_trait;
+
 use crate::relay::traits::types::HasRelayTypes;
-use crate::runtime::traits::mutex::HasRuntimeWithMutex;
+use crate::std_prelude::*;
 
+#[async_trait]
+pub trait HasPacketLock: HasRelayTypes {
+    type PacketLock<'a>: Send;
 
-pub trait HasPacketWorkerLock: HasRelayTypes + HasRuntimeWithMutex {
-    fn mutex_for_packet(&self, packet: &Self::Packet);
+    async fn try_acquire_packet_lock<'a>(
+        &'a self,
+        packet: &'a Self::Packet,
+    ) -> Option<Self::PacketLock<'a>>;
 }

--- a/crates/relayer-components/src/relay/traits/packet_relayers/lock.rs
+++ b/crates/relayer-components/src/relay/traits/packet_relayers/lock.rs
@@ -3,10 +3,43 @@ use async_trait::async_trait;
 use crate::relay::traits::types::HasRelayTypes;
 use crate::std_prelude::*;
 
+/**
+   Provides a packet lock mutex for packet relayers to coordinate and avoid
+   relaying the same packet at the same time.
+
+   Before a packet relayer starts relaying, it should try and acquire a
+   [`PacketLock`](Self::PacketLock) from the relay context. The packet lock
+   would act as a mutex guard and stays active for its lifetime duration.
+   During this period, acquiring the packet lock for another packet would fail,
+   and this would signal to other packet relayers to skip relaying the given
+   packet.
+*/
 #[async_trait]
 pub trait HasPacketLock: HasRelayTypes {
+    /**
+       The mutex guard for a locked packet. This should be kept alive while
+       the packet relayer is relaying a packet.
+
+       During the lifetime of an acquired packet lock, other calls to
+       [`try_acquire_packet_lock`](Self::try_acquire_packet_lock) on the
+       same packet should return `None`.
+    */
     type PacketLock<'a>: Send;
 
+    /**
+       Try and acquire the lock for a given packet. Returns `Some` if the
+       acquire is success, and `None` if the packet lock has already been
+       acquired.
+
+       When the method returns `None`, this signals that another packet relayer
+       is already relaying a given packet, and the caller should abort any
+       relaying operation for that packet.
+
+       When the method returns `Some`, the caller should retain the
+       [`PacketLock`](Self::PacketLock) value throughout the relaying operation
+       for the given packet. This would cause other callers that try to lock
+       the same packet to get `None` returned.
+    */
     async fn try_acquire_packet_lock<'a>(
         &'a self,
         packet: &'a Self::Packet,

--- a/crates/relayer-components/src/relay/traits/packet_relayers/mod.rs
+++ b/crates/relayer-components/src/relay/traits/packet_relayers/mod.rs
@@ -1,3 +1,4 @@
 pub mod ack_packet;
+pub mod lock;
 pub mod receive_packet;
 pub mod timeout_unordered_packet;

--- a/crates/relayer-cosmos/src/base/impls/relay.rs
+++ b/crates/relayer-cosmos/src/base/impls/relay.rs
@@ -162,6 +162,7 @@ where
             packet.source_port.clone(),
             packet.destination_channel.clone(),
             packet.destination_port.clone(),
+            packet.sequence,
         );
 
         let mutex = self.relay.packet_lock_mutex();

--- a/crates/relayer-cosmos/src/base/impls/relay.rs
+++ b/crates/relayer-cosmos/src/base/impls/relay.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::channel::oneshot::{channel, Sender};
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::foreign_client::ForeignClient;
 use ibc_relayer_all_in_one::base::one_for_all::traits::relay::{OfaBaseRelay, OfaRelayTypes};
@@ -20,6 +21,18 @@ use crate::base::types::chain::CosmosChainWrapper;
 use crate::base::types::message::CosmosIbcMessage;
 use crate::base::types::relay::CosmosRelayWrapper;
 
+pub struct PacketLock {
+    pub release_sender: Option<Sender<()>>,
+}
+
+impl Drop for PacketLock {
+    fn drop(&mut self) {
+        if let Some(sender) = self.release_sender.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
 impl<Relay> OfaRelayTypes for CosmosRelayWrapper<Relay>
 where
     Relay: CosmosRelay,
@@ -37,6 +50,8 @@ where
     type SrcChain = CosmosChainWrapper<Relay::SrcChain>;
 
     type DstChain = CosmosChainWrapper<Relay::DstChain>;
+
+    type PacketLock<'a> = PacketLock;
 }
 
 #[async_trait]
@@ -139,6 +154,41 @@ where
             .spawn_blocking(move || build_update_client_messages(&client, height))
             .await
             .map_err(BaseError::join)?
+    }
+
+    async fn try_acquire_packet_lock<'a>(&'a self, packet: &'a Packet) -> Option<PacketLock> {
+        let packet_key = (
+            packet.source_channel.clone(),
+            packet.source_port.clone(),
+            packet.destination_channel.clone(),
+            packet.destination_port.clone(),
+        );
+
+        let mutex = self.relay.packet_lock_mutex();
+
+        let mut lock_table = mutex.lock().await;
+
+        if lock_table.contains(&packet_key) {
+            None
+        } else {
+            lock_table.insert(packet_key.clone());
+
+            let runtime = &self.runtime().runtime.runtime;
+
+            let (sender, receiver) = channel();
+
+            let mutex = mutex.clone();
+
+            runtime.spawn(async move {
+                let _ = receiver.await;
+                let mut lock_table = mutex.lock().await;
+                lock_table.remove(&packet_key);
+            });
+
+            Some(PacketLock {
+                release_sender: Some(sender),
+            })
+        }
     }
 }
 

--- a/crates/relayer-cosmos/src/base/impls/transaction.rs
+++ b/crates/relayer-cosmos/src/base/impls/transaction.rs
@@ -1,7 +1,6 @@
 use core::time::Duration;
 
 use async_trait::async_trait;
-use futures::lock::Mutex;
 use ibc_proto::cosmos::tx::v1beta1::{Fee, Tx, TxRaw};
 use ibc_relayer::chain::cosmos::encode::{key_pair_to_signer, sign_tx};
 use ibc_relayer::chain::cosmos::gas::gas_amount_to_fee;
@@ -24,6 +23,7 @@ use prost::Message as _;
 use tendermint::abci::Event;
 use tendermint::Hash as TxHash;
 use tendermint_rpc::endpoint::tx::Response as TxResponse;
+use tokio::sync::Mutex;
 
 use crate::base::error::{BaseError, Error};
 use crate::base::traits::chain::CosmosChain;

--- a/crates/relayer-cosmos/src/base/impls/transaction.rs
+++ b/crates/relayer-cosmos/src/base/impls/transaction.rs
@@ -1,6 +1,7 @@
 use core::time::Duration;
 
 use async_trait::async_trait;
+use futures::lock::Mutex;
 use ibc_proto::cosmos::tx::v1beta1::{Fee, Tx, TxRaw};
 use ibc_relayer::chain::cosmos::encode::{key_pair_to_signer, sign_tx};
 use ibc_relayer::chain::cosmos::gas::gas_amount_to_fee;
@@ -23,7 +24,6 @@ use prost::Message as _;
 use tendermint::abci::Event;
 use tendermint::Hash as TxHash;
 use tendermint_rpc::endpoint::tx::Response as TxResponse;
-use tokio::sync::Mutex;
 
 use crate::base::error::{BaseError, Error};
 use crate::base::traits::chain::CosmosChain;

--- a/crates/relayer-cosmos/src/base/traits/relay.rs
+++ b/crates/relayer-cosmos/src/base/traits/relay.rs
@@ -1,8 +1,13 @@
+use std::collections::HashSet;
+
+use alloc::sync::Arc;
+use futures::lock::Mutex;
 use ibc_relayer::foreign_client::ForeignClient;
 use ibc_relayer_all_in_one::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_all_in_one::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_components::core::traits::sync::Async;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
+use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 
 use crate::base::traits::chain::CosmosChain;
 use crate::base::types::chain::CosmosChainWrapper;
@@ -33,4 +38,6 @@ pub trait CosmosRelay: Async {
         <Self::SrcChain as CosmosChain>::ChainHandle,
         <Self::DstChain as CosmosChain>::ChainHandle,
     >;
+
+    fn packet_lock_mutex(&self) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>>;
 }

--- a/crates/relayer-cosmos/src/base/traits/relay.rs
+++ b/crates/relayer-cosmos/src/base/traits/relay.rs
@@ -7,6 +7,7 @@ use ibc_relayer_all_in_one::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_all_in_one::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_components::core::traits::sync::Async;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
+use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 
 use crate::base::traits::chain::CosmosChain;
@@ -39,5 +40,7 @@ pub trait CosmosRelay: Async {
         <Self::DstChain as CosmosChain>::ChainHandle,
     >;
 
-    fn packet_lock_mutex(&self) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>>;
+    fn packet_lock_mutex(
+        &self,
+    ) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId, Sequence)>>>;
 }

--- a/crates/relayer-cosmos/src/base/types/transaction.rs
+++ b/crates/relayer-cosmos/src/base/types/transaction.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use tokio::sync::Mutex;
+use futures::lock::Mutex;
 
 pub struct CosmosTxWrapper<Chain> {
     pub chain: Arc<Chain>,

--- a/crates/relayer-cosmos/src/base/types/transaction.rs
+++ b/crates/relayer-cosmos/src/base/types/transaction.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use futures::lock::Mutex;
+use tokio::sync::Mutex;
 
 pub struct CosmosTxWrapper<Chain> {
     pub chain: Arc<Chain>,

--- a/crates/relayer-cosmos/src/contexts/full/relay.rs
+++ b/crates/relayer-cosmos/src/contexts/full/relay.rs
@@ -1,3 +1,7 @@
+use std::collections::HashSet;
+
+use alloc::sync::Arc;
+use futures::lock::Mutex;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::filter::PacketFilter;
 use ibc_relayer::foreign_client::ForeignClient;
@@ -5,6 +9,7 @@ use ibc_relayer_all_in_one::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_all_in_one::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_all_in_one::extra::one_for_all::presets::full::FullPreset;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
+use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 
 use crate::base::traits::relay::CosmosRelay;
 use crate::base::types::chain::CosmosChainWrapper;
@@ -23,6 +28,7 @@ where
     pub src_to_dst_client: ForeignClient<DstChain, SrcChain>,
     pub dst_to_src_client: ForeignClient<SrcChain, DstChain>,
     pub packet_filter: PacketFilter,
+    pub packet_lock_mutex: Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>>,
     pub src_chain_message_batch_sender: CosmosBatchSender,
     pub dst_chain_message_batch_sender: CosmosBatchSender,
 }
@@ -51,6 +57,7 @@ where
             packet_filter,
             src_chain_message_batch_sender,
             dst_chain_message_batch_sender,
+            packet_lock_mutex: Arc::new(Mutex::new(HashSet::new())),
         };
 
         relay
@@ -86,6 +93,10 @@ where
 
     fn dst_to_src_client(&self) -> &ForeignClient<SrcChain, DstChain> {
         &self.dst_to_src_client
+    }
+
+    fn packet_lock_mutex(&self) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>> {
+        &self.packet_lock_mutex
     }
 }
 

--- a/crates/relayer-cosmos/src/contexts/full/relay.rs
+++ b/crates/relayer-cosmos/src/contexts/full/relay.rs
@@ -9,6 +9,7 @@ use ibc_relayer_all_in_one::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_all_in_one::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_all_in_one::extra::one_for_all::presets::full::FullPreset;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
+use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 
 use crate::base::traits::relay::CosmosRelay;
@@ -28,7 +29,7 @@ where
     pub src_to_dst_client: ForeignClient<DstChain, SrcChain>,
     pub dst_to_src_client: ForeignClient<SrcChain, DstChain>,
     pub packet_filter: PacketFilter,
-    pub packet_lock_mutex: Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>>,
+    pub packet_lock_mutex: Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId, Sequence)>>>,
     pub src_chain_message_batch_sender: CosmosBatchSender,
     pub dst_chain_message_batch_sender: CosmosBatchSender,
 }
@@ -95,7 +96,9 @@ where
         &self.dst_to_src_client
     }
 
-    fn packet_lock_mutex(&self) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>> {
+    fn packet_lock_mutex(
+        &self,
+    ) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId, Sequence)>>> {
         &self.packet_lock_mutex
     }
 }

--- a/crates/relayer-cosmos/src/contexts/min/relay.rs
+++ b/crates/relayer-cosmos/src/contexts/min/relay.rs
@@ -8,6 +8,7 @@ use ibc_relayer_all_in_one::base::one_for_all::presets::min::MinimalPreset;
 use ibc_relayer_all_in_one::base::one_for_all::types::chain::OfaChainWrapper;
 use ibc_relayer_all_in_one::base::one_for_all::types::runtime::OfaRuntimeWrapper;
 use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
+use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, PortId};
 
 use crate::base::traits::chain::CosmosChain;
@@ -25,7 +26,7 @@ where
     pub dst_chain: OfaChainWrapper<CosmosChainWrapper<MinCosmosChainContext<DstChain>>>,
     pub src_to_dst_client: ForeignClient<DstChain, SrcChain>,
     pub dst_to_src_client: ForeignClient<SrcChain, DstChain>,
-    pub packet_lock_mutex: Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>>,
+    pub packet_lock_mutex: Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId, Sequence)>>>,
 }
 
 impl<SrcChain, DstChain> MinCosmosRelayContext<SrcChain, DstChain>
@@ -94,7 +95,9 @@ where
         &self.dst_to_src_client
     }
 
-    fn packet_lock_mutex(&self) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId)>>> {
+    fn packet_lock_mutex(
+        &self,
+    ) -> &Arc<Mutex<HashSet<(ChannelId, PortId, ChannelId, PortId, Sequence)>>> {
         &self.packet_lock_mutex
     }
 }

--- a/crates/relayer-cosmos/src/full/types/batch.rs
+++ b/crates/relayer-cosmos/src/full/types/batch.rs
@@ -1,6 +1,6 @@
-use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
-use futures::channel::oneshot::Sender as SenderOnce;
 use tendermint::abci::Event;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::oneshot::Sender as SenderOnce;
 
 use crate::base::error::Error;
 use crate::base::types::message::CosmosIbcMessage;

--- a/crates/relayer-cosmos/src/full/types/batch.rs
+++ b/crates/relayer-cosmos/src/full/types/batch.rs
@@ -1,6 +1,6 @@
+use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
+use futures::channel::oneshot::Sender as SenderOnce;
 use tendermint::abci::Event;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::sync::oneshot::Sender as SenderOnce;
 
 use crate::base::error::Error;
 use crate::base::types::message::CosmosIbcMessage;

--- a/crates/relayer-mock/src/relayer_mock/base/impls/relay.rs
+++ b/crates/relayer-mock/src/relayer_mock/base/impls/relay.rs
@@ -33,6 +33,8 @@ impl OfaRelayTypes for MockRelayContext {
     type SrcChain = MockChainContext;
 
     type DstChain = MockChainContext;
+
+    type PacketLock<'a> = ();
 }
 
 #[async_trait]
@@ -131,5 +133,12 @@ impl OfaBaseRelay for MockRelayContext {
             *height,
             state,
         )])
+    }
+
+    async fn try_acquire_packet_lock<'a>(
+        &'a self,
+        _packet: &'a Self::Packet,
+    ) -> Option<Self::PacketLock<'a>> {
+        Some(())
     }
 }

--- a/crates/relayer-runtime/src/tokio/context.rs
+++ b/crates/relayer-runtime/src/tokio/context.rs
@@ -2,9 +2,6 @@ use alloc::sync::Arc;
 use core::future::Future;
 use core::pin::Pin;
 use core::time::Duration;
-use futures::channel::{mpsc, oneshot};
-use futures::lock::{Mutex, MutexGuard};
-use futures::stream::StreamExt;
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -15,8 +12,10 @@ use ibc_relayer_all_in_one::extra::one_for_all::traits::runtime::OfaFullRuntime;
 use ibc_relayer_components::core::traits::sync::Async;
 use ibc_relayer_components_extra::runtime::traits::spawn::TaskHandle;
 use tokio::runtime::Runtime;
+use tokio::sync::{mpsc, oneshot, Mutex, MutexGuard};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing;
 
 use super::error::Error as TokioError;
@@ -107,32 +106,31 @@ impl OfaFullRuntime for TokioRuntimeContext {
     where
         T: Async,
     {
-        mpsc::unbounded()
+        mpsc::unbounded_channel()
     }
 
     fn send<T>(sender: &Self::Sender<T>, value: T) -> Result<(), Self::Error>
     where
         T: Async,
     {
-        sender
-            .unbounded_send(value)
-            .map_err(|_| TokioError::channel_closed())
+        sender.send(value).map_err(|_| TokioError::channel_closed())
     }
 
     async fn receive<T>(receiver: &mut Self::Receiver<T>) -> Result<T, Self::Error>
     where
         T: Async,
     {
-        receiver.next().await.ok_or_else(TokioError::channel_closed)
+        receiver.recv().await.ok_or_else(TokioError::channel_closed)
     }
 
     fn try_receive<T>(receiver: &mut Self::Receiver<T>) -> Result<Option<T>, Self::Error>
     where
         T: Async,
     {
-        match receiver.try_next() {
-            Ok(batch) => Ok(batch),
-            Err(_) => Err(TokioError::channel_closed()),
+        match receiver.try_recv() {
+            Ok(batch) => Ok(Some(batch)),
+            Err(mpsc::error::TryRecvError::Empty) => Ok(None),
+            Err(mpsc::error::TryRecvError::Disconnected) => Err(TokioError::channel_closed()),
         }
     }
 
@@ -142,7 +140,7 @@ impl OfaFullRuntime for TokioRuntimeContext {
     where
         T: Async,
     {
-        Box::pin(receiver)
+        Box::pin(UnboundedReceiverStream::new(receiver))
     }
 
     fn new_channel_once<T>() -> (Self::SenderOnce<T>, Self::ReceiverOnce<T>)

--- a/crates/relayer-runtime/src/tokio/context.rs
+++ b/crates/relayer-runtime/src/tokio/context.rs
@@ -5,6 +5,7 @@ use core::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use futures::lock::{Mutex, MutexGuard};
 use futures::stream::Stream;
 use ibc_relayer_all_in_one::base::one_for_all::traits::runtime::OfaBaseRuntime;
 use ibc_relayer_all_in_one::base::one_for_all::types::runtime::LogLevel;
@@ -12,7 +13,7 @@ use ibc_relayer_all_in_one::extra::one_for_all::traits::runtime::OfaFullRuntime;
 use ibc_relayer_components::core::traits::sync::Async;
 use ibc_relayer_components_extra::runtime::traits::spawn::TaskHandle;
 use tokio::runtime::Runtime;
-use tokio::sync::{mpsc, oneshot, Mutex, MutexGuard};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_stream::wrappers::UnboundedReceiverStream;


### PR DESCRIPTION
## Description

This PR introduces a `HasPacketLock` trait to help concurrent packet relayers to synchronize and determine whether to relay a packet or not.

This helps fix the issue of the event relayer relaying a redundant ack packet, while the same ack packet has already been relayed by the main full cycle relayer.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
