### PR TITLE
Enable `serde` feature of `ibc-proto`

### DIFF
--- a/crates/relayer-types/Cargo.toml
+++ b/crates/relayer-types/Cargo.toml
@@ -24,7 +24,7 @@ mocks = ["tendermint-testgen", "clock"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.38.0" }
+ibc-proto = { version = "0.38.0", features = ["serde"] }
 ics23 = { version = "0.11.0", features = ["std", "host-functions"] }
 time = { version = "0.3" }
 serde_derive = { version = "1.0.104" }


### PR DESCRIPTION
Fix publishing step by adding missing feature to `ibc-proto` dependency.

This feature was enabled transitively but needs to be explicit for publishing to work.