### PR TITLE
docs: remove e2e badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Cosmos ecosystem][cosmos-shield]][cosmos-link]
 
 [![Build Status][build-image]][build-link]
-[![End to End testing][e2e-image]][e2e-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![Rust Stable][rustc-image]
 ![Rust 1.70+][rustc-version]
@@ -116,8 +115,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 [build-image]: https://github.com/informalsystems/hermes/workflows/Rust/badge.svg
 [build-link]: https://github.com/informalsystems/hermes/actions?query=workflow%3ARust
-[e2e-image]: https://github.com/informalsystems/hermes/workflows/End%20to%20End%20testing/badge.svg
-[e2e-link]: https://github.com/informalsystems/hermes/actions?query=workflow%3A%22End+to+End+testing%22
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-blue.svg
 [license-link]: https://github.com/informalsystems/hermes/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-stable-blue.svg


### PR DESCRIPTION
This badge appears broken. 

<img width="595" alt="Screenshot 2023-10-20 at 4 26 39 PM" src="https://github.com/informalsystems/hermes/assets/3699047/eb575b4b-c134-4b44-9217-5de1eb4282fc">

Feel free to close this PR in favor of updating the badge to some other workflow. I couldn't find one named "End to End testing"

Ref: https://github.com/informalsystems/hermes/actions?query=workflow%3A%22End+to+End+testing%22