### PR TITLE
Reduce CI flakiness by using `cargo-nextest`

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -107,11 +107,12 @@ jobs:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-             nix shell .#python .#${{ matrix.chain.package }} -c \
-               cargo nextest run --retries 2 -p ibc-integration-test --no-fail-fast --nocapture
+            nix shell .#python .#${{ matrix.chain.package }} -c \
+              cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture
 
   ordered-channel-test:
     runs-on: ubuntu-20.04
@@ -136,14 +137,18 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
         run: |
-          nix shell .#python .#gaia6-ordered -c cargo \
-            test -p ibc-integration-test --features ordered --no-fail-fast -- \
-            --nocapture --test-threads=1 test_ordered_channel
+          nix shell .#python .#gaia6-ordered -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features ordered test_ordered_channel
 
   ica-filter-test:
     runs-on: ubuntu-20.04
@@ -181,12 +186,13 @@ jobs:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features ica --no-fail-fast -- \
-            --nocapture --test-threads=1 test_ica_filter
+          nix shell .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features ica test_ica_filter
 
   ics29-fee-test:
     runs-on: ubuntu-20.04
@@ -226,16 +232,20 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features ics29-fee --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features ics29-fee --no-fail-fast -- \
-            --nocapture --test-threads=1 fee::
+          nix shell .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features ics29-fee fee::
 
   forward-packet:
     runs-on: ubuntu-20.04
@@ -272,16 +282,20 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features forward-packet --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features forward-packet --no-fail-fast -- \
-            --nocapture --test-threads=1 forward::
+          nix shell .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features forward-packet forward::
 
   ics31:
     runs-on: ubuntu-20.04
