### PR TITLE
Configurable range for histogram buckets for latency metrics

### DIFF
--- a/.changelog/unreleased/improvements/ibc-telemetry/3366-configurable-histogram-buckets.md
+++ b/.changelog/unreleased/improvements/ibc-telemetry/3366-configurable-histogram-buckets.md
@@ -1,0 +1,6 @@
+- Add two new configurations for the telemetry:
+  - `submitted_range` used to specify the range of the histogram
+    buckets for the `tx_latency_submitted` metric.
+  - `confirmed_range` used to specify the range of the histogram
+    buckets for the `tx_latency_confirmed` metric.
+  ([#3366](https://github.com/informalsystems/hermes/issues/3366))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,6 +1671,7 @@ dependencies = [
  "serde_json",
  "tendermint",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/config.toml
+++ b/config.toml
@@ -110,6 +110,36 @@ host = '127.0.0.1'
 # by the telemetry service. Default: 3001
 port = 3001
 
+# Specify the range of the 10 histogram buckets in ms for the `tx_latency_submitted` metric.
+# Default: { min = 500, max = 10000 } which will result in the following buckets:
+# tx_latency_submitted_bucket{...,le="950"} 0
+# tx_latency_submitted_bucket{...,le="1900"} 1
+# tx_latency_submitted_bucket{...,le="2850"} 1
+# tx_latency_submitted_bucket{...,le="3800"} 1
+# tx_latency_submitted_bucket{...,le="4750"} 1
+# tx_latency_submitted_bucket{...,le="5700"} 1
+# tx_latency_submitted_bucket{...,le="6650"} 1
+# tx_latency_submitted_bucket{...,le="7600"} 1
+# tx_latency_submitted_bucket{...,le="8550"} 1
+# tx_latency_submitted_bucket{...,le="9500"} 1
+# tx_latency_submitted_bucket{...,le="+Inf"} 1
+# submitted_range = { min = 5000, max = 10000 }
+
+# Specify the range of the 10 histogram buckets in ms for the `tx_latency_confirmed` metric.
+# Default: { min = 1000, max = 20000 } which will result in the following buckets:
+# tx_latency_confirmed_bucket{...,le="1900"} 0
+# tx_latency_confirmed_bucket{...,le="3800"} 0
+# tx_latency_confirmed_bucket{...,le="5700"} 0
+# tx_latency_confirmed_bucket{...,le="7600"} 0
+# tx_latency_confirmed_bucket{...,le="9500"} 0
+# tx_latency_confirmed_bucket{...,le="11400"} 0
+# tx_latency_confirmed_bucket{...,le="13300"} 0
+# tx_latency_confirmed_bucket{...,le="15200"} 0
+# tx_latency_confirmed_bucket{...,le="17100"} 0
+# tx_latency_confirmed_bucket{...,le="19000"} 0
+# tx_latency_confirmed_bucket{...,le="+Inf"} 1
+confirmed_range = { min = 1000, max = 20000 }
+
 
 # A chains section includes parameters related to a chain and the full node to which
 # the relayer can send transactions and queries.

--- a/crates/relayer-cli/src/commands/start.rs
+++ b/crates/relayer-cli/src/commands/start.rs
@@ -193,7 +193,12 @@ fn spawn_telemetry_server(config: &Config) {
 
     let _span = tracing::error_span!("telemetry").entered();
 
-    let state = ibc_telemetry::global();
+    let state = ibc_telemetry::init(
+        config.telemetry.submitted_range.min,
+        config.telemetry.submitted_range.max,
+        config.telemetry.confirmed_range.min,
+        config.telemetry.confirmed_range.max,
+    );
     let telemetry = config.telemetry.clone();
 
     if !telemetry.enabled {

--- a/crates/relayer/tests/config/fixtures/relayer_conf_example_invalid_telemetry.toml
+++ b/crates/relayer/tests/config/fixtures/relayer_conf_example_invalid_telemetry.toml
@@ -1,0 +1,68 @@
+[global]
+log_level = 'error'
+
+[mode]
+
+[mode.clients]
+enabled = true
+refresh = true
+misbehaviour = true
+
+[mode.connections]
+enabled = false
+
+[mode.channels]
+enabled = false
+
+[mode.packets]
+enabled = true
+clear_interval = 100
+clear_on_start = true
+tx_confirmation = true
+
+[telemetry]
+enabled = true
+host = '127.0.0.1'
+port = 3001
+submitted_range = { min = 10000, max = 5000 }
+confirmed_range = { min = 10000, max = 20000 }
+
+[[chains]]
+id = 'chain_A'
+rpc_addr = 'http://127.0.0.1:26657'
+grpc_addr = 'http://127.0.0.1:9090'
+websocket_addr = 'ws://localhost:26657/websocket'
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+max_gas = 200000
+gas_price = { price = 0.001, denom = 'stake' }
+max_msg_num = 4
+max_tx_size = 1048576
+clock_drift = '5s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'cosmos' }
+
+[chains.packet_filter]
+policy = 'allow'
+list = [
+  ['ica*', '*'],
+  ['transfer', 'channel-0'],
+]
+
+[[chains]]
+id = 'chain_B'
+rpc_addr = 'http://127.0.0.1:26557'
+grpc_addr = 'http://127.0.0.1:9090'
+websocket_addr = 'ws://localhost:26557/websocket'
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+gas_price = { price = 0.001, denom = 'stake' }
+clock_drift = '5s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'ethermint', proto_type = { pk_type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey' } }

--- a/crates/relayer/tests/config/fixtures/relayer_conf_example_valid_telemetry.toml
+++ b/crates/relayer/tests/config/fixtures/relayer_conf_example_valid_telemetry.toml
@@ -1,0 +1,68 @@
+[global]
+log_level = 'error'
+
+[mode]
+
+[mode.clients]
+enabled = true
+refresh = true
+misbehaviour = true
+
+[mode.connections]
+enabled = false
+
+[mode.channels]
+enabled = false
+
+[mode.packets]
+enabled = true
+clear_interval = 100
+clear_on_start = true
+tx_confirmation = true
+
+[telemetry]
+enabled = true
+host = '127.0.0.1'
+port = 3001
+submitted_range = { min = 5000, max = 10000 }
+confirmed_range = { min = 10000, max = 20000 }
+
+[[chains]]
+id = 'chain_A'
+rpc_addr = 'http://127.0.0.1:26657'
+grpc_addr = 'http://127.0.0.1:9090'
+websocket_addr = 'ws://localhost:26657/websocket'
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+max_gas = 200000
+gas_price = { price = 0.001, denom = 'stake' }
+max_msg_num = 4
+max_tx_size = 1048576
+clock_drift = '5s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'cosmos' }
+
+[chains.packet_filter]
+policy = 'allow'
+list = [
+  ['ica*', '*'],
+  ['transfer', 'channel-0'],
+]
+
+[[chains]]
+id = 'chain_B'
+rpc_addr = 'http://127.0.0.1:26557'
+grpc_addr = 'http://127.0.0.1:9090'
+websocket_addr = 'ws://localhost:26557/websocket'
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+gas_price = { price = 0.001, denom = 'stake' }
+clock_drift = '5s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'ethermint', proto_type = { pk_type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey' } }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -25,6 +25,7 @@ serde_json               = "1.0.94"
 serde                    = "1.0.149"
 axum                     = "0.6.18"
 tokio                    = "1.26.0"
