### PR TITLE
Implement basic IBC connection handshake in relayer-next

### DIFF
--- a/crates/relayer-all-in-one/src/all_for_one/chain.rs
+++ b/crates/relayer-all-in-one/src/all_for_one/chain.rs
@@ -1,6 +1,9 @@
 use ibc_relayer_components::chain::traits::queries::consensus_state::CanQueryConsensusState;
 use ibc_relayer_components::chain::traits::queries::received_packet::CanQueryReceivedPacket;
 use ibc_relayer_components::chain::traits::queries::status::CanQueryChainStatus;
+use ibc_relayer_components::chain::traits::types::connection::{
+    HasConnectionHandshakePayloads, HasInitConnectionOptionsType,
+};
 use ibc_relayer_components::chain::traits::types::consensus_state::HasConsensusStateType;
 use ibc_relayer_components::chain::traits::types::ibc_events::write_ack::HasWriteAcknowledgementEvent;
 use ibc_relayer_components::chain::traits::types::packet::HasIbcPacketTypes;
@@ -14,12 +17,14 @@ pub trait AfoChain<Counterparty>:
     + HasAfoRuntime
     + HasLoggerWithBaseLevels
     + HasTelemetry
+    + CanQueryChainStatus
     + HasIbcPacketTypes<Counterparty>
     + HasWriteAcknowledgementEvent<Counterparty>
     + HasConsensusStateType<Counterparty>
     + CanQueryConsensusState<Counterparty>
     + CanQueryReceivedPacket<Counterparty>
-    + CanQueryChainStatus
+    + HasInitConnectionOptionsType<Counterparty>
+    + HasConnectionHandshakePayloads<Counterparty>
 where
     Counterparty: AfoCounterpartyChain<Self>,
 {
@@ -44,12 +49,14 @@ where
         + HasAfoRuntime
         + HasLoggerWithBaseLevels
         + HasTelemetry
+        + CanQueryChainStatus
         + HasIbcPacketTypes<Counterparty>
         + HasWriteAcknowledgementEvent<Counterparty>
         + HasConsensusStateType<Counterparty>
         + CanQueryConsensusState<Counterparty>
         + CanQueryReceivedPacket<Counterparty>
-        + CanQueryChainStatus,
+        + HasInitConnectionOptionsType<Counterparty>
+        + HasConnectionHandshakePayloads<Counterparty>,
 {
 }
 

--- a/crates/relayer-all-in-one/src/all_for_one/relay.rs
+++ b/crates/relayer-all-in-one/src/all_for_one/relay.rs
@@ -2,6 +2,8 @@ use ibc_relayer_components::chain::types::aliases::{IncomingPacket, OutgoingPack
 use ibc_relayer_components::logger::traits::level::HasLoggerWithBaseLevels;
 use ibc_relayer_components::relay::traits::auto_relayer::CanAutoRelay;
 use ibc_relayer_components::relay::traits::chains::HasRelayChains;
+use ibc_relayer_components::relay::traits::connection::open_handshake::CanRelayConnectionOpenHandshake;
+use ibc_relayer_components::relay::traits::connection::open_init::CanInitConnection;
 use ibc_relayer_components::relay::traits::event_relayer::CanRelayEvent;
 use ibc_relayer_components::relay::traits::ibc_message_sender::CanSendIbcMessages;
 use ibc_relayer_components::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
@@ -40,6 +42,8 @@ pub trait AfoRelay:
     + CanRelayTimeoutUnorderedPacket
     + CanSendIbcMessagesFromBatchWorker<SourceTarget>
     + CanSendIbcMessagesFromBatchWorker<DestinationTarget>
+    + CanInitConnection
+    + CanRelayConnectionOpenHandshake
     + SupportsPacketRetry
 {
     type AfoSrcChain: AfoChain<Self::AfoDstChain>;
@@ -74,6 +78,8 @@ where
         + CanRelayTimeoutUnorderedPacket
         + CanSendIbcMessagesFromBatchWorker<SourceTarget>
         + CanSendIbcMessagesFromBatchWorker<DestinationTarget>
+        + CanInitConnection
+        + CanRelayConnectionOpenHandshake
         + SupportsPacketRetry,
 {
     type AfoSrcChain = SrcChain;

--- a/crates/relayer-all-in-one/src/lib.rs
+++ b/crates/relayer-all-in-one/src/lib.rs
@@ -23,40 +23,18 @@
     For a quick introduction, check here for a
     [crash course on context-generic programming](crate::docs::context_generic_programming)
 
-    ## Relayer Variants
-
-    There are currently two variants of relayers supported by the relayer
-    framework. The [`base`] or minimal variant provides the base components
-    required to implement a minimal version of an IBC relayer. The [`extra`]
-    variant provides all the additional components that can be used to run
-    a full-featured relayer.
-
-    Note that all the components in both [`base`] and [`extra`] are implemented
-    in a fully modular fashion. As a result, power users can choose to use only
-    a subset of components provided by the framework, or introduce new
-    components that provide additional functionalities.
-
     ## All-In-One Traits
 
-    The relayer framework provides several
+    The relayer framework provides
     _[all-in-one traits](crate::docs::context_generic_programming#all-in-one-traits)_
-    for users to
-    easily implement and use custom relayers. The all-in-one traits are
+    for users to easily implement and use custom relayers. The all-in-one traits are
     configured with a _preset_ list of components, and is best suited
     for users who find the presets to be sufficient.
 
     A good starting point to learn about the all-in-one traits is to look at
     the _one-for-all_ consumer traits like
-    [`OfaBaseChain`](base::one_for_all::traits::chain::OfaBaseChain) and
-    [`OfaBaseRelay`](base::one_for_all::traits::relay::OfaBaseRelay).
-
-    There are currently two all-in-one variants of the relayer. The
-    [`base`] or minimal variant expose the minimal set of requirements
-    that a context needs to implement in order to construct a minimal
-    relayer. The [`extra`] variant requires the context to implement
-    additional traits, such as
-    [OfaFullChain](crate::extra::one_for_all::traits::chain::OfaFullChain),
-    in order to construct a full-featured relayer.
+    [`OfaChain`](one_for_all::traits::chain::OfaChain) and
+    [`OfaRelay`](one_for_all::traits::relay::OfaRelay).
 
     The all-in-one traits provided by the relayer framework for convenience,
     and they are _not_ meant to cover all possible use cases of using the relayer.
@@ -70,7 +48,7 @@
 
     For basic users who just want quick and easy way to creat custom relayers,
     it is usually sufficient to learn how to use the all-in-one traits like
-    [`OfaBaseRelay`](base::one_for_all::traits::relay::OfaBaseRelay).
+    [`OfaRelay`](crate::one_for_all::traits::relay::OfaRelay).
     But for power users who want to have more customization, or developers
     who are maintaining the relayer framework itself, it is necessary to
     have a deeper understanding of how context-generic programming works,
@@ -80,7 +58,7 @@
     A good starting point to understand the relayer framework internals
     is to look at how abstract types are defined in
     [`HasChainTypes`](ibc_relayer_components::chain::traits::types::chain::HasChainTypes) and
-    [`HasRelayChains`](ibc_relayer_components::relay::traits::types::HasRelayChains).
+    [`HasRelayChains`](ibc_relayer_components::relay::traits::chains::HasRelayChains).
     There are also simple components like
     [`CanQueryChainStatus`](ibc_relayer_components::chain::traits::queries::status::CanQueryChainStatus)
     that can be understood as standalone pieces.

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
@@ -1,0 +1,99 @@
+use async_trait::async_trait;
+use ibc_relayer_components::chain::traits::message_builders::connection::CanBuildConnectionHandshakePayloads;
+use ibc_relayer_components::chain::traits::types::connection::{
+    HasConnectionDetailsType, HasConnectionHandshakePayloads, HasConnectionVersionType,
+    HasInitConnectionOptionsType,
+};
+
+use crate::one_for_all::traits::chain::OfaIbcChain;
+use crate::one_for_all::types::chain::OfaChainWrapper;
+use crate::std_prelude::*;
+
+impl<Chain, Counterparty> HasConnectionHandshakePayloads<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    type ConnectionOpenInitPayload = Chain::ConnectionOpenInitPayload;
+
+    type ConnectionOpenTryPayload = Chain::ConnectionOpenTryPayload;
+
+    type ConnectionOpenAckPayload = Chain::ConnectionOpenAckPayload;
+
+    type ConnectionOpenConfirmPayload = Chain::ConnectionOpenConfirmPayload;
+}
+
+impl<Chain, Counterparty> HasInitConnectionOptionsType<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    type InitConnectionOptions = Chain::InitConnectionOptions;
+}
+
+impl<Chain, Counterparty> HasConnectionVersionType<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    type ConnectionVersion = Chain::ConnectionVersion;
+}
+
+impl<Chain, Counterparty> HasConnectionDetailsType<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    type ConnectionDetails = Chain::ConnectionDetails;
+}
+
+#[async_trait]
+impl<Chain, Counterparty> CanBuildConnectionHandshakePayloads<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    async fn build_connection_open_init_payload(
+        &self,
+    ) -> Result<Self::ConnectionOpenInitPayload, Self::Error> {
+        self.chain.build_connection_open_init_payload().await
+    }
+
+    async fn build_connection_open_try_payload(
+        &self,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenTryPayload, Self::Error> {
+        self.chain
+            .build_connection_open_try_payload(height, client_id, connection_id)
+            .await
+    }
+
+    async fn build_connection_open_ack_payload(
+        &self,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenAckPayload, Self::Error> {
+        self.chain
+            .build_connection_open_ack_payload(height, client_id, connection_id)
+            .await
+    }
+
+    async fn build_connection_open_confirm_payload(
+        &self,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenConfirmPayload, Self::Error> {
+        self.chain
+            .build_connection_open_confirm_payload(height, client_id, connection_id)
+            .await
+    }
+}

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
@@ -9,7 +9,9 @@ use ibc_relayer_components::chain::traits::types::connection::{
     HasConnectionDetailsType, HasConnectionHandshakePayloads, HasConnectionVersionType,
     HasInitConnectionOptionsType,
 };
-use ibc_relayer_components::chain::traits::types::ibc_events::connection::HasConnectionOpenInitEvent;
+use ibc_relayer_components::chain::traits::types::ibc_events::connection::{
+    HasConnectionOpenInitEvent, HasConnectionOpenTryEvent,
+};
 
 impl<Chain, Counterparty> HasConnectionHandshakePayloads<OfaChainWrapper<Counterparty>>
     for OfaChainWrapper<Chain>
@@ -71,6 +73,27 @@ where
         event: &Chain::ConnectionOpenInitEvent,
     ) -> &Chain::ConnectionId {
         Chain::connection_open_init_event_connection_id(event)
+    }
+}
+
+impl<Chain, Counterparty> HasConnectionOpenTryEvent<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    type ConnectionOpenTryEvent = Chain::ConnectionOpenTryEvent;
+
+    fn try_extract_connection_open_try_event(
+        event: Chain::Event,
+    ) -> Option<Chain::ConnectionOpenTryEvent> {
+        Chain::try_extract_connection_open_try_event(event)
+    }
+
+    fn connection_open_try_event_connection_id(
+        event: &Chain::ConnectionOpenTryEvent,
+    ) -> &Chain::ConnectionId {
+        Chain::connection_open_try_event_connection_id(event)
     }
 }
 

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use ibc_relayer_components::chain::traits::message_builders::connection::CanBuildConnectionHandshakePayloads;
+use ibc_relayer_components::chain::traits::message_builders::connection::{
+    CanBuildConnectionHandshakeMessages, CanBuildConnectionHandshakePayloads,
+};
 use ibc_relayer_components::chain::traits::types::connection::{
     HasConnectionDetailsType, HasConnectionHandshakePayloads, HasConnectionVersionType,
     HasInitConnectionOptionsType,
@@ -94,6 +96,68 @@ where
     ) -> Result<Self::ConnectionOpenConfirmPayload, Self::Error> {
         self.chain
             .build_connection_open_confirm_payload(height, client_id, connection_id)
+            .await
+    }
+}
+
+#[async_trait]
+impl<Chain, Counterparty> CanBuildConnectionHandshakeMessages<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    async fn build_connection_open_init_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        init_connection_options: &Self::InitConnectionOptions,
+        counterparty_payload: Counterparty::ConnectionOpenInitPayload,
+    ) -> Result<Self::Message, Self::Error> {
+        self.chain
+            .build_connection_open_init_message(
+                client_id,
+                counterparty_client_id,
+                init_connection_options,
+                counterparty_payload,
+            )
+            .await
+    }
+
+    async fn build_connection_open_try_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenTryPayload,
+    ) -> Result<Self::Message, Self::Error> {
+        self.chain
+            .build_connection_open_try_message(
+                client_id,
+                counterparty_client_id,
+                counterparty_connection_id,
+                counterparty_payload,
+            )
+            .await
+    }
+
+    async fn build_connection_open_ack_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenAckPayload,
+    ) -> Result<Self::Message, Self::Error> {
+        self.chain
+            .build_connection_open_ack_message(connection_id, counterparty_payload)
+            .await
+    }
+
+    async fn build_connection_open_confirm_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenConfirmPayload,
+    ) -> Result<Self::Message, Self::Error> {
+        self.chain
+            .build_connection_open_confirm_message(connection_id, counterparty_payload)
             .await
     }
 }

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
@@ -1,3 +1,6 @@
+use crate::one_for_all::traits::chain::OfaIbcChain;
+use crate::one_for_all::types::chain::OfaChainWrapper;
+use crate::std_prelude::*;
 use async_trait::async_trait;
 use ibc_relayer_components::chain::traits::message_builders::connection::{
     CanBuildConnectionHandshakeMessages, CanBuildConnectionHandshakePayloads,
@@ -6,10 +9,7 @@ use ibc_relayer_components::chain::traits::types::connection::{
     HasConnectionDetailsType, HasConnectionHandshakePayloads, HasConnectionVersionType,
     HasInitConnectionOptionsType,
 };
-
-use crate::one_for_all::traits::chain::OfaIbcChain;
-use crate::one_for_all::types::chain::OfaChainWrapper;
-use crate::std_prelude::*;
+use ibc_relayer_components::chain::traits::types::ibc_events::connection::HasConnectionOpenInitEvent;
 
 impl<Chain, Counterparty> HasConnectionHandshakePayloads<OfaChainWrapper<Counterparty>>
     for OfaChainWrapper<Chain>
@@ -51,6 +51,27 @@ where
     Counterparty: OfaIbcChain<Chain>,
 {
     type ConnectionDetails = Chain::ConnectionDetails;
+}
+
+impl<Chain, Counterparty> HasConnectionOpenInitEvent<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    type ConnectionOpenInitEvent = Chain::ConnectionOpenInitEvent;
+
+    fn try_extract_connection_open_init_event(
+        event: Chain::Event,
+    ) -> Option<Chain::ConnectionOpenInitEvent> {
+        Chain::try_extract_connection_open_init_event(event)
+    }
+
+    fn connection_open_init_event_connection_id(
+        event: &Chain::ConnectionOpenInitEvent,
+    ) -> &Chain::ConnectionId {
+        Chain::connection_open_init_event_connection_id(event)
+    }
 }
 
 #[async_trait]

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/connection.rs
@@ -144,10 +144,15 @@ where
     async fn build_connection_open_ack_message(
         &self,
         connection_id: &Self::ConnectionId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenAckPayload,
     ) -> Result<Self::Message, Self::Error> {
         self.chain
-            .build_connection_open_ack_message(connection_id, counterparty_payload)
+            .build_connection_open_ack_message(
+                connection_id,
+                counterparty_connection_id,
+                counterparty_payload,
+            )
             .await
     }
 

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/mod.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/mod.rs
@@ -1,3 +1,4 @@
+pub mod connection;
 pub mod error;
 pub mod event_subscription;
 pub mod logger;

--- a/crates/relayer-all-in-one/src/one_for_all/impls/chain/types.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/chain/types.rs
@@ -5,7 +5,9 @@ use ibc_relayer_components::chain::traits::types::ibc::{
     HasCounterpartyMessageHeight, HasIbcChainTypes,
 };
 use ibc_relayer_components::chain::traits::types::ibc_events::send_packet::HasSendPacketEvent;
-use ibc_relayer_components::chain::traits::types::ibc_events::write_ack::HasWriteAcknowledgementEvent;
+use ibc_relayer_components::chain::traits::types::ibc_events::write_ack::{
+    CanBuildPacketFromWriteAckEvent, HasWriteAcknowledgementEvent,
+};
 use ibc_relayer_components::chain::traits::types::message::{
     CanEstimateMessageSize, HasMessageType,
 };
@@ -180,8 +182,15 @@ where
     ) -> Option<Self::WriteAcknowledgementEvent> {
         Chain::try_extract_write_acknowledgement_event(event)
     }
+}
 
-    fn extract_packet_from_write_acknowledgement_event(
+impl<Chain, Counterparty> CanBuildPacketFromWriteAckEvent<OfaChainWrapper<Counterparty>>
+    for OfaChainWrapper<Chain>
+where
+    Chain: OfaIbcChain<Counterparty>,
+    Counterparty: OfaIbcChain<Chain>,
+{
+    fn build_packet_from_write_acknowledgement_event(
         ack: &Self::WriteAcknowledgementEvent,
     ) -> &Self::IncomingPacket {
         Chain::extract_packet_from_write_acknowledgement_event(ack)

--- a/crates/relayer-all-in-one/src/one_for_all/impls/relay/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/relay/connection.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+
+use ibc_relayer_components::relay::impls::connection::open_init::{
+    InitializeConnection, InjectMissingConnectionInitEventError,
+};
+use ibc_relayer_components::relay::traits::connection::open_init::{
+    CanInitConnection, ConnectionInitializer,
+};
+
+use crate::one_for_all::traits::chain::{OfaChain, OfaIbcChain};
+use crate::one_for_all::traits::relay::OfaRelay;
+use crate::one_for_all::types::relay::OfaRelayWrapper;
+use crate::std_prelude::*;
+
+impl<Relay> InjectMissingConnectionInitEventError for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    fn missing_connection_init_event_error(&self) -> Relay::Error {
+        self.relay.missing_connection_init_event_error()
+    }
+}
+
+#[async_trait]
+impl<Relay> CanInitConnection for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    async fn init_connection(
+        &self,
+        init_connection_options: &<Relay::SrcChain as OfaIbcChain<Relay::DstChain>>::InitConnectionOptions,
+    ) -> Result<<Relay::SrcChain as OfaChain>::ConnectionId, Self::Error> {
+        InitializeConnection::init_connection(self, init_connection_options).await
+    }
+}

--- a/crates/relayer-all-in-one/src/one_for_all/impls/relay/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/relay/connection.rs
@@ -1,10 +1,22 @@
 use async_trait::async_trait;
 
+use ibc_relayer_components::relay::impls::connection::open_ack::RelayConnectionOpenAck;
+use ibc_relayer_components::relay::impls::connection::open_confirm::RelayConnectionOpenConfirm;
+use ibc_relayer_components::relay::impls::connection::open_handshake::RelayConnectionOpenHandshake;
 use ibc_relayer_components::relay::impls::connection::open_init::{
     InitializeConnection, InjectMissingConnectionInitEventError,
 };
 use ibc_relayer_components::relay::impls::connection::open_try::{
     InjectMissingConnectionTryEventError, RelayConnectionOpenTry,
+};
+use ibc_relayer_components::relay::traits::connection::open_ack::{
+    CanRelayConnectionOpenAck, ConnectionOpenAckRelayer,
+};
+use ibc_relayer_components::relay::traits::connection::open_confirm::{
+    CanRelayConnectionOpenConfirm, ConnectionOpenConfirmRelayer,
+};
+use ibc_relayer_components::relay::traits::connection::open_handshake::{
+    CanRelayConnectionOpenHandshake, ConnectionOpenHandshakeRelayer,
 };
 use ibc_relayer_components::relay::traits::connection::open_init::{
     CanInitConnection, ConnectionInitializer,
@@ -63,5 +75,56 @@ where
         src_connection_id: &<Relay::SrcChain as OfaChain>::ConnectionId,
     ) -> Result<<Relay::DstChain as OfaChain>::ConnectionId, Self::Error> {
         RelayConnectionOpenTry::relay_connection_open_try(self, src_connection_id).await
+    }
+}
+
+#[async_trait]
+impl<Relay> CanRelayConnectionOpenAck for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    async fn relay_connection_open_ack(
+        &self,
+        src_connection_id: &<Relay::SrcChain as OfaChain>::ConnectionId,
+        dst_connection_id: &<Relay::DstChain as OfaChain>::ConnectionId,
+    ) -> Result<(), Self::Error> {
+        RelayConnectionOpenAck::relay_connection_open_ack(
+            self,
+            src_connection_id,
+            dst_connection_id,
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl<Relay> CanRelayConnectionOpenConfirm for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    async fn relay_connection_open_confirm(
+        &self,
+        src_connection_id: &<Relay::SrcChain as OfaChain>::ConnectionId,
+        dst_connection_id: &<Relay::DstChain as OfaChain>::ConnectionId,
+    ) -> Result<(), Self::Error> {
+        RelayConnectionOpenConfirm::relay_connection_open_confirm(
+            self,
+            src_connection_id,
+            dst_connection_id,
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl<Relay> CanRelayConnectionOpenHandshake for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    async fn relay_connection_open_handshake(
+        &self,
+        src_connection_id: &<Relay::SrcChain as OfaChain>::ConnectionId,
+    ) -> Result<<Relay::DstChain as OfaChain>::ConnectionId, Self::Error> {
+        RelayConnectionOpenHandshake::relay_connection_open_handshake(self, src_connection_id).await
     }
 }

--- a/crates/relayer-all-in-one/src/one_for_all/impls/relay/connection.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/relay/connection.rs
@@ -3,8 +3,14 @@ use async_trait::async_trait;
 use ibc_relayer_components::relay::impls::connection::open_init::{
     InitializeConnection, InjectMissingConnectionInitEventError,
 };
+use ibc_relayer_components::relay::impls::connection::open_try::{
+    InjectMissingConnectionTryEventError, RelayConnectionOpenTry,
+};
 use ibc_relayer_components::relay::traits::connection::open_init::{
     CanInitConnection, ConnectionInitializer,
+};
+use ibc_relayer_components::relay::traits::connection::open_try::{
+    CanRelayConnectionOpenTry, ConnectionOpenTryRelayer,
 };
 
 use crate::one_for_all::traits::chain::{OfaChain, OfaIbcChain};
@@ -21,6 +27,19 @@ where
     }
 }
 
+impl<Relay> InjectMissingConnectionTryEventError for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    fn missing_connection_try_event_error(
+        &self,
+        src_connection_id: &<Relay::SrcChain as OfaChain>::ConnectionId,
+    ) -> Relay::Error {
+        self.relay
+            .missing_connection_try_event_error(src_connection_id)
+    }
+}
+
 #[async_trait]
 impl<Relay> CanInitConnection for OfaRelayWrapper<Relay>
 where
