### PR TITLE
fix: link to gaiad-manager

### DIFF
--- a/guide/src/tutorials/pre-requisites/index.md
+++ b/guide/src/tutorials/pre-requisites/index.md
@@ -9,5 +9,5 @@ In order to follow the tutorials using local chains, please make sure that [Gaia
 * **[Gaia](./gaia.md)**
     * Install `Gaia`, the first implementation of the CosmosHub. 
     
-* **[Gaiad Manager](./gaia.md)**
+* **[Gaiad Manager](./gaiad-manager.md)**
     * Install Gaiad Manager, a command-line tool (CLI) that helps manage local `gaiad` networks.


### PR DESCRIPTION
Previously the link incorrectly navigated to the Gaia page