### PR TITLE
Set CompatMode fallback to v0.34 when the version query fails

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/3666-default-compat-mode-to-v034.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/3666-default-compat-mode-to-v034.md
@@ -1,2 +1,2 @@
-- Set fallback compatibility version for CometBFT to v0.34
+- Change fallback compatibility version for CometBFT from v0.37 to v0.34
   ([\#3666](https://github.com/informalsystems/hermes/issues/3666))

--- a/.changelog/unreleased/improvements/ibc-relayer/3666-default-compat-mode-to-v034.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/3666-default-compat-mode-to-v034.md
@@ -1,0 +1,2 @@
+- Set fallback compatibility version for CometBFT to v0.34
+  ([\#3666](https://github.com/informalsystems/hermes/issues/3666))

--- a/crates/relayer-cli/src/commands/listen.rs
+++ b/crates/relayer-cli/src/commands/listen.rs
@@ -172,8 +172,8 @@ fn detect_compatibility_mode(
     let client = HttpClient::new(config.rpc_addr.clone())?;
     let status = rt.block_on(client.status())?;
     let compat_mode = CompatMode::from_version(status.node_info.version).unwrap_or_else(|e| {
-        warn!("Unsupported tendermint version, will use v0.37 compatibility mode but relaying might not work as desired: {e}");
-        CompatMode::V0_37
+        warn!("Unsupported tendermint version, will use v0.34 compatibility mode but relaying might not work as desired: {e}");
+        CompatMode::V0_34
     });
     Ok(compat_mode)
 }

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -879,8 +879,8 @@ impl ChainEndpoint for CosmosSdkChain {
         let node_info = rt.block_on(fetch_node_info(&rpc_client, &config))?;
 
         let compat_mode = CompatMode::from_version(node_info.version).unwrap_or_else(|e| {
-            warn!("Unsupported tendermint version, will use v0.37 compatibility mode but relaying might not work as desired: {e}");
-            CompatMode::V0_37
+            warn!("Unsupported tendermint version, will use v0.34 compatibility mode but relaying might not work as desired: {e}");
+            CompatMode::V0_34
         });
         rpc_client.set_compat_mode(compat_mode);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3666

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

The node information is retrieved with the `/status` query and the version is used to define the `CompatMode`. If the version retrieved by the query isn't v0.34 or v0.37, the previous fallback value was v0.37.

This PR update the fallback value to v0.34 in order to allow relaying for chains such as Celestia.
This is temporary as there will be a new configuration to specify the `CompatMode` version https://github.com/informalsystems/hermes/issues/3623

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
