### PR TITLE
Remove debug log noise from event_monitor

### DIFF
--- a/crates/relayer/src/event/monitor.rs
+++ b/crates/relayer/src/event/monitor.rs
@@ -452,7 +452,7 @@ impl EventMonitor {
     fn process_batch(&mut self, batch: EventBatch) {
         telemetry!(ws_events, &batch.chain_id, batch.events.len() as u64);
 
-        debug!(chain = %batch.chain_id, len = %batch.events.len(), "emitting batch");
+        trace!(chain = %batch.chain_id, len = %batch.events.len(), "emitting batch");
 
         self.event_bus.broadcast(Arc::new(Ok(batch)));
     }
@@ -478,7 +478,7 @@ fn stream_batches(
     // Collect IBC events from each RPC event
     let events = subscriptions
         .map_ok(move |rpc_event| {
-            debug!(chain = %id, "received an RPC event: {}", rpc_event.query);
+            trace!(chain = %id, "received an RPC event: {}", rpc_event.query);
             collect_events(&id, rpc_event)
         })
         .map_err(Error::canceled_or_generic)
@@ -496,7 +496,7 @@ fn stream_batches(
 
         sort_events(&mut events_with_heights);
 
-        debug!(chain = %chain_id, len = %events_with_heights.len(), "assembled batch");
+        trace!(chain = %chain_id, len = %events_with_heights.len(), "assembled batch");
 
         EventBatch {
             height,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

When running with `log_level = 'debug'` there is a lot of `debug` log noise. Even with the changes in this PR, the log is full of:
```
2023-05-29T14:07:40.225325Z DEBUG ThreadId(44) event_monitor{chain=ibc-1}: deadline has elapsed
2023-05-29T14:07:40.983320Z DEBUG ThreadId(45) event_monitor{chain=ibc-2}: deadline has elapsed
```
not sure where these are coming from and how to disable.

Started to see this after `v1.5.0`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