@@ -312,16 +326,20 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features ics31 --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-          nix shell ${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features ics31 --no-fail-fast -- \
-            --nocapture --test-threads=1 ics31::
+          nix shell ${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features ics31 ics31::
   fee-grant:
     runs-on: ubuntu-20.04
     strategy:
@@ -354,6 +372,9 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features fee-grant --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -361,9 +382,9 @@ jobs:
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features fee-grant --no-fail-fast -- \
-            --nocapture --test-threads=1 fee_grant::
+          nix shell .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features fee-grant fee_grant::
 
   clean-workers:
     runs-on: ubuntu-20.04
@@ -394,16 +415,20 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features ics31 --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features clean-workers --no-fail-fast -- \
-            --nocapture --test-threads=1 clean_workers::
+          nix shell .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features clean-workers clean_workers::
 
   interchain-security-no-ica:
     runs-on: ubuntu-20.04
@@ -434,16 +459,20 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: gaiad,${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: cosmos,${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#gaia9 .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features interchain-security --no-fail-fast -- \
-            --nocapture --test-threads=1 interchain_security::
+          nix shell .#gaia9 .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features interchain-security interchain_security::
 
   interchain-security-ica:
     runs-on: ubuntu-20.04
@@ -474,16 +503,20 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           CHAIN_COMMAND_PATHS: gaiad,${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: cosmos,${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#gaia9 .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features interchain-security,ica --no-fail-fast -- \
-            --nocapture --test-threads=1 interchain_security::
+          nix shell .#gaia9 .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features interchain-security,ica interchain_security::
 
   interchain-security-icq:
     runs-on: ubuntu-20.04
@@ -514,6 +547,9 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -521,9 +557,9 @@ jobs:
           CHAIN_COMMAND_PATHS: gaiad,${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: cosmos,${{ matrix.chain.account_prefix }}
         run: |
-          nix shell .#gaia9 .#${{ matrix.chain.package }} -c cargo \
-            test -p ibc-integration-test --features interchain-security,ics31 --no-fail-fast -- \
-            --nocapture --test-threads=1 interchain_security::
+          nix shell .#gaia9 .#${{ matrix.chain.package }} -c \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            --features interchain-security,ics31 interchain_security::
 
   model-based-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -100,7 +100,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Run integration test
         env:
           RUST_LOG: info
@@ -137,7 +137,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -181,7 +181,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -233,7 +233,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features ics29-fee --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -282,7 +282,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features forward-packet --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -325,7 +325,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features ics31 --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -370,7 +370,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features fee-grant --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -412,7 +412,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features ics31 --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -455,7 +455,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -498,7 +498,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -541,7 +541,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -111,7 +111,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
             nix shell .#python .#${{ matrix.chain.package }} -c \
-              cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture
+              cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2
 
   ordered-channel-test:
     runs-on: ubuntu-20.04
@@ -145,7 +145,7 @@ jobs:
           NEXTEST_RETRIES: 2
         run: |
           nix shell .#python .#gaia6-ordered -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features ordered test_ordered_channel
 
   ica-filter-test:
@@ -191,7 +191,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features ica test_ica_filter
 
   ics29-fee-test:
@@ -243,7 +243,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features ics29-fee fee::
 
   forward-packet:
@@ -292,7 +292,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features forward-packet forward::
 
   ics31:
@@ -335,7 +335,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
           nix shell ${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features ics31 ics31::
   fee-grant:
     runs-on: ubuntu-20.04
@@ -379,7 +379,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features fee-grant fee_grant::
 
   clean-workers:
@@ -422,7 +422,7 @@ jobs:
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features clean-workers clean_workers::
 
   interchain-security-no-ica:
@@ -465,7 +465,7 @@ jobs:
           ACCOUNT_PREFIXES: cosmos,${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#gaia9 .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features interchain-security interchain_security::
 
   interchain-security-ica:
@@ -508,7 +508,7 @@ jobs:
           ACCOUNT_PREFIXES: cosmos,${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#gaia9 .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features interchain-security,ica interchain_security::
 
   interchain-security-icq:
@@ -550,7 +550,7 @@ jobs:
           ACCOUNT_PREFIXES: cosmos,${{ matrix.chain.account_prefix }}
         run: |
           nix shell .#gaia9 .#${{ matrix.chain.package }} -c \
-            cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture \
+            cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2 \
             --features interchain-security,ics31 interchain_security::
 
   model-based-test:
@@ -591,4 +591,4 @@ jobs:
       #       .#apalache \
       #       -c cargo \
       #       test -p ibc-integration-test --features mbt --no-fail-fast -- \
-      #       --nocapture --test-threads=1 mbt
+      #       --failure-output final --test-threads=2 --test-threads=1 mbt

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -100,8 +100,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - name: Run integration test
         env:
           RUST_LOG: info
@@ -138,8 +137,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -182,6 +180,8 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -233,8 +233,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features ics29-fee --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -283,8 +282,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features forward-packet --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -327,8 +325,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features ics31 --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -373,8 +370,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features fee-grant --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -416,8 +412,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features ics31 --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -460,8 +455,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -504,8 +498,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
@@ -548,8 +541,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --features interchain-security --no-fail-fast --no-run
       - name: Install cargo-nextest
-        run:
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        uses: taiki-e/install-action@nextest
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -99,20 +99,19 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
-      - uses: nick-fields/retry@v2
+      - name: Install cargo-nextest
+        run:
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - name: Run integration test
         env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
           CHAIN_COMMAND_PATHS: ${{ matrix.chain.command }}
           ACCOUNT_PREFIXES: ${{ matrix.chain.account_prefix }}
-        with:
-           max_attempts: 2
-           timeout_minutes: 90
-           command: |
-             nix shell .#python .#${{ matrix.chain.package }} -c cargo \
-               test -p ibc-integration-test --no-fail-fast -- \
-               --nocapture --test-threads=2
+        run: |
+             nix shell .#python .#${{ matrix.chain.package }} -c \
+               cargo nextest run --retries 2 -p ibc-integration-test --no-fail-fast --nocapture
 
   ordered-channel-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/multi-chains.yaml
+++ b/.github/workflows/multi-chains.yaml
@@ -101,17 +101,15 @@ jobs:
         with:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
-      - uses: nick-fields/retry@v2
-        env:
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1
+          NEXTEST_RETRIES: 2
           ACCOUNT_PREFIXES: ${{ matrix.first-package.account_prefix }},${{ matrix.second-package.account_prefix }}
-        with:
-           max_attempts: 2
-           timeout_minutes: 60
-           command: |
+        run: |
              CHAIN_COMMAND_PATHS=$(nix shell .#${{ matrix.first-package.package }} -c which ${{ matrix.first-package.command }}),$(nix shell .#${{ matrix.second-package.package }} -c which ${{ matrix.second-package.command }}) \
-              nix shell .#python -c cargo \
-              test -p ibc-integration-test --no-fail-fast -- \
-              --nocapture --test-threads=2
+               nix shell .#python -c \
+                 cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture

--- a/.github/workflows/multi-chains.yaml
+++ b/.github/workflows/multi-chains.yaml
@@ -102,7 +102,7 @@ jobs:
           command: test
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1

--- a/.github/workflows/multi-chains.yaml
+++ b/.github/workflows/multi-chains.yaml
@@ -103,7 +103,8 @@ jobs:
           args: -p ibc-integration-test --no-fail-fast --no-run
       - name: Install cargo-nextest
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-      - env:
+      - name: Run multi-chains integration tests
+        env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
           NO_COLOR_LOG: 1

--- a/.github/workflows/multi-chains.yaml
+++ b/.github/workflows/multi-chains.yaml
@@ -53,7 +53,7 @@ jobs:
       ) || (
         github.event.action == 'labeled' && github.event.label.name == 'CI: multi-chains'
       )
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multi-chains.yaml
+++ b/.github/workflows/multi-chains.yaml
@@ -112,4 +112,4 @@ jobs:
         run: |
              CHAIN_COMMAND_PATHS=$(nix shell .#${{ matrix.first-package.package }} -c which ${{ matrix.first-package.command }}),$(nix shell .#${{ matrix.second-package.package }} -c which ${{ matrix.second-package.command }}) \
                nix shell .#python -c \
-                 cargo nextest run -p ibc-integration-test --no-fail-fast --nocapture
+                 cargo nextest run -p ibc-integration-test --no-fail-fast --failure-output final --test-threads=2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,14 +89,16 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features --no-fail-fast --no-run
       - uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features --no-fail-fast --workspace --exclude ibc-integration-test -- --nocapture
+          command: nextest
+          args: run --all-features --no-fail-fast --workspace --exclude ibc-integration-test --no-capture
 
   # test-coverage:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The CI is getting very flaky. I'm trying to use [cargo nextest with retries](https://nexte.st/book/retries.html) to retry individual tests, rather than retrying the whole integration test when one fails.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