+tracing                  = "0.1.36"
 
 [dependencies.tendermint]
 version = "0.32.0"

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -7,19 +7,62 @@ use std::error::Error;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 
-use once_cell::sync::Lazy;
+use once_cell::sync::OnceCell;
 use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
 pub use crate::state::TelemetryState;
 
-pub fn new_state() -> Arc<TelemetryState> {
-    Arc::new(TelemetryState::default())
+pub fn new_state(
+    tx_latency_submitted_min: u64,
+    tx_latency_submitted_max: u64,
+    tx_latency_confirmed_min: u64,
+    tx_latency_confirmed_max: u64,
+) -> Arc<TelemetryState> {
+    Arc::new(TelemetryState::new(
+        tx_latency_submitted_min,
+        tx_latency_submitted_max,
+        tx_latency_confirmed_min,
+        tx_latency_confirmed_max,
+    ))
 }
 
-static GLOBAL_STATE: Lazy<Arc<TelemetryState>> = Lazy::new(new_state);
+static GLOBAL_STATE: OnceCell<Arc<TelemetryState>> = OnceCell::new();
+
+pub fn init(
+    tx_latency_submitted_min: u64,
+    tx_latency_submitted_max: u64,
+    tx_latency_confirmed_min: u64,
+    tx_latency_confirmed_max: u64,
+) -> &'static Arc<TelemetryState> {
+    let new_state = new_state(
+        tx_latency_submitted_min,
+        tx_latency_submitted_max,
+        tx_latency_confirmed_min,
+        tx_latency_confirmed_max,
+    );
+    match GLOBAL_STATE.set(new_state) {
+        Ok(_) => debug!("initialised telemetry global state"),
+        Err(_) => debug!("telemetry global state was already set"),
+    }
+    GLOBAL_STATE.get().unwrap()
+}
 
 pub fn global() -> &'static Arc<TelemetryState> {
