### PR TITLE
Add `Modular Architecture` to Features Matrix.

### DIFF
--- a/guide/src/advanced/features.md
+++ b/guide/src/advanced/features.md
@@ -118,6 +118,7 @@ __Feature comparison between Hermes and the Go relayer__
 | Packet_TimeoutClose_P  | ✅    | ✅     |
 | Packet_Optimistic      | ❌    | ❌     | relay packets over non-Open channels
 |                        |       |        |
+| Modular Architecture   | ❌    | ✅     | defined interface can be implemented for different chain types
 | Cl_Non_Tendermint      | ❌    | ❌     | supports non tendermint IBC light clients
 | Chain_Non_Cosmos       | ❌    | ❌     | supports non cosmos-SDK chains
 |                        |       |        |


### PR DESCRIPTION
Relayer functionality was refactored behind an interface (so that different chain types could implement that interface), beginning in https://github.com/cosmos/relayer/pull/521 on December 30, 2021.