@@ -31,5 +50,18 @@ where
         init_connection_options: &<Relay::SrcChain as OfaIbcChain<Relay::DstChain>>::InitConnectionOptions,
     ) -> Result<<Relay::SrcChain as OfaChain>::ConnectionId, Self::Error> {
         InitializeConnection::init_connection(self, init_connection_options).await
+    }
+}
+
+#[async_trait]
+impl<Relay> CanRelayConnectionOpenTry for OfaRelayWrapper<Relay>
+where
+    Relay: OfaRelay,
+{
+    async fn relay_connection_open_try(
+        &self,
+        src_connection_id: &<Relay::SrcChain as OfaChain>::ConnectionId,
+    ) -> Result<<Relay::DstChain as OfaChain>::ConnectionId, Self::Error> {
+        RelayConnectionOpenTry::relay_connection_open_try(self, src_connection_id).await
     }
 }

--- a/crates/relayer-all-in-one/src/one_for_all/impls/relay/message_sender.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/relay/message_sender.rs
@@ -17,6 +17,7 @@ where
 {
     async fn send_messages(
         &self,
+        _target: SourceTarget,
         messages: Vec<<Relay::SrcChain as OfaChain>::Message>,
     ) -> Result<Vec<Vec<<Relay::SrcChain as OfaChain>::Event>>, Self::Error> {
         <components::IbcMessageSender as IbcMessageSender<Self, SourceTarget>>::send_messages(
@@ -33,6 +34,7 @@ where
 {
     async fn send_messages(
         &self,
+        _target: DestinationTarget,
         messages: Vec<<Relay::DstChain as OfaChain>::Message>,
     ) -> Result<Vec<Vec<<Relay::DstChain as OfaChain>::Event>>, Self::Error> {
         <components::IbcMessageSender as IbcMessageSender<Self, DestinationTarget>>::send_messages(

--- a/crates/relayer-all-in-one/src/one_for_all/impls/relay/mod.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/impls/relay/mod.rs
@@ -1,5 +1,6 @@
 pub mod auto_relayer;
 pub mod batch;
+pub mod connection;
 pub mod error;
 pub mod event_relayer;
 pub mod logger;

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -186,6 +186,8 @@ where
 
     type ConnectionOpenInitEvent: Async;
 
+    type ConnectionOpenTryEvent: Async;
+
     fn incoming_packet_src_channel_id(packet: &Self::IncomingPacket) -> &Counterparty::ChannelId;
 
     fn incoming_packet_dst_channel_id(packet: &Self::IncomingPacket) -> &Self::ChannelId;
@@ -242,6 +244,14 @@ where
 
     fn connection_open_init_event_connection_id(
         event: &Self::ConnectionOpenInitEvent,
+    ) -> &Self::ConnectionId;
+
+    fn try_extract_connection_open_try_event(
+        event: Self::Event,
+    ) -> Option<Self::ConnectionOpenTryEvent>;
+
+    fn connection_open_try_event_connection_id(
+        event: &Self::ConnectionOpenTryEvent,
     ) -> &Self::ConnectionId;
 
     async fn query_chain_id_from_channel_id(

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -313,6 +313,8 @@ where
     async fn build_connection_open_try_message(
         &self,
         client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenTryPayload,
     ) -> Result<Self::Message, Self::Error>;
 

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -75,25 +75,25 @@ pub trait OfaChain: Async {
        Corresponds to
        [`HasIbcChainTypes::ConnectionId`](ibc_relayer_components::chain::traits::types::ibc::HasIbcChainTypes::ConnectionId).
     */
-    type ConnectionId: Display + Async;
+    type ConnectionId: Display + Clone + Async;
 
     /**
        Corresponds to
        [`HasIbcChainTypes::ChannelId`](ibc_relayer_components::chain::traits::types::ibc::HasIbcChainTypes::ChannelId).
     */
-    type ChannelId: Display + Async;
+    type ChannelId: Display + Clone + Async;
 
     /**
        Corresponds to
        [`HasIbcChainTypes::PortId`](ibc_relayer_components::chain::traits::types::ibc::HasIbcChainTypes::PortId).
     */
-    type PortId: Display + Async;
+    type PortId: Display + Clone + Async;
 
     /**
        Corresponds to
        [`HasIbcChainTypes::Sequence`](ibc_relayer_components::chain::traits::types::ibc::HasIbcChainTypes::Sequence).
     */
-    type Sequence: Display + Async;
+    type Sequence: Display + Clone + Async;
 
     /**
        Corresponds to

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -39,7 +39,7 @@ pub trait OfaChain: Async {
        Corresponds to
        [`HasChainTypes::Height`](ibc_relayer_components::chain::traits::types::height::HasHeightType::Height).
     */
-    type Height: Ord + Display + Async;
+    type Height: Clone + Ord + Display + Async;
 
     /**
        Corresponds to

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -321,6 +321,7 @@ where
     async fn build_connection_open_ack_message(
         &self,
         connection_id: &Self::ConnectionId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenAckPayload,
     ) -> Result<Self::Message, Self::Error>;
 

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -184,6 +184,8 @@ where
 
     type ConnectionOpenConfirmPayload: Async;
 
+    type ConnectionOpenInitEvent: Async;
+
     fn incoming_packet_src_channel_id(packet: &Self::IncomingPacket) -> &Counterparty::ChannelId;
 
     fn incoming_packet_dst_channel_id(packet: &Self::IncomingPacket) -> &Self::ChannelId;
@@ -233,6 +235,14 @@ where
     fn extract_packet_from_write_acknowledgement_event(
         ack: &Self::WriteAcknowledgementEvent,
     ) -> &Self::IncomingPacket;
+
+    fn try_extract_connection_open_init_event(
+        event: Self::Event,
+    ) -> Option<Self::ConnectionOpenInitEvent>;
+
+    fn connection_open_init_event_connection_id(
+        event: &Self::ConnectionOpenInitEvent,
+    ) -> &Self::ConnectionId;
 
     async fn query_chain_id_from_channel_id(
         &self,

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -174,6 +174,8 @@ where
 
     type ConnectionVersion: Eq + Default + Async;
 
+    type InitConnectionOptions: Async;
+
     type ConnectionOpenInitPayload: Async;
 
     type ConnectionOpenTryPayload: Async;
@@ -274,4 +276,55 @@ where
         height: &Self::Height,
         packet: &Self::IncomingPacket,
     ) -> Result<Counterparty::Message, Self::Error>;
+
+    async fn build_connection_open_init_payload(
+        &self,
+    ) -> Result<Self::ConnectionOpenInitPayload, Self::Error>;
+
+    async fn build_connection_open_try_payload(
+        &self,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenTryPayload, Self::Error>;
+
+    async fn build_connection_open_ack_payload(
+        &self,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenAckPayload, Self::Error>;
+
+    async fn build_connection_open_confirm_payload(
+        &self,
+        height: &Self::Height,
+        client_id: &Self::ClientId,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionOpenConfirmPayload, Self::Error>;
+
+    async fn build_connection_open_init_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        init_connection_options: &Self::InitConnectionOptions,
+        counterparty_payload: Counterparty::ConnectionOpenInitPayload,
+    ) -> Result<Self::Message, Self::Error>;
+
+    async fn build_connection_open_try_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_payload: Counterparty::ConnectionOpenTryPayload,
+    ) -> Result<Self::Message, Self::Error>;
+
+    async fn build_connection_open_ack_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenAckPayload,
+    ) -> Result<Self::Message, Self::Error>;
+
+    async fn build_connection_open_confirm_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_payload: Counterparty::ConnectionOpenConfirmPayload,
+    ) -> Result<Self::Message, Self::Error>;
 }

--- a/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/chain.rs
@@ -170,6 +170,18 @@ where
     */
     type OutgoingPacket: Async;
 
+    type ConnectionDetails: Async;
+
+    type ConnectionVersion: Eq + Default + Async;
+
+    type ConnectionOpenInitPayload: Async;
+
+    type ConnectionOpenTryPayload: Async;
+
+    type ConnectionOpenAckPayload: Async;
+
+    type ConnectionOpenConfirmPayload: Async;
+
     fn incoming_packet_src_channel_id(packet: &Self::IncomingPacket) -> &Counterparty::ChannelId;
 
     fn incoming_packet_dst_channel_id(packet: &Self::IncomingPacket) -> &Self::ChannelId;

--- a/crates/relayer-all-in-one/src/one_for_all/traits/relay.rs
+++ b/crates/relayer-all-in-one/src/one_for_all/traits/relay.rs
@@ -49,6 +49,13 @@ pub trait OfaRelay: Async {
 
     fn max_retry_exceeded_error(e: Self::Error) -> Self::Error;
 
+    fn missing_connection_init_event_error(&self) -> Self::Error;
+
+    fn missing_connection_try_event_error(
+        &self,
+        src_connection_id: &<Self::SrcChain as OfaChain>::ConnectionId,
+    ) -> Self::Error;
+
     fn runtime(&self) -> &OfaRuntimeWrapper<Self::Runtime>;
 
     fn logger(&self) -> &Self::Logger;

--- a/crates/relayer-components-extra/src/relay/impls/auto_relayers/parallel_bidirectional.rs
+++ b/crates/relayer-components-extra/src/relay/impls/auto_relayers/parallel_bidirectional.rs
@@ -9,7 +9,9 @@ use ibc_relayer_components::runtime::traits::runtime::HasRuntime;
 use crate::runtime::traits::spawn::{HasSpawner, Spawner};
 use crate::std_prelude::*;
 
-/// A parallel variant of [`ConcurrentBidirectionalRelayer`] that spawns two separate
+/// A parallel variant of
+/// [`ConcurrentBidirectionalRelayer`](ibc_relayer_components::relay::impls::auto_relayers::concurrent_bidirectional::ConcurrentBidirectionalRelayer)
+/// that spawns two separate
 /// tasks, each responsible for relaying for one of the targets. As such, it has an
 /// additional `HasSpawner` constraint that the concurrent variant does not require.
 pub struct ParallelBidirectionalRelayer<InRelayer>(pub PhantomData<InRelayer>);

--- a/crates/relayer-components-extra/src/relay/impls/auto_relayers/parallel_two_way.rs
+++ b/crates/relayer-components-extra/src/relay/impls/auto_relayers/parallel_two_way.rs
@@ -9,7 +9,9 @@ use crate::std_prelude::*;
 /// A parallel two-way relay context that is composed of a `BiRelay` type that
 /// can auto-relay between two connected targets.
 ///
-/// As opposed to the [`ConcurrentTwoWayAutoRelay`] variant, this type achieves
+/// As opposed to the
+/// [`ConcurrentTwoWayAutoRelay`](ibc_relayer_components::relay::impls::auto_relayers::concurrent_two_way::ConcurrentTwoWayAutoRelay)
+/// variant, this type achieves
 /// concurrency by spawning two tasks, each one responsible for relaying in
 /// different directions. As such, it has an additional `HasSpawner` constraint
 /// that the concurrent variant does not require.

--- a/crates/relayer-components-extra/src/telemetry/impls/consensus_state.rs
+++ b/crates/relayer-components-extra/src/telemetry/impls/consensus_state.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use ibc_relayer_components::chain::traits::queries::consensus_state::ConsensusStateQuerier;
 use ibc_relayer_components::chain::traits::types::consensus_state::HasConsensusStateType;
 use ibc_relayer_components::chain::traits::types::ibc::HasIbcChainTypes;
+use ibc_relayer_components::core::traits::error::HasErrorType;
 
 use crate::std_prelude::*;
 use crate::telemetry::traits::metrics::{HasMetric, TelemetryCounter};
@@ -15,7 +16,7 @@ pub struct ConsensusStateTelemetryQuerier<InQuerier> {
 impl<InQuerier, Chain, Counterparty, Telemetry> ConsensusStateQuerier<Chain, Counterparty>
     for ConsensusStateTelemetryQuerier<InQuerier>
 where
-    Chain: HasIbcChainTypes<Counterparty> + HasTelemetry<Telemetry = Telemetry>,
+    Chain: HasIbcChainTypes<Counterparty> + HasTelemetry<Telemetry = Telemetry> + HasErrorType,
     Counterparty: HasConsensusStateType<Chain>,
     InQuerier: ConsensusStateQuerier<Chain, Counterparty>,
     Telemetry: HasMetric<TelemetryCounter>,

--- a/crates/relayer-components-extra/src/telemetry/impls/status.rs
+++ b/crates/relayer-components-extra/src/telemetry/impls/status.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use ibc_relayer_components::chain::traits::queries::status::*;
 use ibc_relayer_components::chain::traits::types::status::HasChainStatusType;
+use ibc_relayer_components::core::traits::error::HasErrorType;
 
 use crate::std_prelude::*;
 use crate::telemetry::traits::metrics::{HasMetric, TelemetryCounter};
@@ -15,7 +16,7 @@ impl<InQuerier, Chain, Telemetry> ChainStatusQuerier<Chain>
     for ChainStatusTelemetryQuerier<InQuerier>
 where
     InQuerier: ChainStatusQuerier<Chain>,
-    Chain: HasChainStatusType + HasTelemetry<Telemetry = Telemetry>,
+    Chain: HasChainStatusType + HasTelemetry<Telemetry = Telemetry> + HasErrorType,
     Telemetry: HasMetric<TelemetryCounter>,
     Telemetry::Value: From<u64>,
 {

--- a/crates/relayer-components/src/chain/traits/client/client_state.rs
+++ b/crates/relayer-components/src/chain/traits/client/client_state.rs
@@ -1,0 +1,13 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::client_state::HasClientStateSettingsType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanBuildClientState<Counterparty>: HasClientStateSettingsType<Counterparty> {
+    async fn build_client_state(
+        &self,
+        height: &Self::Height,
+        settings: &Self::ClientStateSettings,
+    ) -> Self::ClientState;
+}

--- a/crates/relayer-components/src/chain/traits/client/consensus_state.rs
+++ b/crates/relayer-components/src/chain/traits/client/consensus_state.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::client_state::HasClientStateType;
+use crate::chain::traits::types::consensus_state::HasConsensusStateType;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanBuildConsensusState<Counterparty>:
+    HasConsensusStateType<Counterparty> + HasClientStateType<Counterparty> + HasErrorType
+{
+    async fn build_consensus_state(
+        trusted_height: &Self::Height,
+        target_height: &Self::Height,
+        client_state: &Self::ClientState,
+    ) -> Result<Self::ConsensusState, Self::Error>;
+}

--- a/crates/relayer-components/src/chain/traits/client/mod.rs
+++ b/crates/relayer-components/src/chain/traits/client/mod.rs
@@ -1,0 +1,2 @@
+pub mod client_state;
+pub mod consensus_state;

--- a/crates/relayer-components/src/chain/traits/connection/mod.rs
+++ b/crates/relayer-components/src/chain/traits/connection/mod.rs
@@ -1,0 +1,1 @@
+pub mod proofs;

--- a/crates/relayer-components/src/chain/traits/connection/proofs.rs
+++ b/crates/relayer-components/src/chain/traits/connection/proofs.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::commitment::HasCommitmentProofsType;
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanBuildConnectionProofs<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasCommitmentProofsType<Counterparty> + HasErrorType
+{
+    async fn build_connection_proofs(
+        &self,
+        connection_id: &Self::ConnectionId,
+        height: &Self::Height,
+    ) -> Result<Self::CommitmentProofs, Self::Error>;
+}

--- a/crates/relayer-components/src/chain/traits/message_builders/ack_packet.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/ack_packet.rs
@@ -3,11 +3,12 @@ use async_trait::async_trait;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAcknowledgementEvent;
 use crate::chain::traits::types::packet::HasIbcPacketTypes;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanBuildAckPacketMessage<Counterparty>:
-    HasWriteAcknowledgementEvent<Counterparty> + HasIbcPacketTypes<Counterparty>
+    HasWriteAcknowledgementEvent<Counterparty> + HasIbcPacketTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasIbcChainTypes<Self>,
 {

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -1,9 +1,7 @@
-use core::time::Duration;
-
 use async_trait::async_trait;
 
 use crate::chain::traits::types::connection::{
-    HasConnectionHandshakePayloads, HasConnectionVersionType,
+    HasConnectionHandshakePayloads, HasInitConnectionOptionsType,
 };
 use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
@@ -14,7 +12,7 @@ pub trait CanBuildConnectionHandshakePayloads<Counterparty>:
 {
     async fn build_connection_open_init_payload(
         &self,
-    ) -> Result<Self::ConnectionInitPayload, Self::Error>;
+    ) -> Result<Self::ConnectionOpenInitPayload, Self::Error>;
 
     async fn build_connection_open_try_payload(
         &self,
@@ -40,7 +38,7 @@ pub trait CanBuildConnectionHandshakePayloads<Counterparty>:
 
 #[async_trait]
 pub trait CanBuildConnectionHandshakeMessages<Counterparty>:
-    HasConnectionVersionType<Counterparty> + HasErrorType
+    HasInitConnectionOptionsType<Counterparty> + HasErrorType
 where
     Counterparty: HasConnectionHandshakePayloads<Self>,
 {
@@ -48,9 +46,8 @@ where
         &self,
         client_id: &Self::ClientId,
         counterparty_client_id: &Counterparty::ClientId,
-        connection_version: &Self::ConnectionVersion,
-        delay_period: Duration,
-        counterparty_payload: Counterparty::ConnectionInitPayload,
+        init_connection_options: &Self::InitConnectionOptions,
+        counterparty_payload: Counterparty::ConnectionOpenInitPayload,
     ) -> Result<Self::Message, Self::Error>;
 
     async fn build_connection_open_try_message(

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -3,8 +3,8 @@ use core::time::Duration;
 use async_trait::async_trait;
 
 use crate::chain::traits::types::client_state::HasClientStateType;
-use crate::chain::traits::types::commitment::{HasCommitmentPrefixType, HasCommitmentProofsType};
-use crate::chain::traits::types::connection::HasConnectionVersionType;
+use crate::chain::traits::types::commitment::HasCommitmentProofsType;
+use crate::chain::traits::types::connection::{HasConnectionDetailsType, HasConnectionVersionType};
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::message::HasMessageType;
 use crate::core::traits::error::HasErrorType;
@@ -32,20 +32,16 @@ where
 pub trait CanBuildConnectionOpenTryMessage<Counterparty>:
     HasIbcChainTypes<Counterparty> + HasMessageType + HasErrorType
 where
-    Counterparty: HasIbcChainTypes<Self>
-        + HasConnectionVersionType<Self>
-        + HasCommitmentPrefixType<Self>
-        + HasCommitmentProofsType<Self>,
+    Counterparty:
+        HasIbcChainTypes<Self> + HasConnectionDetailsType<Self> + HasCommitmentProofsType<Self>,
 {
     async fn build_connection_open_try_message(
         &self,
         client_id: &Self::ClientId,
         counterparty_client_id: &Counterparty::ClientId,
         counterparty_connection_id: &Counterparty::ConnectionId,
-        counterparty_commitment: &Counterparty::CommitmentPrefix,
-        connection_version: &Counterparty::ConnectionVersion,
+        connection_end: &Counterparty::ConnectionDetails,
         commitment_proofs: &Counterparty::CommitmentProofs,
-        delay_period: Duration,
     ) -> Result<Self::Message, Self::Error>;
 }
 

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -63,7 +63,6 @@ where
 
     async fn build_connection_open_ack_message(
         &self,
-        client_id: &Self::ClientId,
         connection_id: &Self::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenAckPayload,
     ) -> Result<Self::Message, Self::Error>;

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -53,6 +53,8 @@ where
     async fn build_connection_open_try_message(
         &self,
         client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenTryPayload,
     ) -> Result<Self::Message, Self::Error>;
 

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -69,7 +69,6 @@ where
 
     async fn build_connection_open_confirm_message(
         &self,
-        client_id: &Self::ClientId,
         connection_id: &Self::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenConfirmPayload,
     ) -> Result<Self::Message, Self::Error>;

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -1,0 +1,78 @@
+use core::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::chain::traits::types::client_state::HasClientStateType;
+use crate::chain::traits::types::commitment::{HasCommitmentPrefixType, HasCommitmentProofsType};
+use crate::chain::traits::types::connection::HasConnectionVersionType;
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::chain::traits::types::message::HasMessageType;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanBuildConnectionOpenInitMessage<Counterparty>:
+    HasIbcChainTypes<Counterparty>
+    + HasConnectionVersionType<Counterparty>
+    + HasMessageType
+    + HasErrorType
+where
+    Counterparty: HasIbcChainTypes<Self>,
+{
+    async fn build_connection_open_init_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        connection_version: &Self::ConnectionVersion,
+        delay_period: Duration,
+    ) -> Result<Self::Message, Self::Error>;
+}
+
+#[async_trait]
+pub trait CanBuildConnectionOpenTryMessage<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasMessageType + HasErrorType
+where
+    Counterparty: HasIbcChainTypes<Self>
+        + HasConnectionVersionType<Self>
+        + HasCommitmentPrefixType<Self>
+        + HasCommitmentProofsType<Self>,
+{
+    async fn build_connection_open_try_message(
+        &self,
+        client_id: &Self::ClientId,
+        counterparty_client_id: &Counterparty::ClientId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
+        counterparty_commitment: &Counterparty::CommitmentPrefix,
+        connection_version: &Counterparty::ConnectionVersion,
+        commitment_proofs: &Counterparty::CommitmentProofs,
+        delay_period: Duration,
+    ) -> Result<Self::Message, Self::Error>;
+}
+
+#[async_trait]
+pub trait CanBuildConnectionOpenAckMessage<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasClientStateType<Counterparty> + HasMessageType + HasErrorType
+where
+    Counterparty: HasIbcChainTypes<Self> + HasCommitmentProofsType<Self>,
+{
+    async fn build_connection_open_ack_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
+        client_state: &Self::ClientState,
+        commitment_proofs: &Counterparty::CommitmentProofs,
+    ) -> Result<Self::Message, Self::Error>;
+}
+
+#[async_trait]
+pub trait CanBuildConnectionOpenConfirmMessage<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasMessageType + HasErrorType
+where
+    Counterparty: HasIbcChainTypes<Self> + HasCommitmentProofsType<Self>,
+{
+    async fn build_connection_open_confirm_message(
+        &self,
+        connection_id: &Self::ConnectionId,
+        commitment_proofs: &Counterparty::CommitmentProofs,
+    ) -> Result<Self::Message, Self::Error>;
+}

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -61,6 +61,7 @@ where
     async fn build_connection_open_ack_message(
         &self,
         connection_id: &Self::ConnectionId,
+        counterparty_connection_id: &Counterparty::ConnectionId,
         counterparty_payload: Counterparty::ConnectionOpenAckPayload,
     ) -> Result<Self::Message, Self::Error>;
 

--- a/crates/relayer-components/src/chain/traits/message_builders/connection.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/connection.rs
@@ -12,10 +12,8 @@ use crate::std_prelude::*;
 pub trait CanBuildConnectionHandshakePayloads<Counterparty>:
     HasConnectionHandshakePayloads<Counterparty> + HasErrorType
 {
-    async fn build_connection_init_payload(
+    async fn build_connection_open_init_payload(
         &self,
-        height: &Self::Height,
-        client_id: &Self::ClientId,
     ) -> Result<Self::ConnectionInitPayload, Self::Error>;
 
     async fn build_connection_open_try_payload(

--- a/crates/relayer-components/src/chain/traits/message_builders/create_client.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/create_client.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::client_state::HasClientStateType;
+use crate::chain::traits::types::consensus_state::HasConsensusStateType;
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanBuildCreateClientMessage<Counterparty>:
+    HasClientStateType<Counterparty> + HasConsensusStateType<Counterparty> + HasErrorType
+where
+    Counterparty: HasIbcChainTypes<Self>,
+{
+    async fn build_create_client_message(
+        client_state: &Self::ClientState,
+        consensus_state: &Self::ConsensusState,
+    ) -> Result<Self::Message, Self::Error>;
+}

--- a/crates/relayer-components/src/chain/traits/message_builders/create_client.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/create_client.rs
@@ -3,17 +3,17 @@ use async_trait::async_trait;
 use crate::chain::traits::types::client_state::HasClientStateType;
 use crate::chain::traits::types::consensus_state::HasConsensusStateType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::chain::traits::types::message::HasMessageType;
 use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanBuildCreateClientMessage<Counterparty>:
-    HasClientStateType<Counterparty> + HasConsensusStateType<Counterparty> + HasErrorType
+pub trait CanBuildCreateClientMessage<Counterparty>: HasMessageType + HasErrorType
 where
-    Counterparty: HasIbcChainTypes<Self>,
+    Counterparty: HasIbcChainTypes<Self> + HasClientStateType<Self> + HasConsensusStateType<Self>,
 {
     async fn build_create_client_message(
-        client_state: &Self::ClientState,
-        consensus_state: &Self::ConsensusState,
+        client_state: &Counterparty::ClientState,
+        consensus_state: &Counterparty::ConsensusState,
     ) -> Result<Self::Message, Self::Error>;
 }

--- a/crates/relayer-components/src/chain/traits/message_builders/mod.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/mod.rs
@@ -1,3 +1,4 @@
 pub mod ack_packet;
+pub mod create_client;
 pub mod receive_packet;
 pub mod timeout_unordered_packet;

--- a/crates/relayer-components/src/chain/traits/message_builders/mod.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/mod.rs
@@ -1,4 +1,5 @@
 pub mod ack_packet;
+pub mod connection;
 pub mod create_client;
 pub mod receive_packet;
 pub mod timeout_unordered_packet;

--- a/crates/relayer-components/src/chain/traits/message_builders/receive_packet.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/receive_packet.rs
@@ -2,10 +2,12 @@ use async_trait::async_trait;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::packet::HasIbcPacketTypes;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanBuildReceivePacketMessage<Counterparty>: HasIbcPacketTypes<Counterparty>
+pub trait CanBuildReceivePacketMessage<Counterparty>:
+    HasIbcPacketTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasIbcChainTypes<Self>,
 {

--- a/crates/relayer-components/src/chain/traits/message_builders/timeout_unordered_packet.rs
+++ b/crates/relayer-components/src/chain/traits/message_builders/timeout_unordered_packet.rs
@@ -2,11 +2,12 @@ use async_trait::async_trait;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::packet::HasIbcPacketTypes;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanBuildTimeoutUnorderedPacketMessage<Counterparty>:
-    HasIbcPacketTypes<Counterparty>
+    HasIbcPacketTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasIbcChainTypes<Self>,
 {

--- a/crates/relayer-components/src/chain/traits/message_sender.rs
+++ b/crates/relayer-components/src/chain/traits/message_sender.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 
 use crate::chain::traits::types::event::HasEventType;
 use crate::chain::traits::types::message::HasMessageType;
+use crate::core::traits::error::HasErrorType;
 use crate::core::traits::sync::Async;
 use crate::std_prelude::*;
 
@@ -60,7 +61,7 @@ use crate::std_prelude::*;
    provides the same interface for sending messages using this trait.
 */
 #[async_trait]
-pub trait CanSendMessages: HasMessageType + HasEventType {
+pub trait CanSendMessages: HasMessageType + HasEventType + HasErrorType {
     /**
         Given a list of [messages](HasMessageType::Message), submit the messages
         atomically to the chain.
@@ -89,7 +90,7 @@ pub trait CanSendMessages: HasMessageType + HasEventType {
 #[async_trait]
 pub trait MessageSender<Chain>: Async
 where
-    Chain: HasMessageType + HasEventType,
+    Chain: HasMessageType + HasEventType + HasErrorType,
 {
     /**
        Corresponds to [`CanSendMessages::send_messages`]

--- a/crates/relayer-components/src/chain/traits/message_sender.rs
+++ b/crates/relayer-components/src/chain/traits/message_sender.rs
@@ -100,3 +100,59 @@ where
         messages: Vec<Chain::Message>,
     ) -> Result<Vec<Vec<Chain::Event>>, Chain::Error>;
 }
+
+pub trait InjectMismatchIbcEventsCountError: HasErrorType {
+    fn mismatch_ibc_events_count_error(expected: usize, actual: usize) -> Self::Error;
+}
+
+#[async_trait]
+pub trait CanSendFixSizedMessages: HasMessageType + HasEventType + HasErrorType {
+    async fn send_messages_fixed<const COUNT: usize>(
+        &self,
+        messages: [Self::Message; COUNT],
+    ) -> Result<[Vec<Self::Event>; COUNT], Self::Error>;
+}
+
+#[async_trait]
+pub trait CanSendSingleMessage: HasMessageType + HasEventType + HasErrorType {
+    async fn send_message(&self, message: Self::Message) -> Result<Vec<Self::Event>, Self::Error>;
+}
+
+#[async_trait]
+impl<Chain> CanSendFixSizedMessages for Chain
+where
+    Chain: CanSendMessages + InjectMismatchIbcEventsCountError,
+{
+    async fn send_messages_fixed<const COUNT: usize>(
+        &self,
+        messages: [Chain::Message; COUNT],
+    ) -> Result<[Vec<Chain::Event>; COUNT], Self::Error> {
+        let events_vec = self.send_messages(messages.into()).await?;
+
+        let events = events_vec
+            .try_into()
+            .map_err(|e: Vec<_>| Chain::mismatch_ibc_events_count_error(COUNT, e.len()))?;
+
+        Ok(events)
+    }
+}
+
+#[async_trait]
+impl<Chain> CanSendSingleMessage for Chain
+where
+    Chain: CanSendMessages,
+{
+    async fn send_message(
+        &self,
+        message: Chain::Message,
+    ) -> Result<Vec<Chain::Event>, Chain::Error> {
+        let events = self
+            .send_messages(vec![message])
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        Ok(events)
+    }
+}

--- a/crates/relayer-components/src/chain/traits/mod.rs
+++ b/crates/relayer-components/src/chain/traits/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod event_subscription;
 pub mod logs;
 pub mod message_builders;

--- a/crates/relayer-components/src/chain/traits/mod.rs
+++ b/crates/relayer-components/src/chain/traits/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod connection;
 pub mod event_subscription;
 pub mod logs;
 pub mod message_builders;

--- a/crates/relayer-components/src/chain/traits/mod.rs
+++ b/crates/relayer-components/src/chain/traits/mod.rs
@@ -6,3 +6,4 @@ pub mod message_builders;
 pub mod message_sender;
 pub mod queries;
 pub mod types;
+pub mod wait;

--- a/crates/relayer-components/src/chain/traits/queries/channel.rs
+++ b/crates/relayer-components/src/chain/traits/queries/channel.rs
@@ -2,11 +2,12 @@ use async_trait::async_trait;
 
 use crate::chain::traits::types::chain::HasChainTypes;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanQueryCounterpartyChainIdFromChannel<Counterparty>:
-    HasIbcChainTypes<Counterparty>
+    HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasChainTypes,
 {

--- a/crates/relayer-components/src/chain/traits/queries/client.rs
+++ b/crates/relayer-components/src/chain/traits/queries/client.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::client_state::HasClientStateType;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanQueryClientState<Counterparty>:
+    HasClientStateType<Counterparty> + HasErrorType
+{
+    async fn query_connection(
+        &self,
+        client_id: &Self::ClientId,
+        height: &Self::Height,
+    ) -> Result<Self::ClientState, Self::Error>;
+}

--- a/crates/relayer-components/src/chain/traits/queries/connection.rs
+++ b/crates/relayer-components/src/chain/traits/queries/connection.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::connection::HasConnectionEndType;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanQueryConnection<Counterparty>:
+    HasConnectionEndType<Counterparty> + HasErrorType
+{
+    async fn query_connection(
+        &self,
+        connection_id: &Self::ConnectionId,
+    ) -> Result<Self::ConnectionEnd, Self::Error>;
+}

--- a/crates/relayer-components/src/chain/traits/queries/connection.rs
+++ b/crates/relayer-components/src/chain/traits/queries/connection.rs
@@ -1,15 +1,24 @@
 use async_trait::async_trait;
 
-use crate::chain::traits::types::connection::HasConnectionDetailsType;
+use crate::chain::traits::types::connection::{HasConnectionDetailsType, HasConnectionVersionType};
 use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanQueryConnection<Counterparty>:
+pub trait CanQueryConnectionDetails<Counterparty>:
     HasConnectionDetailsType<Counterparty> + HasErrorType
 {
-    async fn query_connection(
+    async fn query_connection_details(
         &self,
         connection_id: &Self::ConnectionId,
     ) -> Result<Self::ConnectionDetails, Self::Error>;
+}
+
+#[async_trait]
+pub trait CanQueryCompatibleConnectionVersions<Counterparty>:
+    HasConnectionVersionType<Counterparty> + HasErrorType
+{
+    async fn query_compatible_connection_versions(
+        &self,
+    ) -> Result<Vec<Self::ConnectionVersion>, Self::Error>;
 }

--- a/crates/relayer-components/src/chain/traits/queries/connection.rs
+++ b/crates/relayer-components/src/chain/traits/queries/connection.rs
@@ -1,15 +1,15 @@
 use async_trait::async_trait;
 
-use crate::chain::traits::types::connection::HasConnectionEndType;
+use crate::chain::traits::types::connection::HasConnectionDetailsType;
 use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanQueryConnection<Counterparty>:
-    HasConnectionEndType<Counterparty> + HasErrorType
+    HasConnectionDetailsType<Counterparty> + HasErrorType
 {
     async fn query_connection(
         &self,
         connection_id: &Self::ConnectionId,
-    ) -> Result<Self::ConnectionEnd, Self::Error>;
+    ) -> Result<Self::ConnectionDetails, Self::Error>;
 }

--- a/crates/relayer-components/src/chain/traits/queries/consensus_state.rs
+++ b/crates/relayer-components/src/chain/traits/queries/consensus_state.rs
@@ -2,12 +2,13 @@ use async_trait::async_trait;
 
 use crate::chain::traits::types::consensus_state::HasConsensusStateType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait ConsensusStateQuerier<Chain, Counterparty>
 where
-    Chain: HasIbcChainTypes<Counterparty>,
+    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
     Counterparty: HasConsensusStateType<Chain>,
 {
     async fn query_consensus_state(
@@ -18,7 +19,8 @@ where
 }
 
 #[async_trait]
-pub trait CanQueryConsensusState<Counterparty>: HasIbcChainTypes<Counterparty>
+pub trait CanQueryConsensusState<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasConsensusStateType<Self>,
 {

--- a/crates/relayer-components/src/chain/traits/queries/mod.rs
+++ b/crates/relayer-components/src/chain/traits/queries/mod.rs
@@ -1,4 +1,6 @@
 pub mod channel;
+pub mod client;
+pub mod connection;
 pub mod consensus_state;
 pub mod received_packet;
 pub mod status;

--- a/crates/relayer-components/src/chain/traits/queries/received_packet.rs
+++ b/crates/relayer-components/src/chain/traits/queries/received_packet.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait ReceivedPacketQuerier<Chain, Counterparty>
 where
-    Chain: HasIbcChainTypes<Counterparty>,
+    Chain: HasIbcChainTypes<Counterparty> + HasErrorType,
     Counterparty: HasIbcChainTypes<Chain>,
 {
     async fn query_is_packet_received(
@@ -18,7 +19,8 @@ where
 }
 
 #[async_trait]
-pub trait CanQueryReceivedPacket<Counterparty>: HasIbcChainTypes<Counterparty>
+pub trait CanQueryReceivedPacket<Counterparty>:
+    HasIbcChainTypes<Counterparty> + HasErrorType
 where
     Counterparty: HasIbcChainTypes<Self>,
 {

--- a/crates/relayer-components/src/chain/traits/queries/status.rs
+++ b/crates/relayer-components/src/chain/traits/queries/status.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::chain::traits::types::status::HasChainStatusType;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 /**
@@ -8,7 +9,7 @@ use crate::std_prelude::*;
    [current status](HasChainStatusType::ChainStatus) of the blockchain.
 */
 #[async_trait]
-pub trait CanQueryChainStatus: HasChainStatusType {
+pub trait CanQueryChainStatus: HasChainStatusType + HasErrorType {
     /**
         Query the current status of the blockchain. The returned
         [status](HasChainStatusType::ChainStatus) is required to have the same
@@ -32,6 +33,9 @@ pub trait CanQueryChainStatus: HasChainStatusType {
    The provider trait for [`ChainStatusQuerier`].
 */
 #[async_trait]
-pub trait ChainStatusQuerier<Chain: HasChainStatusType> {
+pub trait ChainStatusQuerier<Chain>
+where
+    Chain: HasChainStatusType + HasErrorType,
+{
     async fn query_chain_status(context: &Chain) -> Result<Chain::ChainStatus, Chain::Error>;
 }

--- a/crates/relayer-components/src/chain/traits/queries/status.rs
+++ b/crates/relayer-components/src/chain/traits/queries/status.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use crate::chain::traits::types::height::HasHeightType;
 use crate::chain::traits::types::status::HasChainStatusType;
 use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
@@ -38,4 +39,22 @@ where
     Chain: HasChainStatusType + HasErrorType,
 {
     async fn query_chain_status(context: &Chain) -> Result<Chain::ChainStatus, Chain::Error>;
+}
+
+#[async_trait]
+pub trait CanQueryChainHeight: HasHeightType + HasErrorType {
+    async fn query_chain_height(&self) -> Result<Self::Height, Self::Error>;
+}
+
+#[async_trait]
+impl<Chain> CanQueryChainHeight for Chain
+where
+    Chain: CanQueryChainStatus,
+    Chain::Height: Clone,
+{
+    async fn query_chain_height(&self) -> Result<Chain::Height, Chain::Error> {
+        let status = self.query_chain_status().await?;
+        let height = Chain::chain_status_height(&status);
+        Ok(height.clone())
+    }
 }

--- a/crates/relayer-components/src/chain/traits/queries/write_ack.rs
+++ b/crates/relayer-components/src/chain/traits/queries/write_ack.rs
@@ -2,11 +2,12 @@ use async_trait::async_trait;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAcknowledgementEvent;
+use crate::core::traits::error::HasErrorType;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanQueryWriteAcknowledgement<Counterparty>:
-    HasWriteAcknowledgementEvent<Counterparty>
+    HasWriteAcknowledgementEvent<Counterparty> + HasErrorType
 where
     Counterparty: HasIbcChainTypes<Self>,
 {

--- a/crates/relayer-components/src/chain/traits/types/chain.rs
+++ b/crates/relayer-components/src/chain/traits/types/chain.rs
@@ -7,15 +7,11 @@ use crate::chain::traits::types::event::HasEventType;
 use crate::chain::traits::types::height::HasHeightType;
 use crate::chain::traits::types::message::HasMessageType;
 use crate::chain::traits::types::timestamp::HasTimestampType;
-use crate::core::traits::error::HasErrorType;
 
 /**
    This covers the minimal abstract types that are used inside a chain context.
 
    A chain context have the following abstract types:
-
-   -   [`Error`](HasErrorType::Error) - the error type encapsulating errors occured
-       during chain operations.
 
    -   [`Height`](HasHeightType::Height) - the height of a chain, which should
         behave like natural numbers.
@@ -41,16 +37,11 @@ use crate::core::traits::error::HasErrorType;
     about the transaction context.
 */
 pub trait HasChainTypes:
-    HasHeightType + HasMessageType + HasEventType + HasChainIdType + HasTimestampType + HasErrorType
+    HasHeightType + HasMessageType + HasEventType + HasChainIdType + HasTimestampType
 {
 }
 
 impl<Chain> HasChainTypes for Chain where
-    Chain: HasHeightType
-        + HasMessageType
-        + HasEventType
-        + HasChainIdType
-        + HasTimestampType
-        + HasErrorType
+    Chain: HasHeightType + HasMessageType + HasEventType + HasChainIdType + HasTimestampType
 {
 }

--- a/crates/relayer-components/src/chain/traits/types/client_state.rs
+++ b/crates/relayer-components/src/chain/traits/types/client_state.rs
@@ -1,0 +1,13 @@
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::sync::Async;
+
+pub trait HasClientStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    /**
+        The client state of the `Self` chain's client on the `Counterparty` chain
+    */
+    type ClientState: Async;
+}
+
+pub trait HasClientStateSettingsType<Counterparty>: HasClientStateType<Counterparty> {
+    type ClientStateSettings: Async;
+}

--- a/crates/relayer-components/src/chain/traits/types/commitment.rs
+++ b/crates/relayer-components/src/chain/traits/types/commitment.rs
@@ -1,0 +1,9 @@
+use crate::core::traits::sync::Async;
+
+pub trait HasCommitmentPrefixType<Counterparty>: Async {
+    type CommitmentPrefix: Async;
+}
+
+pub trait HasCommitmentProofsType<Counterparty>: Async {
+    type CommitmentProofs: Async;
+}

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::core::traits::sync::Async;
 
@@ -6,7 +8,7 @@ pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty>
 }
 
 pub trait HasConnectionStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
-    type ConnectionState;
+    type ConnectionState: Async;
 
     fn is_connection_state_init(connection_state: &Self::ConnectionState) -> bool;
 
@@ -15,8 +17,20 @@ pub trait HasConnectionStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
     fn is_connection_state_open(connection_state: &Self::ConnectionState) -> bool;
 }
 
-pub trait HasConnectionEndType<Counterparty>: HasConnectionStateType<Counterparty> {
-    type ConnectionEnd;
+pub trait HasConnectionDetailsType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    type ConnectionDetails: Async;
+}
 
-    fn connection_state(connection: &Self::ConnectionEnd) -> &Self::ConnectionState;
+pub trait HasConnectionDetailsFields<Counterparty>:
+    HasConnectionDetailsType<Counterparty>
+    + HasConnectionStateType<Counterparty>
+    + HasConnectionVersionType<Counterparty>
+{
+    fn connection_details_state(connection: &Self::ConnectionDetails) -> &Self::ConnectionState;
+
+    fn connection_details_delay(connection: &Self::ConnectionDetails) -> Duration;
+
+    fn connection_details_versions(
+        connection: &Self::ConnectionDetails,
+    ) -> &[Self::ConnectionVersion];
 }

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -30,7 +30,7 @@ pub trait HasConnectionHandshakePayloads<Counterparty>: HasIbcChainTypes<Counter
 }
 
 pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty> {
-    type ConnectionVersion: Async;
+    type ConnectionVersion: Eq + Async;
 }
 
 pub trait HasConnectionDetailsType<Counterparty>: HasIbcChainTypes<Counterparty> {

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -15,12 +15,16 @@ pub trait HasConnectionStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
     fn connection_base_state(state: &Self::ConnectionState) -> Option<ConnectionBaseState>;
 }
 
+pub trait HasInitConnectionOptionsType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    type InitConnectionOptions: Async;
+}
+
 /**
     Payload that contains necessary counterparty information such as proofs and parameters
     in order for a self chain to build a connection handshake message.
 */
 pub trait HasConnectionHandshakePayloads<Counterparty>: HasIbcChainTypes<Counterparty> {
-    type ConnectionInitPayload: Async;
+    type ConnectionOpenInitPayload: Async;
 
     type ConnectionOpenTryPayload: Async;
 

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -30,7 +30,7 @@ pub trait HasConnectionHandshakePayloads<Counterparty>: HasIbcChainTypes<Counter
 }
 
 pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty> {
-    type ConnectionVersion: Eq + Async;
+    type ConnectionVersion: Eq + Default + Async;
 }
 
 pub trait HasConnectionDetailsType<Counterparty>: HasIbcChainTypes<Counterparty> {

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -1,0 +1,6 @@
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::sync::Async;
+
+pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    type ConnectionVersion: Async;
+}

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -3,18 +3,34 @@ use core::time::Duration;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::core::traits::sync::Async;
 
-pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty> {
-    type ConnectionVersion: Async;
+pub enum ConnectionBaseState {
+    Init,
+    TryOpen,
+    Open,
 }
 
 pub trait HasConnectionStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
     type ConnectionState: Async;
 
-    fn is_connection_state_init(connection_state: &Self::ConnectionState) -> bool;
+    fn connection_base_state(state: &Self::ConnectionState) -> Option<ConnectionBaseState>;
+}
 
-    fn is_connection_state_try_open(connection_state: &Self::ConnectionState) -> bool;
+/**
+    Payload that contains necessary counterparty information such as proofs and parameters
+    in order for a self chain to build a connection handshake message.
+*/
+pub trait HasConnectionHandshakePayloads<Counterparty>: HasIbcChainTypes<Counterparty> {
+    type ConnectionInitPayload: Async;
 
-    fn is_connection_state_open(connection_state: &Self::ConnectionState) -> bool;
+    type ConnectionOpenTryPayload: Async;
+
+    type ConnectionOpenAckPayload: Async;
+
+    type ConnectionOpenConfirmPayload: Async;
+}
+
+pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    type ConnectionVersion: Async;
 }
 
 pub trait HasConnectionDetailsType<Counterparty>: HasIbcChainTypes<Counterparty> {

--- a/crates/relayer-components/src/chain/traits/types/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/connection.rs
@@ -4,3 +4,19 @@ use crate::core::traits::sync::Async;
 pub trait HasConnectionVersionType<Counterparty>: HasIbcChainTypes<Counterparty> {
     type ConnectionVersion: Async;
 }
+
+pub trait HasConnectionStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    type ConnectionState;
+
+    fn is_connection_state_init(connection_state: &Self::ConnectionState) -> bool;
+
+    fn is_connection_state_try_open(connection_state: &Self::ConnectionState) -> bool;
+
+    fn is_connection_state_open(connection_state: &Self::ConnectionState) -> bool;
+}
+
+pub trait HasConnectionEndType<Counterparty>: HasConnectionStateType<Counterparty> {
+    type ConnectionEnd;
+
+    fn connection_state(connection: &Self::ConnectionEnd) -> &Self::ConnectionState;
+}

--- a/crates/relayer-components/src/chain/traits/types/consensus_state.rs
+++ b/crates/relayer-components/src/chain/traits/types/consensus_state.rs
@@ -1,10 +1,9 @@
-use crate::chain::traits::types::chain::HasChainTypes;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::core::traits::sync::Async;
 
-pub trait HasConsensusStateType<Counterparty>: HasIbcChainTypes<Counterparty>
-where
-    Counterparty: HasChainTypes,
-{
+pub trait HasConsensusStateType<Counterparty>: HasIbcChainTypes<Counterparty> {
+    /**
+        The consensus state of the `Self` chain's client on the `Counterparty` chain
+    */
     type ConsensusState: Async;
 }

--- a/crates/relayer-components/src/chain/traits/types/ibc.rs
+++ b/crates/relayer-components/src/chain/traits/types/ibc.rs
@@ -46,10 +46,7 @@ use crate::std_prelude::*;
    access to two chain contexts are handled by the
    [relay context](crate::relay).
 */
-pub trait HasIbcChainTypes<Counterparty>: HasChainTypes
-where
-    Counterparty: HasChainTypes,
-{
+pub trait HasIbcChainTypes<Counterparty>: HasChainTypes {
     /**
        The client ID of the counterparty chain, that is stored on the self
        chain.

--- a/crates/relayer-components/src/chain/traits/types/ibc_events/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/ibc_events/connection.rs
@@ -15,3 +15,18 @@ where
         event: &Self::ConnectionOpenTryEvent,
     ) -> &Self::ConnectionId;
 }
+
+pub trait HasConnectionOpenInitEvent<Counterparty>: HasIbcChainTypes<Counterparty>
+where
+    Counterparty: HasIbcChainTypes<Self>,
+{
+    type ConnectionOpenInitEvent: Async;
+
+    fn try_extract_connection_open_init_event(
+        event: Self::Event,
+    ) -> Option<Self::ConnectionOpenInitEvent>;
+
+    fn connection_open_init_event_connection_id(
+        event: &Self::ConnectionOpenInitEvent,
+    ) -> &Self::ConnectionId;
+}

--- a/crates/relayer-components/src/chain/traits/types/ibc_events/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/ibc_events/connection.rs
@@ -13,15 +13,5 @@ where
 
     fn connection_open_try_event_connection_id(
         event: &Self::ConnectionOpenTryEvent,
-    ) -> Self::ConnectionId;
-
-    fn connection_open_try_event_client_id(event: &Self::ConnectionOpenTryEvent) -> Self::ClientId;
-
-    fn connection_open_try_event_counterparty_connection_id(
-        event: &Self::ConnectionOpenTryEvent,
-    ) -> Counterparty::ConnectionId;
-
-    fn connection_open_try_event_counterparty_client_id(
-        event: &Self::ConnectionOpenTryEvent,
-    ) -> Counterparty::ClientId;
+    ) -> &Self::ConnectionId;
 }

--- a/crates/relayer-components/src/chain/traits/types/ibc_events/connection.rs
+++ b/crates/relayer-components/src/chain/traits/types/ibc_events/connection.rs
@@ -1,0 +1,27 @@
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::sync::Async;
+
+pub trait HasConnectionOpenTryEvent<Counterparty>: HasIbcChainTypes<Counterparty>
+where
+    Counterparty: HasIbcChainTypes<Self>,
+{
+    type ConnectionOpenTryEvent: Async;
+
+    fn try_extract_connection_open_try_event(
+        event: Self::Event,
+    ) -> Option<Self::ConnectionOpenTryEvent>;
+
+    fn connection_open_try_event_connection_id(
+        event: &Self::ConnectionOpenTryEvent,
+    ) -> Self::ConnectionId;
+
+    fn connection_open_try_event_client_id(event: &Self::ConnectionOpenTryEvent) -> Self::ClientId;
+
+    fn connection_open_try_event_counterparty_connection_id(
+        event: &Self::ConnectionOpenTryEvent,
+    ) -> Counterparty::ConnectionId;
+
+    fn connection_open_try_event_counterparty_client_id(
+        event: &Self::ConnectionOpenTryEvent,
+    ) -> Counterparty::ClientId;
+}

--- a/crates/relayer-components/src/chain/traits/types/ibc_events/mod.rs
+++ b/crates/relayer-components/src/chain/traits/types/ibc_events/mod.rs
@@ -4,5 +4,6 @@
    [`HasWriteAcknowledgementEvent`](write_ack::HasWriteAcknowledgementEvent).
 */
 
+pub mod connection;
 pub mod send_packet;
 pub mod write_ack;

--- a/crates/relayer-components/src/chain/traits/types/ibc_events/write_ack.rs
+++ b/crates/relayer-components/src/chain/traits/types/ibc_events/write_ack.rs
@@ -45,7 +45,13 @@ where
     fn try_extract_write_acknowledgement_event(
         event: &Self::Event,
     ) -> Option<Self::WriteAcknowledgementEvent>;
+}
 
+pub trait CanBuildPacketFromWriteAckEvent<Counterparty>:
+    HasWriteAcknowledgementEvent<Counterparty>
+where
+    Counterparty: HasIbcChainTypes<Self>,
+{
     /**
        Extract the [`IncomingPacket`](HasIbcPacketTypes::IncomingPacket)
        from a write acknowledgement event.
@@ -60,7 +66,7 @@ where
        refactored into a method like
        `query_packet_from_write_acknowledgement_event`.
     */
-    fn extract_packet_from_write_acknowledgement_event(
+    fn build_packet_from_write_acknowledgement_event(
         ack: &Self::WriteAcknowledgementEvent,
     ) -> &Self::IncomingPacket;
 }

--- a/crates/relayer-components/src/chain/traits/types/message.rs
+++ b/crates/relayer-components/src/chain/traits/types/message.rs
@@ -17,7 +17,7 @@ use crate::std_prelude::*;
    we want to avoid defining multiple associated `Message` types so that
    they can never be ambiguous.
 */
-pub trait HasMessageType: HasErrorType {
+pub trait HasMessageType: Async {
     /**
        The messages that can be assembled into transactions and be submitted to
        a blockchain.
@@ -55,7 +55,7 @@ pub trait HasMessageType: HasErrorType {
     type Message: Async;
 }
 
-pub trait CanEstimateMessageSize: HasMessageType {
+pub trait CanEstimateMessageSize: HasMessageType + HasErrorType {
     /**
        Estimate the size of a message after it is encoded into raw bytes
        inside a transaction.

--- a/crates/relayer-components/src/chain/traits/types/mod.rs
+++ b/crates/relayer-components/src/chain/traits/types/mod.rs
@@ -8,6 +8,8 @@
 pub mod chain;
 pub mod chain_id;
 pub mod client_state;
+pub mod commitment;
+pub mod connection;
 pub mod consensus_state;
 pub mod event;
 pub mod height;

--- a/crates/relayer-components/src/chain/traits/types/mod.rs
+++ b/crates/relayer-components/src/chain/traits/types/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod chain;
 pub mod chain_id;
+pub mod client_state;
 pub mod consensus_state;
 pub mod event;
 pub mod height;

--- a/crates/relayer-components/src/chain/traits/wait.rs
+++ b/crates/relayer-components/src/chain/traits/wait.rs
@@ -31,7 +31,7 @@ where
         loop {
             let current_height = self.query_chain_height().await?;
 
-            if &current_height >= height {
+            if &current_height > height {
                 return Ok(current_height.clone());
             } else {
                 self.runtime().sleep(Duration::from_millis(100)).await;

--- a/crates/relayer-components/src/chain/traits/wait.rs
+++ b/crates/relayer-components/src/chain/traits/wait.rs
@@ -1,10 +1,43 @@
+use core::time::Duration;
+
 use async_trait::async_trait;
 
+use crate::chain::traits::queries::status::CanQueryChainStatus;
 use crate::chain::traits::types::height::HasHeightType;
 use crate::core::traits::error::HasErrorType;
+use crate::runtime::traits::runtime::HasRuntime;
+use crate::runtime::traits::sleep::CanSleep;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanWaitChainSurpassHeight: HasHeightType + HasErrorType {
-    async fn wait_chain_surpass_height(&self, height: &Self::Height) -> Result<(), Self::Error>;
+    async fn wait_chain_surpass_height(
+        &self,
+        height: &Self::Height,
+    ) -> Result<Self::Height, Self::Error>;
+}
+
+#[async_trait]
+impl<Chain> CanWaitChainSurpassHeight for Chain
+where
+    Chain: CanQueryChainStatus + HasRuntime,
+    Chain::Runtime: CanSleep,
+    Chain::Height: Clone,
+{
+    async fn wait_chain_surpass_height(
+        &self,
+        height: &Chain::Height,
+    ) -> Result<Chain::Height, Chain::Error> {
+        loop {
+            let current_status = self.query_chain_status().await?;
+
+            let current_height = Chain::chain_status_height(&current_status);
+
+            if current_height >= height {
+                return Ok(current_height.clone());
+            } else {
+                self.runtime().sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
 }

--- a/crates/relayer-components/src/chain/traits/wait.rs
+++ b/crates/relayer-components/src/chain/traits/wait.rs
@@ -31,7 +31,7 @@ where
         loop {
             let current_height = self.query_chain_height().await?;
 
-            if &current_height > height {
+            if &current_height >= height {
                 return Ok(current_height.clone());
             } else {
                 self.runtime().sleep(Duration::from_millis(100)).await;

--- a/crates/relayer-components/src/chain/traits/wait.rs
+++ b/crates/relayer-components/src/chain/traits/wait.rs
@@ -10,21 +10,21 @@ use crate::runtime::traits::sleep::CanSleep;
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanWaitChainSurpassHeight: HasHeightType + HasErrorType {
-    async fn wait_chain_surpass_height(
+pub trait CanWaitChainReachHeight: HasHeightType + HasErrorType {
+    async fn wait_chain_reach_height(
         &self,
         height: &Self::Height,
     ) -> Result<Self::Height, Self::Error>;
 }
 
 #[async_trait]
-impl<Chain> CanWaitChainSurpassHeight for Chain
+impl<Chain> CanWaitChainReachHeight for Chain
 where
     Chain: CanQueryChainHeight + HasRuntime,
     Chain::Runtime: CanSleep,
     Chain::Height: Clone,
 {
-    async fn wait_chain_surpass_height(
+    async fn wait_chain_reach_height(
         &self,
         height: &Chain::Height,
     ) -> Result<Chain::Height, Chain::Error> {

--- a/crates/relayer-components/src/chain/traits/wait.rs
+++ b/crates/relayer-components/src/chain/traits/wait.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::chain::traits::queries::status::CanQueryChainStatus;
+use crate::chain::traits::queries::status::CanQueryChainHeight;
 use crate::chain::traits::types::height::HasHeightType;
 use crate::core::traits::error::HasErrorType;
 use crate::runtime::traits::runtime::HasRuntime;
@@ -20,7 +20,7 @@ pub trait CanWaitChainSurpassHeight: HasHeightType + HasErrorType {
 #[async_trait]
 impl<Chain> CanWaitChainSurpassHeight for Chain
 where
-    Chain: CanQueryChainStatus + HasRuntime,
+    Chain: CanQueryChainHeight + HasRuntime,
     Chain::Runtime: CanSleep,
     Chain::Height: Clone,
 {
@@ -29,11 +29,9 @@ where
         height: &Chain::Height,
     ) -> Result<Chain::Height, Chain::Error> {
         loop {
-            let current_status = self.query_chain_status().await?;
+            let current_height = self.query_chain_height().await?;
 
-            let current_height = Chain::chain_status_height(&current_status);
-
-            if current_height >= height {
+            if &current_height >= height {
                 return Ok(current_height.clone());
             } else {
                 self.runtime().sleep(Duration::from_millis(100)).await;

--- a/crates/relayer-components/src/chain/traits/wait.rs
+++ b/crates/relayer-components/src/chain/traits/wait.rs
@@ -1,0 +1,10 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::height::HasHeightType;
+use crate::core::traits::error::HasErrorType;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanWaitChainSurpassHeight: HasHeightType + HasErrorType {
+    async fn wait_chain_surpass_height(&self, height: &Self::Height) -> Result<(), Self::Error>;
+}

--- a/crates/relayer-components/src/relay/impls/auto_relayers/concurrent_two_way.rs
+++ b/crates/relayer-components/src/relay/impls/auto_relayers/concurrent_two_way.rs
@@ -11,7 +11,7 @@ use crate::std_prelude::*;
 /// A concurrent two-way relay context that is composed of a `BiRelay` type that
 /// can auto-relay between two connected targets.
 ///
-/// As opposed to the [`ParallelTwoWayAutoRelay`] variant, this concurrent variant
+/// As opposed to the `ParallelTwoWayAutoRelay` variant, this concurrent variant
 /// runs in a single thread and achieves concurrency via cooperative multi-tasking.
 pub struct ConcurrentTwoWayAutoRelay;
 

--- a/crates/relayer-components/src/relay/impls/connection/bootstrap.rs
+++ b/crates/relayer-components/src/relay/impls/connection/bootstrap.rs
@@ -8,6 +8,18 @@ use crate::relay::traits::connection::open_init::CanInitConnection;
 use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
 use crate::std_prelude::*;
 
+/**
+   This is an autotrait implementation by the relay context to allow bootstrapping
+   of new IBC connections as initiated by the relayer.
+
+   This can be used by the users of the relayer to create new connections. It can
+   also be used in integration tests to create new connections.
+
+   Note that this should _not_ be used when relaying connection creation that
+   are initiated by external users. For that purpose, use
+   [`RelayConnectionOpenHandshake`](crate::relay::impls::connection::open_handshake::RelayConnectionOpenHandshake),
+   which would reuse the given connection ID instead of creating new ones.
+*/
 #[async_trait]
 pub trait CanBootstrapConnection: HasRelayChains
 where

--- a/crates/relayer-components/src/relay/impls/connection/bootstrap.rs
+++ b/crates/relayer-components/src/relay/impls/connection/bootstrap.rs
@@ -1,8 +1,6 @@
-use core::time::Duration;
-
 use async_trait::async_trait;
 
-use crate::chain::traits::queries::connection::CanQueryCompatibleConnectionVersions;
+use crate::chain::traits::types::connection::HasInitConnectionOptionsType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::connection::open_handshake::CanRelayConnectionOpenHandshake;
@@ -11,10 +9,15 @@ use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanBootstrapConnection: HasRelayChains {
+pub trait CanBootstrapConnection: HasRelayChains
+where
+    Self::SrcChain: HasInitConnectionOptionsType<Self::DstChain>,
+{
     async fn bootstrap_connection(
         &self,
-        connection_delay: Duration,
+        init_connection_options: &<Self::SrcChain as HasInitConnectionOptionsType<
+            Self::DstChain,
+        >>::InitConnectionOptions,
     ) -> Result<(SrcConnectionId<Self>, DstConnectionId<Self>), Self::Error>;
 }
 
@@ -24,27 +27,14 @@ where
     Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
         + CanInitConnection
         + CanRelayConnectionOpenHandshake,
-    SrcChain: CanQueryCompatibleConnectionVersions<DstChain>,
+    SrcChain: HasInitConnectionOptionsType<DstChain>,
     DstChain: HasIbcChainTypes<SrcChain>,
 {
     async fn bootstrap_connection(
         &self,
-        connection_delay: Duration,
+        init_connection_options: &SrcChain::InitConnectionOptions,
     ) -> Result<(SrcChain::ConnectionId, DstChain::ConnectionId), Self::Error> {
-        let compatible_versions = self
-            .src_chain()
-            .query_compatible_connection_versions()
-            .await
-            .map_err(Relay::src_chain_error)?;
-
-        let connection_version = compatible_versions
-            .into_iter()
-            .next()
-            .unwrap_or_else(Default::default);
-
-        let src_connection_id = self
-            .init_connection(connection_version, connection_delay)
-            .await?;
+        let src_connection_id = self.init_connection(init_connection_options).await?;
 
         let dst_connection_id = self
             .relay_connection_open_handshake(&src_connection_id)

--- a/crates/relayer-components/src/relay/impls/connection/bootstrap.rs
+++ b/crates/relayer-components/src/relay/impls/connection/bootstrap.rs
@@ -1,0 +1,55 @@
+use core::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::chain::traits::queries::connection::CanQueryCompatibleConnectionVersions;
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::connection::open_handshake::CanRelayConnectionOpenHandshake;
+use crate::relay::traits::connection::open_init::CanInitConnection;
+use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanBootstrapConnection: HasRelayChains {
+    async fn bootstrap_connection(
+        &self,
+        connection_delay: Duration,
+    ) -> Result<(SrcConnectionId<Self>, DstConnectionId<Self>), Self::Error>;
+}
+
+#[async_trait]
+impl<Relay, SrcChain, DstChain> CanBootstrapConnection for Relay
+where
+    Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
+        + CanInitConnection
+        + CanRelayConnectionOpenHandshake,
+    SrcChain: CanQueryCompatibleConnectionVersions<DstChain>,
+    DstChain: HasIbcChainTypes<SrcChain>,
+{
+    async fn bootstrap_connection(
+        &self,
+        connection_delay: Duration,
+    ) -> Result<(SrcChain::ConnectionId, DstChain::ConnectionId), Self::Error> {
+        let compatible_versions = self
+            .src_chain()
+            .query_compatible_connection_versions()
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let connection_version = compatible_versions
+            .into_iter()
+            .next()
+            .unwrap_or_else(Default::default);
+
+        let src_connection_id = self
+            .init_connection(connection_version, connection_delay)
+            .await?;
+
+        let dst_connection_id = self
+            .relay_connection_open_handshake(&src_connection_id)
+            .await?;
+
+        Ok((src_connection_id, dst_connection_id))
+    }
+}

--- a/crates/relayer-components/src/relay/impls/connection/mod.rs
+++ b/crates/relayer-components/src/relay/impls/connection/mod.rs
@@ -1,1 +1,2 @@
+pub mod open_ack;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/impls/connection/mod.rs
+++ b/crates/relayer-components/src/relay/impls/connection/mod.rs
@@ -1,2 +1,3 @@
 pub mod open_ack;
+pub mod open_confirm;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/impls/connection/mod.rs
+++ b/crates/relayer-components/src/relay/impls/connection/mod.rs
@@ -1,4 +1,5 @@
 pub mod open_ack;
 pub mod open_confirm;
 pub mod open_handshake;
+pub mod open_init;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/impls/connection/mod.rs
+++ b/crates/relayer-components/src/relay/impls/connection/mod.rs
@@ -1,3 +1,4 @@
 pub mod open_ack;
 pub mod open_confirm;
+pub mod open_handshake;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/impls/connection/mod.rs
+++ b/crates/relayer-components/src/relay/impls/connection/mod.rs
@@ -1,3 +1,4 @@
+pub mod bootstrap;
 pub mod open_ack;
 pub mod open_confirm;
 pub mod open_handshake;

--- a/crates/relayer-components/src/relay/impls/connection/mod.rs
+++ b/crates/relayer-components/src/relay/impls/connection/mod.rs
@@ -1,0 +1,1 @@
+pub mod open_try;

--- a/crates/relayer-components/src/relay/impls/connection/open_ack.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_ack.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::message_builders::connection::{
+    CanBuildConnectionHandshakeMessages, CanBuildConnectionHandshakePayloads,
+};
+use crate::chain::traits::message_sender::CanSendMessages;
+use crate::chain::traits::queries::status::CanQueryChainHeight;
+use crate::chain::traits::wait::CanWaitChainSurpassHeight;
+use crate::relay::impls::update_client::CanSendUpdateClientMessage;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::connection::open_ack::ConnectionOpenAckRelayer;
+use crate::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
+use crate::relay::traits::target::{DestinationTarget, SourceTarget};
+use crate::std_prelude::*;
+
+pub struct RelayConnectionOpenAck;
+
+#[async_trait]
+impl<Relay, SrcChain, DstChain> ConnectionOpenAckRelayer<Relay> for RelayConnectionOpenAck
+where
+    Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
+        + CanSendUpdateClientMessage<DestinationTarget>
+        + CanBuildUpdateClientMessage<SourceTarget>,
+    SrcChain: CanSendMessages
+        + CanQueryChainHeight
+        + CanWaitChainSurpassHeight
+        + CanBuildConnectionHandshakeMessages<DstChain>,
+    DstChain: CanQueryChainHeight + CanBuildConnectionHandshakePayloads<SrcChain>,
+    DstChain::ConnectionId: Clone,
+{
+    async fn relay_connection_open_ack(
+        relay: &Relay,
+        src_connection_id: &SrcChain::ConnectionId,
+        dst_connection_id: &DstChain::ConnectionId,
+    ) -> Result<(), Relay::Error> {
+        let src_chain = relay.src_chain();
+        let dst_chain = relay.dst_chain();
+
+        let src_height = src_chain
+            .query_chain_height()
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        relay
+            .send_update_client_messages(DestinationTarget, &src_height)
+            .await?;
+
+        let dst_height = dst_chain
+            .query_chain_height()
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let src_update_client_messages = relay
+            .build_update_client_messages(SourceTarget, &dst_height)
+            .await?;
+
+        let open_ack_payload = dst_chain
+            .build_connection_open_ack_payload(
+                &dst_height,
+                relay.dst_client_id(),
+                dst_connection_id,
+            )
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let open_ack_message = src_chain
+            .build_connection_open_ack_message(src_connection_id, open_ack_payload)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let src_messages = {
+            let mut messages = src_update_client_messages;
+            messages.push(open_ack_message);
+            messages
+        };
+
+        src_chain
+            .wait_chain_surpass_height(&src_height)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        src_chain
+            .send_messages(src_messages)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        Ok(())
+    }
+}

--- a/crates/relayer-components/src/relay/impls/connection/open_ack.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_ack.rs
@@ -36,6 +36,8 @@ where
         let src_chain = relay.src_chain();
         let dst_chain = relay.dst_chain();
 
+        let dst_client_id = relay.dst_client_id();
+
         let src_height = src_chain
             .query_chain_height()
             .await
@@ -55,11 +57,7 @@ where
             .await?;
 
         let open_ack_payload = dst_chain
-            .build_connection_open_ack_payload(
-                &dst_height,
-                relay.dst_client_id(),
-                dst_connection_id,
-            )
+            .build_connection_open_ack_payload(&dst_height, dst_client_id, dst_connection_id)
             .await
             .map_err(Relay::dst_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/connection/open_ack.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_ack.rs
@@ -62,7 +62,11 @@ where
             .map_err(Relay::dst_chain_error)?;
 
         let open_ack_message = src_chain
-            .build_connection_open_ack_message(src_connection_id, open_ack_payload)
+            .build_connection_open_ack_message(
+                src_connection_id,
+                dst_connection_id,
+                open_ack_payload,
+            )
             .await
             .map_err(Relay::src_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/connection/open_ack.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_ack.rs
@@ -14,6 +14,17 @@ use crate::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
 use crate::relay::traits::target::{DestinationTarget, SourceTarget};
 use crate::std_prelude::*;
 
+/**
+   A base implementation of [`ConnectionOpenAckRelayer`] that relays a new connection
+   at the destination chain that is in `OPEN_TRY` state, and submits it as a
+   `ConnectionOpenAck` message to the destination chain.
+
+   This implements the `ConnOpenAck` step of the IBC connection handshake protocol.
+
+   Note that this implementation does not check that the connections at the
+   source and destination chain are really in the `OPEN_TRY` state. This will be
+   implemented as a separate wrapper component. (TODO)
+*/
 pub struct RelayConnectionOpenAck;
 
 #[async_trait]

--- a/crates/relayer-components/src/relay/impls/connection/open_ack.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_ack.rs
@@ -6,7 +6,7 @@ use crate::chain::traits::message_builders::connection::{
 use crate::chain::traits::message_sender::CanSendMessages;
 use crate::chain::traits::queries::status::CanQueryChainHeight;
 use crate::chain::traits::types::height::CanIncrementHeight;
-use crate::chain::traits::wait::CanWaitChainSurpassHeight;
+use crate::chain::traits::wait::CanWaitChainReachHeight;
 use crate::relay::impls::update_client::CanSendUpdateClientMessage;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::connection::open_ack::ConnectionOpenAckRelayer;
@@ -24,7 +24,7 @@ where
         + CanBuildUpdateClientMessage<SourceTarget>,
     SrcChain: CanSendMessages
         + CanQueryChainHeight
-        + CanWaitChainSurpassHeight
+        + CanWaitChainReachHeight
         + CanBuildConnectionHandshakeMessages<DstChain>,
     DstChain:
         CanQueryChainHeight + CanIncrementHeight + CanBuildConnectionHandshakePayloads<SrcChain>,
@@ -82,7 +82,7 @@ where
         };
 
         src_chain
-            .wait_chain_surpass_height(&src_height)
+            .wait_chain_reach_height(&src_height)
             .await
             .map_err(Relay::src_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/connection/open_confirm.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_confirm.rs
@@ -12,6 +12,17 @@ use crate::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
 use crate::relay::traits::target::DestinationTarget;
 use crate::std_prelude::*;
 
+/**
+   A base implementation of [`ConnectionOpenConfirmRelayer`] that relays a new connection
+   at the source chain that is in `OPEN` state, and submits it as a
+   `ConnectionOpenConfirm` message to the destination chain.
+
+   This implements the `ConnOpenConfirm` step of the IBC connection handshake protocol.
+
+   Note that this implementation does not check that the connection at the source
+   chain is really in the `OPEN` state, and that the connection at the destination chain
+   is in the `OPEN_TRY` state. This will be implemented as a separate wrapper component. (TODO)
+*/
 pub struct RelayConnectionOpenConfirm;
 
 #[async_trait]

--- a/crates/relayer-components/src/relay/impls/connection/open_confirm.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_confirm.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::message_builders::connection::{
+    CanBuildConnectionHandshakeMessages, CanBuildConnectionHandshakePayloads,
+};
+use crate::chain::traits::message_sender::CanSendMessages;
+use crate::chain::traits::queries::status::CanQueryChainHeight;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::connection::open_confirm::ConnectionOpenConfirmRelayer;
+use crate::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
+use crate::relay::traits::target::DestinationTarget;
+use crate::std_prelude::*;
+
+pub struct RelayConnectionOpenConfirm;
+
+#[async_trait]
+impl<Relay, SrcChain, DstChain> ConnectionOpenConfirmRelayer<Relay> for RelayConnectionOpenConfirm
+where
+    Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
+        + CanBuildUpdateClientMessage<DestinationTarget>,
+    SrcChain: CanQueryChainHeight + CanBuildConnectionHandshakePayloads<DstChain>,
+    DstChain: CanSendMessages + CanQueryChainHeight + CanBuildConnectionHandshakeMessages<SrcChain>,
+    DstChain::ConnectionId: Clone,
+{
+    async fn relay_connection_open_confirm(
+        relay: &Relay,
+        src_connection_id: &SrcChain::ConnectionId,
+        dst_connection_id: &DstChain::ConnectionId,
+    ) -> Result<(), Relay::Error> {
+        let src_chain = relay.src_chain();
+        let dst_chain = relay.dst_chain();
+
+        let src_client_id = relay.src_client_id();
+
+        let src_height = src_chain
+            .query_chain_height()
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let dst_update_client_messages = relay
+            .build_update_client_messages(DestinationTarget, &src_height)
+            .await?;
+
+        let open_confirm_payload = src_chain
+            .build_connection_open_confirm_payload(&src_height, src_client_id, src_connection_id)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let open_confirm_message = dst_chain
+            .build_connection_open_confirm_message(dst_connection_id, open_confirm_payload)
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let dst_messages = {
+            let mut messages = dst_update_client_messages;
+            messages.push(open_confirm_message);
+            messages
+        };
+
+        dst_chain
+            .send_messages(dst_messages)
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        Ok(())
+    }
+}

--- a/crates/relayer-components/src/relay/impls/connection/open_handshake.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_handshake.rs
@@ -8,6 +8,18 @@ use crate::relay::traits::connection::open_handshake::ConnectionOpenHandshakeRel
 use crate::relay::traits::connection::open_try::CanRelayConnectionOpenTry;
 use crate::std_prelude::*;
 
+/**
+   Relays a connection open handshake using a connection ID that has been
+   initialized at the source chain.
+
+   Specifically, the `ConnOpenTry`, `ConnOpenAck`, and `ConnOpenConfirm` steps of
+   the handshake protocol are performed between both chains. Upon successful
+   completion of the handshake protocol, a connection will have been established
+   between both chains.
+
+   This can be used for relaying of connections that are created by external
+   users.
+*/
 pub struct RelayConnectionOpenHandshake;
 
 #[async_trait]

--- a/crates/relayer-components/src/relay/impls/connection/open_handshake.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_handshake.rs
@@ -1,0 +1,40 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::connection::open_ack::CanRelayConnectionOpenAck;
+use crate::relay::traits::connection::open_confirm::CanRelayConnectionOpenConfirm;
+use crate::relay::traits::connection::open_handshake::ConnectionOpenHandshakeRelayer;
+use crate::relay::traits::connection::open_try::CanRelayConnectionOpenTry;
+use crate::std_prelude::*;
+
+pub struct RelayConnectionOpenHandshake;
+
+#[async_trait]
+impl<Relay, SrcChain, DstChain> ConnectionOpenHandshakeRelayer<Relay>
+    for RelayConnectionOpenHandshake
+where
+    Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
+        + CanRelayConnectionOpenTry
+        + CanRelayConnectionOpenAck
+        + CanRelayConnectionOpenConfirm,
+    SrcChain: HasIbcChainTypes<DstChain>,
+    DstChain: HasIbcChainTypes<SrcChain>,
+{
+    async fn relay_connection_open_handshake(
+        relay: &Relay,
+        src_connection_id: &SrcChain::ConnectionId,
+    ) -> Result<DstChain::ConnectionId, Relay::Error> {
+        let dst_connection_id = relay.relay_connection_open_try(src_connection_id).await?;
+
+        relay
+            .relay_connection_open_ack(src_connection_id, &dst_connection_id)
+            .await?;
+
+        relay
+            .relay_connection_open_confirm(src_connection_id, &dst_connection_id)
+            .await?;
+
+        Ok(dst_connection_id)
+    }
+}

--- a/crates/relayer-components/src/relay/impls/connection/open_init.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_init.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
 use core::iter::Iterator;
-use core::time::Duration;
 
 use crate::chain::traits::message_builders::connection::{
     CanBuildConnectionHandshakeMessages, CanBuildConnectionHandshakePayloads,
 };
 use crate::chain::traits::message_sender::CanSendSingleMessage;
-use crate::chain::traits::types::connection::HasConnectionVersionType;
+use crate::chain::traits::types::connection::HasInitConnectionOptionsType;
 use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenInitEvent;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::connection::open_init::ConnectionInitializer;
@@ -24,7 +23,7 @@ where
     Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
         + InjectMissingConnectionInitEventError,
     SrcChain: CanSendSingleMessage
-        + HasConnectionVersionType<DstChain>
+        + HasInitConnectionOptionsType<DstChain>
         + CanBuildConnectionHandshakeMessages<DstChain>
         + HasConnectionOpenInitEvent<DstChain>,
     DstChain: CanBuildConnectionHandshakePayloads<SrcChain>,
@@ -32,8 +31,7 @@ where
 {
     async fn init_connection(
         relay: &Relay,
-        connection_version: &SrcChain::ConnectionVersion,
-        delay_period: Duration,
+        init_connection_options: &SrcChain::InitConnectionOptions,
     ) -> Result<SrcChain::ConnectionId, Relay::Error> {
         let src_chain = relay.src_chain();
         let dst_chain = relay.dst_chain();
@@ -50,8 +48,7 @@ where
             .build_connection_open_init_message(
                 src_client_id,
                 dst_client_id,
-                connection_version,
-                delay_period,
+                init_connection_options,
                 open_init_payload,
             )
             .await

--- a/crates/relayer-components/src/relay/impls/connection/open_init.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_init.rs
@@ -1,0 +1,75 @@
+use async_trait::async_trait;
+use core::iter::Iterator;
+use core::time::Duration;
+
+use crate::chain::traits::message_builders::connection::{
+    CanBuildConnectionHandshakeMessages, CanBuildConnectionHandshakePayloads,
+};
+use crate::chain::traits::message_sender::CanSendSingleMessage;
+use crate::chain::traits::types::connection::HasConnectionVersionType;
+use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenInitEvent;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::connection::open_init::ConnectionInitializer;
+use crate::std_prelude::*;
+
+pub trait InjectMissingConnectionInitEventError: HasRelayChains {
+    fn missing_connection_init_event_error(&self) -> Self::Error;
+}
+
+pub struct InitializeConnection;
+
+#[async_trait]
+impl<Relay, SrcChain, DstChain> ConnectionInitializer<Relay> for InitializeConnection
+where
+    Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
+        + InjectMissingConnectionInitEventError,
+    SrcChain: CanSendSingleMessage
+        + HasConnectionVersionType<DstChain>
+        + CanBuildConnectionHandshakeMessages<DstChain>
+        + HasConnectionOpenInitEvent<DstChain>,
+    DstChain: CanBuildConnectionHandshakePayloads<SrcChain>,
+    SrcChain::ConnectionId: Clone,
+{
+    async fn init_connection(
+        relay: &Relay,
+        connection_version: &SrcChain::ConnectionVersion,
+        delay_period: Duration,
+    ) -> Result<SrcChain::ConnectionId, Relay::Error> {
+        let src_chain = relay.src_chain();
+        let dst_chain = relay.dst_chain();
+
+        let src_client_id = relay.src_client_id();
+        let dst_client_id = relay.dst_client_id();
+
+        let open_init_payload = dst_chain
+            .build_connection_open_init_payload()
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let src_message = src_chain
+            .build_connection_open_init_message(
+                src_client_id,
+                dst_client_id,
+                connection_version,
+                delay_period,
+                open_init_payload,
+            )
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let events = src_chain
+            .send_message(src_message)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let open_init_event = events
+            .into_iter()
+            .find_map(|event| SrcChain::try_extract_connection_open_init_event(event))
+            .ok_or_else(|| relay.missing_connection_init_event_error())?;
+
+        let src_connection_id =
+            SrcChain::connection_open_init_event_connection_id(&open_init_event);
+
+        Ok(src_connection_id.clone())
+    }
+}

--- a/crates/relayer-components/src/relay/impls/connection/open_init.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_init.rs
@@ -15,6 +15,12 @@ pub trait InjectMissingConnectionInitEventError: HasRelayChains {
     fn missing_connection_init_event_error(&self) -> Self::Error;
 }
 
+/**
+   A base implementation for [`ConnectionInitializer`] which submits a
+   `ConnectionOpenInit` message to the source chain.
+
+   This implements the `ConnInit` step in the IBC connection handshake protocol.
+*/
 pub struct InitializeConnection;
 
 #[async_trait]

--- a/crates/relayer-components/src/relay/impls/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_try.rs
@@ -9,7 +9,7 @@ use crate::chain::traits::queries::status::CanQueryChainHeight;
 use crate::chain::traits::types::height::CanIncrementHeight;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenTryEvent;
-use crate::chain::traits::wait::CanWaitChainSurpassHeight;
+use crate::chain::traits::wait::CanWaitChainReachHeight;
 use crate::relay::impls::update_client::CanSendUpdateClientMessage;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::connection::open_try::ConnectionOpenTryRelayer;
@@ -37,7 +37,7 @@ where
         CanQueryChainHeight + CanIncrementHeight + CanBuildConnectionHandshakePayloads<DstChain>,
     DstChain: CanSendMessages
         + CanQueryChainHeight
-        + CanWaitChainSurpassHeight
+        + CanWaitChainReachHeight
         + CanBuildConnectionHandshakeMessages<SrcChain>
         + HasConnectionOpenTryEvent<SrcChain>,
     DstChain::ConnectionId: Clone,
@@ -95,7 +95,7 @@ where
         };
 
         dst_chain
-            .wait_chain_surpass_height(&dst_height)
+            .wait_chain_reach_height(&dst_height)
             .await
             .map_err(Relay::dst_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_try.rs
@@ -74,7 +74,12 @@ where
             .map_err(Relay::src_chain_error)?;
 
         let open_try_message = dst_chain
-            .build_connection_open_try_message(dst_client_id, open_try_payload)
+            .build_connection_open_try_message(
+                dst_client_id,
+                src_client_id,
+                src_connection_id,
+                open_try_payload,
+            )
             .await
             .map_err(Relay::dst_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_try.rs
@@ -24,6 +24,17 @@ pub trait InjectMissingConnectionTryEventError: HasRelayChains {
     ) -> Self::Error;
 }
 
+/**
+   A base implementation of [`ConnectionOpenTryRelayer`] that relays a new connection
+   at the source chain that is in `OPEN_INIT` state, and submits it as a
+   `ConnectionOpenTry` message to the destination chain.
+
+   This implements the `ConnOpenTry` step of the IBC connection handshake protocol.
+
+   Note that this implementation does not check that the connection at the source
+   chain is really in the `OPEN_INIT` state. This will be implemented as a separate
+   wrapper component. (TODO)
+*/
 pub struct RelayConnectionOpenTry;
 
 #[async_trait]

--- a/crates/relayer-components/src/relay/impls/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_try.rs
@@ -47,6 +47,9 @@ where
         let src_chain = relay.src_chain();
         let dst_chain = relay.dst_chain();
 
+        let src_client_id = relay.src_client_id();
+        let dst_client_id = relay.dst_client_id();
+
         let dst_height = dst_chain
             .query_chain_height()
             .await
@@ -66,16 +69,12 @@ where
             .await?;
 
         let open_try_payload = src_chain
-            .build_connection_open_try_payload(
-                &src_height,
-                relay.src_client_id(),
-                src_connection_id,
-            )
+            .build_connection_open_try_payload(&src_height, src_client_id, src_connection_id)
             .await
             .map_err(Relay::src_chain_error)?;
 
         let open_try_message = dst_chain
-            .build_connection_open_try_message(relay.dst_client_id(), open_try_payload)
+            .build_connection_open_try_message(dst_client_id, open_try_payload)
             .await
             .map_err(Relay::dst_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/impls/connection/open_try.rs
@@ -1,0 +1,128 @@
+use async_trait::async_trait;
+use core::iter::Iterator;
+
+use crate::chain::traits::connection::proofs::CanBuildConnectionProofs;
+use crate::chain::traits::message_builders::connection::CanBuildConnectionOpenTryMessage;
+use crate::chain::traits::message_sender::CanSendMessages;
+use crate::chain::traits::queries::connection::CanQueryConnection;
+use crate::chain::traits::queries::status::CanQueryChainStatus;
+use crate::chain::traits::types::height::HasHeightType;
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenTryEvent;
+use crate::chain::traits::wait::CanWaitChainSurpassHeight;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::connection::open_try::ConnectionOpenTryRelayer;
+use crate::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
+use crate::relay::traits::target::{DestinationTarget, SourceTarget};
+use crate::std_prelude::*;
+
+pub trait InjectMissingConnectionTryEventError: HasRelayChains {
+    fn missing_connection_try_event_error(
+        src_connection_id: &<Self::SrcChain as HasIbcChainTypes<Self::DstChain>>::ConnectionId,
+    ) -> Self::Error;
+}
+
+pub struct RelayConnectionOpenTry;
+
+#[async_trait]
+impl<Relay, SrcChain, DstChain, OpenTryEvent> ConnectionOpenTryRelayer<Relay>
+    for RelayConnectionOpenTry
+where
+    Relay: HasRelayChains<SrcChain = SrcChain, DstChain = DstChain>
+        + CanBuildUpdateClientMessage<SourceTarget>
+        + CanBuildUpdateClientMessage<DestinationTarget>
+        + InjectMissingConnectionTryEventError,
+    DstChain: CanSendMessages
+        + CanQueryChainStatus
+        + CanWaitChainSurpassHeight
+        + CanBuildConnectionOpenTryMessage<SrcChain>
+        + HasConnectionOpenTryEvent<SrcChain, ConnectionOpenTryEvent = OpenTryEvent>,
+    SrcChain: CanSendMessages
+        + CanQueryChainStatus
+        + CanQueryConnection<DstChain>
+        + CanBuildConnectionProofs<DstChain>,
+{
+    async fn relay_connection_open_try(
+        relay: &Relay,
+        connection_id: &<Relay::SrcChain as HasIbcChainTypes<Relay::DstChain>>::ConnectionId,
+    ) -> Result<OpenTryEvent, Relay::Error> {
+        let src_chain = relay.src_chain();
+        let dst_chain = relay.dst_chain();
+
+        let connection_end = src_chain
+            .query_connection(connection_id)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let dst_status = dst_chain
+            .query_chain_status()
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let dst_height = Relay::DstChain::chain_status_height(&dst_status);
+
+        {
+            let update_client_messages = relay
+                .build_update_client_messages(SourceTarget, dst_height)
+                .await?;
+
+            src_chain
+                .send_messages(update_client_messages)
+                .await
+                .map_err(Relay::src_chain_error)?;
+        }
+
+        let src_status = src_chain
+            .query_chain_status()
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let src_height: &<SrcChain as HasHeightType>::Height =
+            Relay::SrcChain::chain_status_height(&src_status);
+
+        let update_client_messages = relay
+            .build_update_client_messages(DestinationTarget, src_height)
+            .await?;
+
+        let commitment_proofs = src_chain
+            .build_connection_proofs(connection_id, src_height)
+            .await
+            .map_err(Relay::src_chain_error)?;
+
+        let open_try_message = dst_chain
+            .build_connection_open_try_message(
+                relay.dst_client_id(),
+                relay.src_client_id(),
+                connection_id,
+                &connection_end,
+                &commitment_proofs,
+            )
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let dst_messages = {
+            let mut messages = update_client_messages;
+            messages.push(open_try_message);
+            messages
+        };
+
+        dst_chain
+            .wait_chain_surpass_height(dst_height)
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let mut events = dst_chain
+            .send_messages(dst_messages)
+            .await
+            .map_err(Relay::dst_chain_error)?;
+
+        let open_try_event = events
+            .pop()
+            .ok_or_else(|| Relay::missing_connection_try_event_error(connection_id))?
+            .into_iter()
+            .find_map(|event| DstChain::try_extract_connection_open_try_event(event))
+            .ok_or_else(|| Relay::missing_connection_try_event_error(connection_id))?;
+
+        Ok(open_try_event)
+    }
+}

--- a/crates/relayer-components/src/relay/impls/messages/wait_update_client.rs
+++ b/crates/relayer-components/src/relay/impls/messages/wait_update_client.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use async_trait::async_trait;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
-use crate::chain::traits::wait::CanWaitChainSurpassHeight;
+use crate::chain::traits::wait::CanWaitChainReachHeight;
 use crate::logger::traits::level::HasBaseLogLevels;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::logs::logger::CanLogRelayTarget;
@@ -26,7 +26,7 @@ where
     Target: ChainTarget<Relay, TargetChain = TargetChain, CounterpartyChain = CounterpartyChain>,
     InUpdateClient: UpdateClientMessageBuilder<Relay, Target>,
     TargetChain: HasIbcChainTypes<CounterpartyChain>,
-    CounterpartyChain: CanWaitChainSurpassHeight + HasIbcChainTypes<TargetChain>,
+    CounterpartyChain: CanWaitChainReachHeight + HasIbcChainTypes<TargetChain>,
 {
     async fn build_update_client_messages(
         relay: &Relay,
@@ -44,7 +44,7 @@ where
         );
 
         let current_height = counterparty_chain
-            .wait_chain_surpass_height(height)
+            .wait_chain_reach_height(height)
             .await
             .map_err(Target::counterparty_chain_error)?;
 

--- a/crates/relayer-components/src/relay/impls/messages/wait_update_client.rs
+++ b/crates/relayer-components/src/relay/impls/messages/wait_update_client.rs
@@ -1,17 +1,15 @@
 use core::marker::PhantomData;
-use core::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::chain::traits::queries::status::CanQueryChainStatus;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::chain::traits::wait::CanWaitChainSurpassHeight;
 use crate::logger::traits::level::HasBaseLogLevels;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::logs::logger::CanLogRelayTarget;
 use crate::relay::traits::messages::update_client::UpdateClientMessageBuilder;
 use crate::relay::traits::target::ChainTarget;
 use crate::runtime::traits::runtime::HasRuntime;
-use crate::runtime::traits::sleep::CanSleep;
 use crate::std_prelude::*;
 
 /**
@@ -27,17 +25,15 @@ where
     Relay: HasRelayChains + HasRuntime + CanLogRelayTarget<Target>,
     Target: ChainTarget<Relay, TargetChain = TargetChain, CounterpartyChain = CounterpartyChain>,
     InUpdateClient: UpdateClientMessageBuilder<Relay, Target>,
-    CounterpartyChain: HasIbcChainTypes<TargetChain>,
     TargetChain: HasIbcChainTypes<CounterpartyChain>,
-    CounterpartyChain: CanQueryChainStatus,
-    Relay::Runtime: CanSleep,
+    CounterpartyChain: CanWaitChainSurpassHeight + HasIbcChainTypes<TargetChain>,
 {
     async fn build_update_client_messages(
         relay: &Relay,
         target: Target,
         height: &CounterpartyChain::Height,
     ) -> Result<Vec<TargetChain::Message>, Relay::Error> {
-        let chain = Target::counterparty_chain(relay);
+        let counterparty_chain = Target::counterparty_chain(relay);
 
         relay.log_relay_target(
             Relay::Logger::LEVEL_TRACE,
@@ -47,28 +43,20 @@ where
             },
         );
 
-        loop {
-            let current_status = chain
-                .query_chain_status()
-                .await
-                .map_err(Target::counterparty_chain_error)?;
+        let current_height = counterparty_chain
+            .wait_chain_surpass_height(height)
+            .await
+            .map_err(Target::counterparty_chain_error)?;
 
-            let current_height = CounterpartyChain::chain_status_height(&current_status);
+        relay.log_relay_target(
+            Relay::Logger::LEVEL_TRACE,
+            "counterparty chain's height is now greater than or equal to target height",
+            |log| {
+                log.display("target_height", height)
+                    .display("currrent_height", &current_height);
+            },
+        );
 
-            if current_height >= height {
-                relay.log_relay_target(
-                    Relay::Logger::LEVEL_TRACE,
-                    "counterparty chain's height is now greater than or equal to target height",
-                    |log| {
-                        log.display("target_height", height)
-                            .display("currrent_height", &current_height);
-                    },
-                );
-
-                return InUpdateClient::build_update_client_messages(relay, target, height).await;
-            } else {
-                relay.runtime().sleep(Duration::from_millis(100)).await;
-            }
-        }
+        return InUpdateClient::build_update_client_messages(relay, target, height).await;
     }
 }

--- a/crates/relayer-components/src/relay/impls/mod.rs
+++ b/crates/relayer-components/src/relay/impls/mod.rs
@@ -1,4 +1,5 @@
 pub mod auto_relayers;
+pub mod connection;
 pub mod event_relayers;
 pub mod message_senders;
 pub mod messages;

--- a/crates/relayer-components/src/relay/impls/mod.rs
+++ b/crates/relayer-components/src/relay/impls/mod.rs
@@ -5,3 +5,4 @@ pub mod message_senders;
 pub mod messages;
 pub mod packet_filters;
 pub mod packet_relayers;
+pub mod update_client;

--- a/crates/relayer-components/src/relay/impls/packet_relayers/ack/base_ack_packet.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/ack/base_ack_packet.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::chain::traits::message_builders::ack_packet::CanBuildAckPacketMessage;
 use crate::chain::types::aliases::{Height, WriteAcknowledgementEvent};
 use crate::relay::traits::chains::HasRelayChains;
-use crate::relay::traits::ibc_message_sender::{CanSendIbcMessages, IbcMessageSenderExt};
+use crate::relay::traits::ibc_message_sender::CanSendSingleIbcMessage;
 use crate::relay::traits::packet_relayers::ack_packet::AckPacketRelayer;
 use crate::relay::traits::target::SourceTarget;
 use crate::relay::types::aliases::Packet;
@@ -18,7 +18,7 @@ pub struct BaseAckPacketRelayer;
 impl<Relay> AckPacketRelayer<Relay> for BaseAckPacketRelayer
 where
     Relay: HasRelayChains,
-    Relay: CanSendIbcMessages<SourceTarget>,
+    Relay: CanSendSingleIbcMessage<SourceTarget>,
     Relay::DstChain: CanBuildAckPacketMessage<Relay::SrcChain>,
 {
     async fn relay_ack_packet(

--- a/crates/relayer-components/src/relay/impls/packet_relayers/ack/base_ack_packet.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/ack/base_ack_packet.rs
@@ -33,7 +33,7 @@ where
             .await
             .map_err(Relay::dst_chain_error)?;
 
-        relay.send_message(message).await?;
+        relay.send_message(SourceTarget, message).await?;
 
         Ok(())
     }

--- a/crates/relayer-components/src/relay/impls/packet_relayers/receive/base_receive_packet.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/receive/base_receive_packet.rs
@@ -4,7 +4,7 @@ use crate::chain::traits::message_builders::receive_packet::CanBuildReceivePacke
 use crate::chain::traits::types::ibc_events::write_ack::HasWriteAcknowledgementEvent;
 use crate::chain::types::aliases::Height;
 use crate::relay::traits::chains::HasRelayChains;
-use crate::relay::traits::ibc_message_sender::{CanSendIbcMessages, IbcMessageSenderExt};
+use crate::relay::traits::ibc_message_sender::CanSendSingleIbcMessage;
 use crate::relay::traits::packet_relayers::receive_packet::ReceivePacketRelayer;
 use crate::relay::traits::target::DestinationTarget;
 use crate::relay::types::aliases::Packet;
@@ -16,7 +16,7 @@ pub struct BaseReceivePacketRelayer;
 impl<Relay, AckEvent> ReceivePacketRelayer<Relay> for BaseReceivePacketRelayer
 where
     Relay::SrcChain: CanBuildReceivePacketMessage<Relay::DstChain>,
-    Relay: CanSendIbcMessages<DestinationTarget>,
+    Relay: CanSendSingleIbcMessage<DestinationTarget>,
     Relay: HasRelayChains,
     Relay::DstChain:
         HasWriteAcknowledgementEvent<Relay::SrcChain, WriteAcknowledgementEvent = AckEvent>,

--- a/crates/relayer-components/src/relay/impls/packet_relayers/receive/base_receive_packet.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/receive/base_receive_packet.rs
@@ -32,7 +32,7 @@ where
             .await
             .map_err(Relay::src_chain_error)?;
 
-        let events = relay.send_message(message).await?;
+        let events = relay.send_message(DestinationTarget, message).await?;
 
         let ack_event = events
             .iter()

--- a/crates/relayer-components/src/relay/impls/packet_relayers/timeout_unordered/timeout_unordered_packet.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/timeout_unordered/timeout_unordered_packet.rs
@@ -32,7 +32,7 @@ where
             .await
             .map_err(Relay::dst_chain_error)?;
 
-        relay.send_message(message).await?;
+        relay.send_message(SourceTarget, message).await?;
 
         Ok(())
     }

--- a/crates/relayer-components/src/relay/impls/packet_relayers/timeout_unordered/timeout_unordered_packet.rs
+++ b/crates/relayer-components/src/relay/impls/packet_relayers/timeout_unordered/timeout_unordered_packet.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::chain::traits::message_builders::timeout_unordered_packet::CanBuildTimeoutUnorderedPacketMessage;
 use crate::chain::types::aliases::Height;
 use crate::relay::traits::chains::HasRelayChains;
-use crate::relay::traits::ibc_message_sender::{CanSendIbcMessages, IbcMessageSenderExt};
+use crate::relay::traits::ibc_message_sender::CanSendSingleIbcMessage;
 use crate::relay::traits::packet_relayers::timeout_unordered_packet::TimeoutUnorderedPacketRelayer;
 use crate::relay::traits::target::SourceTarget;
 use crate::relay::types::aliases::Packet;
@@ -18,7 +18,7 @@ pub struct BaseTimeoutUnorderedPacketRelayer;
 impl<Relay> TimeoutUnorderedPacketRelayer<Relay> for BaseTimeoutUnorderedPacketRelayer
 where
     Relay: HasRelayChains,
-    Relay: CanSendIbcMessages<SourceTarget>,
+    Relay: CanSendSingleIbcMessage<SourceTarget>,
     Relay::DstChain: CanBuildTimeoutUnorderedPacketMessage<Relay::SrcChain>,
 {
     async fn relay_timeout_unordered_packet(

--- a/crates/relayer-components/src/relay/impls/update_client.rs
+++ b/crates/relayer-components/src/relay/impls/update_client.rs
@@ -35,7 +35,7 @@ where
 
         // If there are no UpdateClient messages returned, it means that the IBC client is
         // already up to date.
-        if messages.len() > 0 {
+        if !messages.is_empty() {
             Target::target_chain(self)
                 .send_messages(messages)
                 .await

--- a/crates/relayer-components/src/relay/impls/update_client.rs
+++ b/crates/relayer-components/src/relay/impls/update_client.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::message_sender::CanSendMessages;
+use crate::chain::types::aliases::Height;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::traits::messages::update_client::CanBuildUpdateClientMessage;
+use crate::relay::traits::target::ChainTarget;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanSendUpdateClientMessage<Target>: HasRelayChains
+where
+    Target: ChainTarget<Self>,
+{
+    async fn send_update_client_messages(
+        &self,
+        target: Target,
+        height: &Height<Target::CounterpartyChain>,
+    ) -> Result<(), Self::Error>;
+}
+
+#[async_trait]
+impl<Relay, Target> CanSendUpdateClientMessage<Target> for Relay
+where
+    Relay: CanBuildUpdateClientMessage<Target>,
+    Target: ChainTarget<Relay>,
+    Target::TargetChain: CanSendMessages,
+{
+    async fn send_update_client_messages(
+        &self,
+        target: Target,
+        height: &Height<Target::CounterpartyChain>,
+    ) -> Result<(), Self::Error> {
+        let messages = self.build_update_client_messages(target, height).await?;
+        Target::target_chain(self)
+            .send_messages(messages)
+            .await
+            .map_err(Target::target_chain_error)?;
+
+        Ok(())
+    }
+}

--- a/crates/relayer-components/src/relay/impls/update_client.rs
+++ b/crates/relayer-components/src/relay/impls/update_client.rs
@@ -32,10 +32,15 @@ where
         height: &Height<Target::CounterpartyChain>,
     ) -> Result<(), Self::Error> {
         let messages = self.build_update_client_messages(target, height).await?;
-        Target::target_chain(self)
-            .send_messages(messages)
-            .await
-            .map_err(Target::target_chain_error)?;
+
+        // If there are no UpdateClient messages returned, it means that the IBC client is
+        // already up to date.
+        if messages.len() > 0 {
+            Target::target_chain(self)
+                .send_messages(messages)
+                .await
+                .map_err(Target::target_chain_error)?;
+        }
 
         Ok(())
     }

--- a/crates/relayer-components/src/relay/mod.rs
+++ b/crates/relayer-components/src/relay/mod.rs
@@ -7,7 +7,7 @@
    chain.
 
    At its core, a relay context should implement
-   [`HasRelayChains`](traits::types::HasRelayChains), which declares the chain
+   [`HasRelayChains`](traits::chains::HasRelayChains), which declares the chain
    sub-contexts as well as the abstract types that are used when relaying.
 
    Since the relay context only supports relaying in one direction, two relay

--- a/crates/relayer-components/src/relay/traits/chains.rs
+++ b/crates/relayer-components/src/relay/traits/chains.rs
@@ -35,17 +35,17 @@ pub trait HasRelayChains: HasErrorType {
         A source chain context that has the IBC chain types that are correspond
         to the destination chain.
     */
-    type SrcChain: HasIbcPacketTypes<Self::DstChain>;
+    type SrcChain: HasIbcPacketTypes<Self::DstChain> + HasErrorType;
 
     /**
         A destination chain context that has the IBC chain types that are correspond
         to the source chain.
     */
     type DstChain: HasIbcPacketTypes<
-        Self::SrcChain,
-        IncomingPacket = <Self::SrcChain as HasIbcPacketTypes<Self::DstChain>>::OutgoingPacket,
-        OutgoingPacket = <Self::SrcChain as HasIbcPacketTypes<Self::DstChain>>::IncomingPacket,
-    >;
+            Self::SrcChain,
+            IncomingPacket = <Self::SrcChain as HasIbcPacketTypes<Self::DstChain>>::OutgoingPacket,
+            OutgoingPacket = <Self::SrcChain as HasIbcPacketTypes<Self::DstChain>>::IncomingPacket,
+        > + HasErrorType;
 
     /**
         Get a reference to the source chain context from the relay context.

--- a/crates/relayer-components/src/relay/traits/chains.rs
+++ b/crates/relayer-components/src/relay/traits/chains.rs
@@ -10,7 +10,7 @@ use crate::core::traits::error::HasErrorType;
     connected to each others. This is reflected by both types being required
     to implement [`HasIbcPacketTypes`] with each others being the counterparty.
 
-    The relay context also has an abstract [`Packet`](Self::Packet) type, which
+    The relay context also has an abstract [`Packet`](crate::relay::traits::packet::HasRelayPacket::Packet) type, which
     represents the IBC packet sent from the source chain to the destination
     chain. In other words, the relay context only covers relaying of IBC packets
     in one direction. To support bi-directional relaying between two chains,

--- a/crates/relayer-components/src/relay/traits/connection/mod.rs
+++ b/crates/relayer-components/src/relay/traits/connection/mod.rs
@@ -1,1 +1,2 @@
+pub mod open_ack;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/traits/connection/mod.rs
+++ b/crates/relayer-components/src/relay/traits/connection/mod.rs
@@ -1,2 +1,3 @@
 pub mod open_ack;
+pub mod open_confirm;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/traits/connection/mod.rs
+++ b/crates/relayer-components/src/relay/traits/connection/mod.rs
@@ -1,3 +1,23 @@
+/*!
+    This module contains the trait interfaces for implementing the
+    [IBC connection handshake protocol](https://github.com/cosmos/ibc/tree/main/spec/core/ics-003-connection-semantics).
+    The protocol establishes a connection between the two participating blockchains.
+    This connection between the two chains is necessary in order for channels to be established between them.
+
+    Each of the different `open_*` modules, except for `open_handshake`, defines
+    a component responsible for a single step in the handshake protocol.
+    The `open_handshake` module wires together the steps that actually constitute
+    the handshake protocol proper.
+    The `open_init` step is not strictly part of the handshake, as it may be initiated
+    by external users; it merely signals the start of the handshake process.
+
+    The relay context only handles the connection handshake initiated in one direction,
+    i.e. as initiated by the source chain and acknowledged by the destination chain.
+    If a connection is first initialized at the destination chain, it will not be
+    handled by this relay context. Instead, it will be handled by the counterpart
+    relay context that has the source and destination chains flipped.
+*/
+
 pub mod open_ack;
 pub mod open_confirm;
 pub mod open_handshake;

--- a/crates/relayer-components/src/relay/traits/connection/mod.rs
+++ b/crates/relayer-components/src/relay/traits/connection/mod.rs
@@ -1,4 +1,5 @@
 pub mod open_ack;
 pub mod open_confirm;
 pub mod open_handshake;
+pub mod open_init;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/traits/connection/mod.rs
+++ b/crates/relayer-components/src/relay/traits/connection/mod.rs
@@ -1,3 +1,4 @@
 pub mod open_ack;
 pub mod open_confirm;
+pub mod open_handshake;
 pub mod open_try;

--- a/crates/relayer-components/src/relay/traits/connection/mod.rs
+++ b/crates/relayer-components/src/relay/traits/connection/mod.rs
@@ -1,0 +1,1 @@
+pub mod open_try;

--- a/crates/relayer-components/src/relay/traits/connection/open_ack.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_ack.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanRelayConnectionOpenAck: HasRelayChains {
+    async fn relay_connection_open_ack(
+        &self,
+        src_connection_id: &SrcConnectionId<Self>,
+        dst_connection_id: &DstConnectionId<Self>,
+    ) -> Result<(), Self::Error>;
+}
+
+#[async_trait]
+pub trait ConnectionOpenAckRelayer<Relay>
+where
+    Relay: HasRelayChains,
+{
+    async fn relay_connection_open_ack(
+        relay: &Relay,
+        src_connection_id: &SrcConnectionId<Relay>,
+        dst_connection_id: &DstConnectionId<Relay>,
+    ) -> Result<(), Relay::Error>;
+}

--- a/crates/relayer-components/src/relay/traits/connection/open_confirm.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_confirm.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanRelayConnectionOpenConfirm: HasRelayChains {
+    async fn relay_connection_open_confirm(
+        &self,
+        src_connection_id: &SrcConnectionId<Self>,
+        dst_connection_id: &DstConnectionId<Self>,
+    ) -> Result<(), Self::Error>;
+}
+
+#[async_trait]
+pub trait ConnectionOpenConfirmRelayer<Relay>
+where
+    Relay: HasRelayChains,
+{
+    async fn relay_connection_open_confirm(
+        relay: &Relay,
+        src_connection_id: &SrcConnectionId<Relay>,
+        dst_connection_id: &DstConnectionId<Relay>,
+    ) -> Result<(), Relay::Error>;
+}

--- a/crates/relayer-components/src/relay/traits/connection/open_handshake.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_handshake.rs
@@ -5,20 +5,20 @@ use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanRelayConnectionOpenTry: HasRelayChains {
-    async fn relay_connection_open_try(
+pub trait CanRelayConnectionOpenHandshake: HasRelayChains {
+    async fn relay_connection_open_handshake(
         &self,
         src_connection_id: &SrcConnectionId<Self>,
     ) -> Result<DstConnectionId<Self>, Self::Error>;
 }
 
 #[async_trait]
-pub trait ConnectionOpenTryRelayer<Relay>
+pub trait ConnectionOpenHandshakeRelayer<Relay>
 where
     Relay: HasRelayChains,
 {
-    async fn relay_connection_open_try(
+    async fn relay_connection_open_handshake(
         relay: &Relay,
-        src_connection_id: &SrcConnectionId<Relay>,
+        connection_id: &SrcConnectionId<Relay>,
     ) -> Result<DstConnectionId<Relay>, Relay::Error>;
 }

--- a/crates/relayer-components/src/relay/traits/connection/open_init.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_init.rs
@@ -1,21 +1,20 @@
-use core::time::Duration;
-
 use async_trait::async_trait;
 
-use crate::chain::traits::types::connection::HasConnectionVersionType;
+use crate::chain::traits::types::connection::HasInitConnectionOptionsType;
 use crate::relay::traits::chains::HasRelayChains;
-use crate::relay::types::aliases::{SrcConnectionId, SrcConnectionVersion};
+use crate::relay::types::aliases::SrcConnectionId;
 use crate::std_prelude::*;
 
 #[async_trait]
 pub trait CanInitConnection: HasRelayChains
 where
-    Self::SrcChain: HasConnectionVersionType<Self::DstChain>,
+    Self::SrcChain: HasInitConnectionOptionsType<Self::DstChain>,
 {
     async fn init_connection(
         &self,
-        version: SrcConnectionVersion<Self>,
-        connection_delay: Duration,
+        init_connection_options: &<Self::SrcChain as HasInitConnectionOptionsType<
+            Self::DstChain,
+        >>::InitConnectionOptions,
     ) -> Result<SrcConnectionId<Self>, Self::Error>;
 }
 
@@ -23,11 +22,12 @@ where
 pub trait ConnectionInitializer<Relay>
 where
     Relay: HasRelayChains,
-    Relay::SrcChain: HasConnectionVersionType<Relay::DstChain>,
+    Relay::SrcChain: HasInitConnectionOptionsType<Relay::DstChain>,
 {
     async fn init_connection(
         relay: &Relay,
-        version: &SrcConnectionVersion<Relay>,
-        delay_period: Duration,
+        init_connection_options: &<Relay::SrcChain as HasInitConnectionOptionsType<
+            Relay::DstChain,
+        >>::InitConnectionOptions,
     ) -> Result<SrcConnectionId<Relay>, Relay::Error>;
 }

--- a/crates/relayer-components/src/relay/traits/connection/open_init.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_init.rs
@@ -1,0 +1,33 @@
+use core::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::chain::traits::types::connection::HasConnectionVersionType;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::types::aliases::{SrcConnectionId, SrcConnectionVersion};
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanInitConnection: HasRelayChains
+where
+    Self::SrcChain: HasConnectionVersionType<Self::DstChain>,
+{
+    async fn init_connection(
+        &self,
+        version: SrcConnectionVersion<Self>,
+        connection_delay: Duration,
+    ) -> Result<SrcConnectionId<Self>, Self::Error>;
+}
+
+#[async_trait]
+pub trait ConnectionInitializer<Relay>
+where
+    Relay: HasRelayChains,
+    Relay::SrcChain: HasConnectionVersionType<Relay::DstChain>,
+{
+    async fn init_connection(
+        relay: &Relay,
+        version: &SrcConnectionVersion<Relay>,
+        delay_period: Duration,
+    ) -> Result<SrcConnectionId<Relay>, Relay::Error>;
+}

--- a/crates/relayer-components/src/relay/traits/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_try.rs
@@ -1,14 +1,35 @@
 use async_trait::async_trait;
 
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
-use crate::core::traits::error::HasErrorType;
+use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenTryEvent;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanRelayConnectionOpenTry: HasRelayChains + HasErrorType {
+pub trait CanRelayConnectionOpenTry: HasRelayChains
+where
+    Self::DstChain: HasConnectionOpenTryEvent<Self::SrcChain>,
+{
     async fn relay_connection_open_try(
         &self,
         connection_id: &<Self::SrcChain as HasIbcChainTypes<Self::DstChain>>::ConnectionId,
-    );
+    ) -> Result<
+        <Self::DstChain as HasConnectionOpenTryEvent<Self::SrcChain>>::ConnectionOpenTryEvent,
+        Self::Error,
+    >;
+}
+
+#[async_trait]
+pub trait ConnectionOpenTryRelayer<Relay>
+where
+    Relay: HasRelayChains,
+    Relay::DstChain: HasConnectionOpenTryEvent<Relay::SrcChain>,
+{
+    async fn relay_connection_open_try(
+        relay: &Relay,
+        connection_id: &<Relay::SrcChain as HasIbcChainTypes<Relay::DstChain>>::ConnectionId,
+    ) -> Result<
+        <Relay::DstChain as HasConnectionOpenTryEvent<Relay::SrcChain>>::ConnectionOpenTryEvent,
+        Relay::Error,
+    >;
 }

--- a/crates/relayer-components/src/relay/traits/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_try.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
+use crate::core::traits::error::HasErrorType;
+use crate::relay::traits::chains::HasRelayChains;
+use crate::std_prelude::*;
+
+#[async_trait]
+pub trait CanRelayConnectionOpenTry: HasRelayChains + HasErrorType {
+    async fn relay_connection_open_try(
+        &self,
+        connection_id: &<Self::SrcChain as HasIbcChainTypes<Self::DstChain>>::ConnectionId,
+    );
+}

--- a/crates/relayer-components/src/relay/traits/connection/open_try.rs
+++ b/crates/relayer-components/src/relay/traits/connection/open_try.rs
@@ -1,35 +1,24 @@
 use async_trait::async_trait;
 
-use crate::chain::traits::types::ibc::HasIbcChainTypes;
-use crate::chain::traits::types::ibc_events::connection::HasConnectionOpenTryEvent;
 use crate::relay::traits::chains::HasRelayChains;
+use crate::relay::types::aliases::{DstConnectionId, SrcConnectionId};
 use crate::std_prelude::*;
 
 #[async_trait]
-pub trait CanRelayConnectionOpenTry: HasRelayChains
-where
-    Self::DstChain: HasConnectionOpenTryEvent<Self::SrcChain>,
-{
+pub trait CanRelayConnectionOpenTry: HasRelayChains {
     async fn relay_connection_open_try(
         &self,
-        connection_id: &<Self::SrcChain as HasIbcChainTypes<Self::DstChain>>::ConnectionId,
-    ) -> Result<
-        <Self::DstChain as HasConnectionOpenTryEvent<Self::SrcChain>>::ConnectionOpenTryEvent,
-        Self::Error,
-    >;
+        src_connection_id: &SrcConnectionId<Self>,
+    ) -> Result<DstConnectionId<Self>, Self::Error>;
 }
 
 #[async_trait]
 pub trait ConnectionOpenTryRelayer<Relay>
 where
     Relay: HasRelayChains,
-    Relay::DstChain: HasConnectionOpenTryEvent<Relay::SrcChain>,
 {
     async fn relay_connection_open_try(
         relay: &Relay,
-        connection_id: &<Relay::SrcChain as HasIbcChainTypes<Relay::DstChain>>::ConnectionId,
-    ) -> Result<
-        <Relay::DstChain as HasConnectionOpenTryEvent<Relay::SrcChain>>::ConnectionOpenTryEvent,
-        Relay::Error,
-    >;
+        connection_id: &SrcConnectionId<Relay>,
+    ) -> Result<DstConnectionId<Relay>, Relay::Error>;
 }

--- a/crates/relayer-components/src/relay/traits/ibc_message_sender.rs
+++ b/crates/relayer-components/src/relay/traits/ibc_message_sender.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 
+use crate::chain::traits::message_sender::InjectMismatchIbcEventsCountError;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::chain::types::aliases::{Event, Message};
-use crate::core::traits::error::HasErrorType;
 use crate::core::traits::sync::Async;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::target::ChainTarget;
@@ -32,36 +32,35 @@ where
     ) -> Result<Vec<Vec<Event<Target::TargetChain>>>, Context::Error>;
 }
 
-pub trait InjectMismatchIbcEventsCountError: HasErrorType {
-    fn mismatch_ibc_events_count_error(expected: usize, actual: usize) -> Self::Error;
-}
-
 #[async_trait]
-pub trait IbcMessageSenderExt<Context, Target>
+pub trait CanSendFixSizedIbcMessages<Target>: HasRelayChains
 where
-    Context: HasRelayChains,
-    Target: ChainTarget<Context>,
+    Target: ChainTarget<Self>,
 {
     async fn send_messages_fixed<const COUNT: usize>(
         &self,
         target: Target,
         messages: [Message<Target::TargetChain>; COUNT],
-    ) -> Result<[Vec<Event<Target::TargetChain>>; COUNT], Context::Error>
-    where
-        Context: InjectMismatchIbcEventsCountError;
+    ) -> Result<[Vec<Event<Target::TargetChain>>; COUNT], Self::Error>;
+}
 
+#[async_trait]
+pub trait CanSendSingleIbcMessage<Target>: HasRelayChains
+where
+    Target: ChainTarget<Self>,
+{
     async fn send_message(
         &self,
         target: Target,
         message: Message<Target::TargetChain>,
-    ) -> Result<Vec<Event<Target::TargetChain>>, Context::Error>;
+    ) -> Result<Vec<Event<Target::TargetChain>>, Self::Error>;
 }
 
 #[async_trait]
-impl<Context, Target, TargetChain, Event, Message> IbcMessageSenderExt<Context, Target> for Context
+impl<Relay, Target, TargetChain, Event, Message> CanSendFixSizedIbcMessages<Target> for Relay
 where
-    Context: CanSendIbcMessages<Target>,
-    Target: ChainTarget<Context, TargetChain = TargetChain>,
+    Relay: CanSendIbcMessages<Target> + InjectMismatchIbcEventsCountError,
+    Target: ChainTarget<Relay, TargetChain = TargetChain>,
     TargetChain: HasIbcChainTypes<Target::CounterpartyChain, Event = Event, Message = Message>,
     Message: Async,
 {
@@ -69,24 +68,30 @@ where
         &self,
         target: Target,
         messages: [Message; COUNT],
-    ) -> Result<[Vec<Event>; COUNT], Context::Error>
-    where
-        Context: InjectMismatchIbcEventsCountError,
-    {
-        let events = self
-            .send_messages(target, messages.into())
-            .await?
+    ) -> Result<[Vec<Event>; COUNT], Relay::Error> {
+        let events_vec = self.send_messages(target, messages.into()).await?;
+
+        let events = events_vec
             .try_into()
-            .map_err(|e: Vec<_>| Context::mismatch_ibc_events_count_error(COUNT, e.len()))?;
+            .map_err(|e: Vec<_>| Relay::mismatch_ibc_events_count_error(COUNT, e.len()))?;
 
         Ok(events)
     }
+}
 
+#[async_trait]
+impl<Relay, Target, TargetChain, Event, Message> CanSendSingleIbcMessage<Target> for Relay
+where
+    Relay: CanSendIbcMessages<Target>,
+    Target: ChainTarget<Relay, TargetChain = TargetChain>,
+    TargetChain: HasIbcChainTypes<Target::CounterpartyChain, Event = Event, Message = Message>,
+    Message: Async,
+{
     async fn send_message(
         &self,
         target: Target,
         message: Message,
-    ) -> Result<Vec<Event>, Context::Error> {
+    ) -> Result<Vec<Event>, Relay::Error> {
         let events = self
             .send_messages(target, vec![message])
             .await?

--- a/crates/relayer-components/src/relay/traits/ibc_message_sender.rs
+++ b/crates/relayer-components/src/relay/traits/ibc_message_sender.rs
@@ -15,6 +15,7 @@ where
 {
     async fn send_messages(
         &self,
+        target: Target,
         messages: Vec<Message<Target::TargetChain>>,
     ) -> Result<Vec<Vec<Event<Target::TargetChain>>>, Self::Error>;
 }
@@ -43,6 +44,7 @@ where
 {
     async fn send_messages_fixed<const COUNT: usize>(
         &self,
+        target: Target,
         messages: [Message<Target::TargetChain>; COUNT],
     ) -> Result<[Vec<Event<Target::TargetChain>>; COUNT], Context::Error>
     where
@@ -50,6 +52,7 @@ where
 
     async fn send_message(
         &self,
+        target: Target,
         message: Message<Target::TargetChain>,
     ) -> Result<Vec<Event<Target::TargetChain>>, Context::Error>;
 }
@@ -64,13 +67,14 @@ where
 {
     async fn send_messages_fixed<const COUNT: usize>(
         &self,
+        target: Target,
         messages: [Message; COUNT],
     ) -> Result<[Vec<Event>; COUNT], Context::Error>
     where
         Context: InjectMismatchIbcEventsCountError,
     {
         let events = self
-            .send_messages(messages.into())
+            .send_messages(target, messages.into())
             .await?
             .try_into()
             .map_err(|e: Vec<_>| Context::mismatch_ibc_events_count_error(COUNT, e.len()))?;
@@ -78,9 +82,13 @@ where
         Ok(events)
     }
 
-    async fn send_message(&self, message: Message) -> Result<Vec<Event>, Context::Error> {
+    async fn send_message(
+        &self,
+        target: Target,
+        message: Message,
+    ) -> Result<Vec<Event>, Context::Error> {
         let events = self
-            .send_messages(vec![message])
+            .send_messages(target, vec![message])
             .await?
             .into_iter()
             .flatten()

--- a/crates/relayer-components/src/relay/traits/mod.rs
+++ b/crates/relayer-components/src/relay/traits/mod.rs
@@ -1,5 +1,6 @@
 pub mod auto_relayer;
 pub mod chains;
+pub mod connection;
 pub mod event_relayer;
 pub mod ibc_message_sender;
 pub mod logs;

--- a/crates/relayer-components/src/relay/traits/target.rs
+++ b/crates/relayer-components/src/relay/traits/target.rs
@@ -4,13 +4,13 @@ use crate::core::traits::error::HasErrorType;
 use crate::core::traits::sync::Async;
 use crate::relay::traits::chains::HasRelayChains;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct SourceTarget;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct DestinationTarget;
 
-pub trait ChainTarget<Relay: HasRelayChains>: Async + Default + private::Sealed {
+pub trait ChainTarget<Relay: HasRelayChains>: Async + Default + Copy + private::Sealed {
     type TargetChain: HasIbcChainTypes<Self::CounterpartyChain> + HasErrorType;
 
     type CounterpartyChain: HasIbcChainTypes<Self::TargetChain> + HasErrorType;

--- a/crates/relayer-components/src/relay/traits/target.rs
+++ b/crates/relayer-components/src/relay/traits/target.rs
@@ -11,9 +11,9 @@ pub struct SourceTarget;
 pub struct DestinationTarget;
 
 pub trait ChainTarget<Relay: HasRelayChains>: Async + Default + private::Sealed {
-    type TargetChain: HasIbcChainTypes<Self::CounterpartyChain>;
+    type TargetChain: HasIbcChainTypes<Self::CounterpartyChain> + HasErrorType;
 
-    type CounterpartyChain: HasIbcChainTypes<Self::TargetChain>;
+    type CounterpartyChain: HasIbcChainTypes<Self::TargetChain> + HasErrorType;
 
     fn target_chain_error(e: <Self::TargetChain as HasErrorType>::Error) -> Relay::Error;
 

--- a/crates/relayer-components/src/relay/types/aliases.rs
+++ b/crates/relayer-components/src/relay/types/aliases.rs
@@ -1,8 +1,15 @@
+use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::packet::HasRelayPacket;
 
-pub type Packet<Context> = <Context as HasRelayPacket>::Packet;
+pub type Packet<Relay> = <Relay as HasRelayPacket>::Packet;
 
-pub type SrcChain<Context> = <Context as HasRelayChains>::SrcChain;
+pub type SrcChain<Relay> = <Relay as HasRelayChains>::SrcChain;
 
-pub type DstChain<Context> = <Context as HasRelayChains>::DstChain;
+pub type DstChain<Relay> = <Relay as HasRelayChains>::DstChain;
+
+pub type SrcConnectionId<Relay> =
+    <SrcChain<Relay> as HasIbcChainTypes<DstChain<Relay>>>::ConnectionId;
+
+pub type DstConnectionId<Relay> =
+    <DstChain<Relay> as HasIbcChainTypes<SrcChain<Relay>>>::ConnectionId;

--- a/crates/relayer-components/src/relay/types/aliases.rs
+++ b/crates/relayer-components/src/relay/types/aliases.rs
@@ -1,3 +1,4 @@
+use crate::chain::traits::types::connection::HasConnectionVersionType;
 use crate::chain::traits::types::ibc::HasIbcChainTypes;
 use crate::relay::traits::chains::HasRelayChains;
 use crate::relay::traits::packet::HasRelayPacket;
@@ -13,3 +14,6 @@ pub type SrcConnectionId<Relay> =
 
 pub type DstConnectionId<Relay> =
     <DstChain<Relay> as HasIbcChainTypes<SrcChain<Relay>>>::ConnectionId;
+
+pub type SrcConnectionVersion<Relay> =
+    <SrcChain<Relay> as HasConnectionVersionType<DstChain<Relay>>>::ConnectionVersion;

--- a/crates/relayer-cosmos/src/all_for_one/chain.rs
+++ b/crates/relayer-cosmos/src/all_for_one/chain.rs
@@ -12,6 +12,7 @@ use ibc_relayer_types::timestamp::Timestamp;
 use ibc_relayer_types::Height;
 use tendermint::abci::Event as AbciEvent;
 
+use crate::types::connection::CosmosInitConnectionOptions;
 use crate::types::error::Error;
 use crate::types::message::CosmosIbcMessage;
 
@@ -34,6 +35,7 @@ pub trait AfoCosmosChain<Counterparty>:
     ChainStatus = ChainStatus,
     IncomingPacket = Packet,
     OutgoingPacket = Packet,
+    InitConnectionOptions = CosmosInitConnectionOptions,
 >
 where
     Counterparty: AfoCounterpartyChain<Self>,
@@ -60,6 +62,7 @@ where
         ChainStatus = ChainStatus,
         IncomingPacket = Packet,
         OutgoingPacket = Packet,
+        InitConnectionOptions = CosmosInitConnectionOptions,
     >,
     Counterparty: AfoCounterpartyChain<Chain>,
 {

--- a/crates/relayer-cosmos/src/impls/chain.rs
+++ b/crates/relayer-cosmos/src/impls/chain.rs
@@ -734,7 +734,7 @@ where
 
                 let version = connection
                     .versions()
-                    .into_iter()
+                    .iter()
                     .next()
                     .cloned()
                     .unwrap_or_default();
@@ -817,7 +817,7 @@ where
                     .query_compatible_versions()
                     .map_err(BaseError::relayer)?;
 
-                let version = versions.into_iter().next().unwrap_or_else(Default::default);
+                let version = versions.into_iter().next().unwrap_or_default();
 
                 let message = CosmosIbcMessage::new(None, move |signer| {
                     let message = MsgConnectionOpenInit {

--- a/crates/relayer-cosmos/src/impls/chain.rs
+++ b/crates/relayer-cosmos/src/impls/chain.rs
@@ -21,6 +21,8 @@ use ibc_relayer_runtime::tokio::error::Error as TokioError;
 use ibc_relayer_runtime::tokio::logger::tracing::TracingLogger;
 use ibc_relayer_runtime::tokio::logger::value::LogValue;
 use ibc_relayer_types::clients::ics07_tendermint::consensus_state::ConsensusState;
+use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
+use ibc_relayer_types::core::ics03_connection::version::Version;
 use ibc_relayer_types::core::ics04_channel::events::{SendPacket, WriteAcknowledgement};
 use ibc_relayer_types::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
 use ibc_relayer_types::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
@@ -185,6 +187,18 @@ where
     type IncomingPacket = Packet;
 
     type OutgoingPacket = Packet;
+
+    type ConnectionVersion = Version;
+
+    type ConnectionDetails = ConnectionEnd;
+
+    type ConnectionOpenInitPayload = ();
+
+    type ConnectionOpenTryPayload = ();
+
+    type ConnectionOpenAckPayload = ();
+
+    type ConnectionOpenConfirmPayload = ();
 
     fn incoming_packet_src_channel_id(packet: &Packet) -> &ChannelId {
         &packet.source_channel

--- a/crates/relayer-cosmos/src/impls/relay.rs
+++ b/crates/relayer-cosmos/src/impls/relay.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use eyre::eyre;
 use futures::channel::oneshot::{channel, Sender};
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::foreign_client::ForeignClient;
@@ -9,7 +10,7 @@ use ibc_relayer_runtime::tokio::context::TokioRuntimeContext;
 use ibc_relayer_runtime::tokio::error::Error as TokioError;
 use ibc_relayer_runtime::tokio::logger::tracing::TracingLogger;
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
-use ibc_relayer_types::core::ics24_host::identifier::ClientId;
+use ibc_relayer_types::core::ics24_host::identifier::{ClientId, ConnectionId};
 use ibc_relayer_types::tx_msg::Msg;
 use ibc_relayer_types::Height;
 
@@ -159,6 +160,18 @@ where
 
     fn max_retry_exceeded_error(e: Error) -> Error {
         e
+    }
+
+    fn missing_connection_init_event_error(&self) -> Error {
+        BaseError::generic(eyre!("missing_connection_init_event_error")).into()
+    }
+
+    fn missing_connection_try_event_error(&self, src_connection_id: &ConnectionId) -> Error {
+        BaseError::generic(eyre!(
+            "missing_connection_try_event_error: {}",
+            src_connection_id
+        ))
+        .into()
     }
 
     async fn should_relay_packet(&self, packet: &Self::Packet) -> Result<bool, Self::Error> {

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -27,3 +27,7 @@ pub struct CosmosConnectionOpenAckPayload {
     pub proofs: Proofs,
     pub version: Version,
 }
+
+pub struct CosmosConnectionOpenConfirmPayload {
+    pub proofs: Proofs,
+}

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -1,7 +1,9 @@
 use core::time::Duration;
 
+use ibc_relayer::client_state::AnyClientState;
 use ibc_relayer_types::core::ics03_connection::version::Version;
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
+use ibc_relayer_types::proofs::Proofs;
 
 pub struct CosmosInitConnectionOptions {
     pub delay_period: Duration,
@@ -10,4 +12,12 @@ pub struct CosmosInitConnectionOptions {
 
 pub struct CosmosConnectionOpenInitPayload {
     pub commitment_prefix: CommitmentPrefix,
+}
+
+pub struct CosmosConnectionOpenTryPayload {
+    pub commitment_prefix: CommitmentPrefix,
+    pub proofs: Proofs,
+    pub client_state: Option<AnyClientState>,
+    pub versions: Vec<Version>,
+    pub delay_period: Duration,
 }

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -1,0 +1,13 @@
+use core::time::Duration;
+
+use ibc_relayer_types::core::ics03_connection::version::Version;
+use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
+
+pub struct CosmosInitConnectionOptions {
+    pub delay_period: Duration,
+    pub connection_version: Version,
+}
+
+pub struct CosmosConnectionOpenInitPayload {
+    pub commitment_prefix: CommitmentPrefix,
+}

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -6,6 +6,7 @@ use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
 use ibc_relayer_types::proofs::Proofs;
 
+#[derive(Default)]
 pub struct CosmosInitConnectionOptions {
     pub delay_period: Duration,
     pub connection_version: Version,

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -36,3 +36,7 @@ pub struct CosmosConnectionOpenConfirmPayload {
 pub struct CosmosConnectionOpenInitEvent {
     pub connection_id: ConnectionId,
 }
+
+pub struct CosmosConnectionOpenTryEvent {
+    pub connection_id: ConnectionId,
+}

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -17,7 +17,13 @@ pub struct CosmosConnectionOpenInitPayload {
 pub struct CosmosConnectionOpenTryPayload {
     pub commitment_prefix: CommitmentPrefix,
     pub proofs: Proofs,
-    pub client_state: Option<AnyClientState>,
+    pub client_state: Option<AnyClientState>, // TODO: remove Option
     pub versions: Vec<Version>,
     pub delay_period: Duration,
+}
+
+pub struct CosmosConnectionOpenAckPayload {
+    pub client_state: Option<AnyClientState>, // TODO: remove Option
+    pub proofs: Proofs,
+    pub version: Version,
 }

--- a/crates/relayer-cosmos/src/types/connection.rs
+++ b/crates/relayer-cosmos/src/types/connection.rs
@@ -3,6 +3,7 @@ use core::time::Duration;
 use ibc_relayer::client_state::AnyClientState;
 use ibc_relayer_types::core::ics03_connection::version::Version;
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentPrefix;
+use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
 use ibc_relayer_types::proofs::Proofs;
 
 pub struct CosmosInitConnectionOptions {
@@ -30,4 +31,8 @@ pub struct CosmosConnectionOpenAckPayload {
 
 pub struct CosmosConnectionOpenConfirmPayload {
     pub proofs: Proofs,
+}
+
+pub struct CosmosConnectionOpenInitEvent {
+    pub connection_id: ConnectionId,
 }

--- a/crates/relayer-cosmos/src/types/mod.rs
+++ b/crates/relayer-cosmos/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod batch;
+pub mod connection;
 pub mod error;
 pub mod message;
 pub mod telemetry;

--- a/crates/relayer-mock/src/relayer_mock/base/impls/chain.rs
+++ b/crates/relayer-mock/src/relayer_mock/base/impls/chain.rs
@@ -179,12 +179,6 @@ impl HasWriteAcknowledgementEvent<MockChainContext> for MockChainContext {
             _ => None,
         }
     }
-
-    fn extract_packet_from_write_acknowledgement_event(
-        _ack: &Self::WriteAcknowledgementEvent,
-    ) -> &Self::IncomingPacket {
-        todo!()
-    }
 }
 
 impl HasConsensusStateType<MockChainContext> for MockChainContext {

--- a/crates/relayer-mock/src/relayer_mock/base/impls/relay.rs
+++ b/crates/relayer-mock/src/relayer_mock/base/impls/relay.rs
@@ -167,14 +167,22 @@ impl HasPacketLock for MockRelayContext {
 
 #[async_trait]
 impl CanSendIbcMessages<SourceTarget> for MockRelayContext {
-    async fn send_messages(&self, messages: Vec<MockMessage>) -> Result<Vec<Vec<Event>>, Error> {
+    async fn send_messages(
+        &self,
+        _target: SourceTarget,
+        messages: Vec<MockMessage>,
+    ) -> Result<Vec<Vec<Event>>, Error> {
         <components::IbcMessageSender as IbcMessageSender<MockRelayContext, SourceTarget>>::send_messages(self, messages).await
     }
 }
 
 #[async_trait]
 impl CanSendIbcMessages<DestinationTarget> for MockRelayContext {
-    async fn send_messages(&self, messages: Vec<MockMessage>) -> Result<Vec<Vec<Event>>, Error> {
+    async fn send_messages(
+        &self,
+        _target: DestinationTarget,
+        messages: Vec<MockMessage>,
+    ) -> Result<Vec<Vec<Event>>, Error> {
         <components::IbcMessageSender as IbcMessageSender<MockRelayContext, DestinationTarget>>::send_messages(self, messages).await
     }
 }

--- a/tools/integration-test/src/tests/next/connection.rs
+++ b/tools/integration-test/src/tests/next/connection.rs
@@ -1,0 +1,50 @@
+use ibc_relayer::config::PacketFilter;
+use ibc_relayer_components::relay::impls::connection::bootstrap::CanBootstrapConnection;
+use ibc_relayer_components::relay::traits::two_way::HasTwoWayRelay;
+use ibc_test_framework::prelude::*;
+
+use crate::tests::next::context::build_cosmos_relay_context;
+
+#[test]
+fn test_connection_handshake_next() -> Result<(), Error> {
+    run_binary_chain_test(&ConnectionHandshakeTest)
+}
+
+pub struct ConnectionHandshakeTest;
+
+impl TestOverrides for ConnectionHandshakeTest {
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChainTest for ConnectionHandshakeTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let pf: PacketFilter = PacketFilter::default();
+
+        let runtime = chains.node_a.value().chain_driver.runtime.as_ref();
+
+        let relay_context = build_cosmos_relay_context(&relayer.config, &chains, pf)?;
+
+        let (connection_id_a, connection_id_b) = runtime
+            .block_on(async move {
+                relay_context
+                    .relay_a_to_b()
+                    .bootstrap_connection(&Default::default())
+                    .await
+            })
+            .unwrap();
+
+        info!(
+            "bootstrapped new IBC connections with ID {} and {}",
+            connection_id_a, connection_id_b
+        );
+
+        Ok(())
+    }
+}

--- a/tools/integration-test/src/tests/next/mod.rs
+++ b/tools/integration-test/src/tests/next/mod.rs
@@ -1,3 +1,4 @@
+pub mod connection;
 pub mod context;
 pub mod filter;
 pub mod timeout_transfer;

--- a/tools/test-framework/src/framework/binary/next.rs
+++ b/tools/test-framework/src/framework/binary/next.rs
@@ -366,7 +366,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> CanWaitForAck for TestContextV2<C
 }
 
 /// This is a temporary solution. When the clean shutdown is implemented in the runtime
-/// context, this should be replaced, see https://github.com/informalsystems/hermes/issues/3245.
+/// context, this should be replaced, see <https://github.com/informalsystems/hermes/issues/3245>.
 impl<ChainA: ChainHandle, ChainB: ChainHandle> CanShutdown for TestContextV2<ChainA, ChainB> {
     fn shutdown(&self, auto_relay_handle: Option<JoinHandle<()>>) {
         if let Some(handle) = auto_relay_handle {


### PR DESCRIPTION

Part of #2925.

## Description

This PR implements the basic IBC connection handshake components in relayer-next. 

The current implementation supports only an end-to-end IBC connection creation, and does not resume connection handshake based on IBC events. It also does not perform additional checks that the created connection on-chain is the same as expected.

Additional features can be defined in future PRs as extra components.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