-    &GLOBAL_STATE
+    match GLOBAL_STATE.get() {
+        Some(state) => state,
+        None => {
+            warn!(
+                "global telemetry state not set, will initialize it using default histogram ranges"
+            );
+            let new_state = new_state(500, 10000, 1000, 20000);
+            match GLOBAL_STATE.set(new_state) {
+                Ok(_) => debug!("initialised telemetry global state"),
+                Err(_) => debug!("telemetry global state was already set"),
+            }
+            GLOBAL_STATE.get().unwrap()
+        }
+    }
 }
 
 pub type BoxError = Box<dyn Error + Send + Sync>;

--- a/crates/telemetry/src/state.rs
+++ b/crates/telemetry/src/state.rs
@@ -195,6 +195,175 @@ pub struct TelemetryState {
 }
 
 impl TelemetryState {
+    pub fn new(
+        tx_latency_submitted_min: u64,
+        tx_latency_submitted_max: u64,
+        tx_latency_confirmed_min: u64,
+        tx_latency_confirmed_max: u64,
+    ) -> Self {
+        use opentelemetry::sdk::export::metrics::aggregation;
+        use opentelemetry::sdk::metrics::{controllers, processors};
+
+        let controller = controllers::basic(processors::factory(
+            RangeCustomAggregatorSelector::new(
+                tx_latency_submitted_min,
+                tx_latency_submitted_max,
+                tx_latency_confirmed_min,
+                tx_latency_confirmed_max,
+            ),
+            aggregation::cumulative_temporality_selector(),
+        ))
+        .build();
+
+        let exporter = opentelemetry_prometheus::ExporterBuilder::new(controller).init();
+
+        let meter = global::meter("hermes");
+
+        Self {
+            exporter,
+
+            workers: meter
+                .i64_up_down_counter("workers")
+                .with_description("Number of workers")
+                .init(),
+
+            client_updates_submitted: meter
+                .u64_counter("client_updates_submitted")
+                .with_description("Number of client update messages submitted")
+                .init(),
+
+            client_misbehaviours_submitted: meter
+                .u64_counter("client_misbehaviours_submitted")
+                .with_description("Number of misbehaviours detected and submitted")
+                .init(),
+
+            receive_packets_confirmed: meter
+                .u64_counter("receive_packets_confirmed")
+                .with_description("Number of confirmed receive packets. Available if relayer runs with Tx confirmation enabled")
+                .init(),
+
+            acknowledgment_packets_confirmed: meter
+                .u64_counter("acknowledgment_packets_confirmed")
+                .with_description("Number of confirmed acknowledgment packets. Available if relayer runs with Tx confirmation enabled")
+                .init(),
+
+            timeout_packets_confirmed: meter
+                .u64_counter("timeout_packets_confirmed")
+                .with_description("Number of confirmed timeout packets. Available if relayer runs with Tx confirmation enabled")
+                .init(),
+
+            queries: meter
+                .u64_counter("queries")
+                .with_description(
+                    "Number of queries submitted by Hermes",
+                )
+                .init(),
+
+            queries_cache_hits: meter
+                .u64_counter("queries_cache_hits")
+                .with_description("Number of cache hits for queries submitted by Hermes")
+                .init(),
+
+            ws_reconnect: meter
+                .u64_counter("ws_reconnect")
+                .with_description("Number of times Hermes reconnected to the websocket endpoint")
+                .init(),
+
+            ws_events: meter
+                .u64_counter("ws_events")
+                .with_description("How many IBC events did Hermes receive via the websocket subscription")
+                .init(),
+
+            messages_submitted: meter
+                .u64_counter("messages_submitted")
+                .with_description("Number of messages submitted to a specific chain")
+                .init(),
+
+            wallet_balance: meter
+                .f64_observable_gauge("wallet_balance")
+                .with_description("The balance of each wallet Hermes uses per chain. Please note that when converting the balance to f64 a loss in precision might be introduced in the displayed value")
+                .init(),
+
+            send_packet_events: meter
+                .u64_counter("send_packet_events")
+                .with_description("Number of SendPacket events received")
+                .init(),
+
+            acknowledgement_events: meter
+                .u64_counter("acknowledgement_events")
+                .with_description("Number of WriteAcknowledgement events received")
+                .init(),
+
+            timeout_events: meter
+                .u64_counter("timeout_events")
+                .with_description("Number of TimeoutPacket events received")
+                .init(),
+
+            cleared_send_packet_events: meter
+                .u64_counter("cleared_send_packet_events")
+                .with_description("Number of SendPacket events received during the initial and periodic clearing")
+                .init(),
+
+            cleared_acknowledgment_events: meter
+                .u64_counter("cleared_acknowledgment_events")
+                .with_description("Number of WriteAcknowledgement events received during the initial and periodic clearing")
+                .init(),
+
+            tx_latency_submitted: meter
+                .u64_observable_gauge("tx_latency_submitted")
+                .with_unit(Unit::new("milliseconds"))
+                .with_description("The latency for all transactions submitted to a specific chain, \
+                    i.e. the difference between the moment when Hermes received a batch of events \
+                    and when it submitted the corresponding transaction(s). Milliseconds.")
+                .init(),
+
+            tx_latency_confirmed: meter
+                .u64_observable_gauge("tx_latency_confirmed")
+                .with_unit(Unit::new("milliseconds"))
+                .with_description("The latency for all transactions submitted & confirmed to a specific chain, \
+                    i.e. the difference between the moment when Hermes received a batch of events \
+                    until the corresponding transaction(s) were confirmed. Milliseconds.")
+                .init(),
+
+            in_flight_events: moka::sync::Cache::builder()
+                .time_to_live(Duration::from_secs(60 * 60)) // Remove entries after 1 hour
+                .time_to_idle(Duration::from_secs(30 * 60)) // Remove entries if they have been idle for 30 minutes
+                .build(),
+
+            backlogs: DashMap::new(),
+
+            backlog_oldest_sequence: meter
+                .u64_observable_gauge("backlog_oldest_sequence")
+                .with_description("Sequence number of the oldest SendPacket event in the backlog")
+                .init(),
+
+            backlog_oldest_timestamp: meter
+                .u64_observable_gauge("backlog_oldest_timestamp")
+                .with_unit(Unit::new("seconds"))
+                .with_description("Local timestamp for the oldest SendPacket event in the backlog")
+                .init(),
+
+            backlog_size: meter
+                .u64_observable_gauge("backlog_size")
+                .with_description("Total number of SendPacket events in the backlog")
+                .init(),
+
+            fee_amounts: meter
+                .u64_counter("ics29_fee_amounts")
+                .with_description("Total amount received from ICS29 fees")
+                .init(),
+
+            visible_fee_addresses: DashSet::new(),
+
+            cached_fees: Mutex::new(Vec::new()),
+
+            period_fees: meter
+                .u64_observable_gauge("ics29_period_fees")
+                .with_description("Amount of ICS29 fees rewarded over the past 7 days")
+                .init(),
+        }
+    }
+
     /// Gather the metrics for export
     pub fn gather(&self) -> Vec<MetricFamily> {
         self.exporter.registry().gather()
@@ -881,6 +1050,64 @@ use opentelemetry::sdk::metrics::aggregators::{histogram, last_value, sum};
 use opentelemetry::sdk::metrics::sdk_api::Descriptor;
 
 #[derive(Debug)]
+struct RangeCustomAggregatorSelector {
+    tx_latency_submitted_min: u64,
+    tx_latency_submitted_max: u64,
+    tx_latency_confirmed_min: u64,
+    tx_latency_confirmed_max: u64,
+}
+
+impl RangeCustomAggregatorSelector {
+    pub fn new(
+        tx_latency_submitted_min: u64,
+        tx_latency_submitted_max: u64,
+        tx_latency_confirmed_min: u64,
+        tx_latency_confirmed_max: u64,
+    ) -> Self {
+        Self {
+            tx_latency_submitted_min,
+            tx_latency_submitted_max,
+            tx_latency_confirmed_min,
+            tx_latency_confirmed_max,
+        }
+    }
+
+    pub fn get_submitted_range(&self) -> Vec<f64> {
+        let step = (self.tx_latency_submitted_max - self.tx_latency_submitted_min) / 10;
+        (self.tx_latency_submitted_min..=self.tx_latency_submitted_max)
+            .filter(|e| e % step == 0)
+            .map(|e| e as f64)
+            .collect::<Vec<_>>()
+    }
+
+    pub fn get_confirmed_range(&self) -> Vec<f64> {
+        let step = (self.tx_latency_confirmed_max - self.tx_latency_confirmed_min) / 10;
+        (self.tx_latency_confirmed_min..=self.tx_latency_confirmed_max)
+            .filter(|e| e % step == 0)
+            .map(|e| e as f64)
+            .collect::<Vec<_>>()
+    }
+}
+
+impl AggregatorSelector for RangeCustomAggregatorSelector {
+    fn aggregator_for(&self, descriptor: &Descriptor) -> Option<Arc<dyn Aggregator + Send + Sync>> {
+        match descriptor.name() {
+            "wallet_balance" => Some(Arc::new(last_value())),
+            "backlog_oldest_sequence" => Some(Arc::new(last_value())),
+            "backlog_oldest_timestamp" => Some(Arc::new(last_value())),
+            "backlog_size" => Some(Arc::new(last_value())),
+            // Prometheus' supports only collector for histogram, sum, and last value aggregators.
+            // https://docs.rs/opentelemetry-prometheus/0.10.0/src/opentelemetry_prometheus/lib.rs.html#411-418
+            // TODO: Once quantile sketches are supported, replace histograms with that.
+            "tx_latency_submitted" => Some(Arc::new(histogram(&self.get_submitted_range()))),
+            "tx_latency_confirmed" => Some(Arc::new(histogram(&self.get_confirmed_range()))),
+            "ics29_period_fees" => Some(Arc::new(last_value())),
+            _ => Some(Arc::new(sum())),
+        }
+    }
+}
+
+#[derive(Debug)]
 struct CustomAggregatorSelector;
 
 impl AggregatorSelector for CustomAggregatorSelector {
@@ -894,10 +1121,12 @@ impl AggregatorSelector for CustomAggregatorSelector {
             // https://docs.rs/opentelemetry-prometheus/0.10.0/src/opentelemetry_prometheus/lib.rs.html#411-418
             // TODO: Once quantile sketches are supported, replace histograms with that.
             "tx_latency_submitted" => Some(Arc::new(histogram(&[
-                200.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
+                200.0, 500.0, 1000.0, 2000.0, 5000.0, 6000.0, 7000.0, 8000.0, 9000.0, 10000.0,
+                12000.0, 14000.0, 16000.0,
             ]))),
             "tx_latency_confirmed" => Some(Arc::new(histogram(&[
-                1000.0, 5000.0, 9000.0, 13000.0, 17000.0, 20000.0,
+                1000.0, 5000.0, 9000.0, 13000.0, 17000.0, 20000.0, 23000.0, 25000.0, 27000.0,
+                30000.0,
             ]))),
             "ics29_period_fees" => Some(Arc::new(last_value())),
             _ => Some(Arc::new(sum())),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3366

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR adds 2 new configurations:

- `submitted_range` used to specify the range of the histogram
    buckets for the `tx_latency_submitted` metric.
- `confirmed_range` used to specify the range of the histogram
    buckets for the `tx_latency_confirmed` metric.

Allowing the buckets to be changed without the need to recompile Hermes

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
