### PR TITLE
Add `Penumbra support` to Features Matrix.

### DIFF
--- a/guide/src/advanced/features.md
+++ b/guide/src/advanced/features.md
@@ -119,7 +119,8 @@ __Feature comparison between Hermes and the Go relayer__
 | Packet_Optimistic      | ❌    | ❌     | relay packets over non-Open channels
 |                        |       |        |
 | Cl_Non_Tendermint      | ❌    | ❌     | supports non tendermint IBC light clients
-| Chain_Non_Cosmos       | ❌    | ❌     | supports non cosmos-SDK chains
+| Chain_Non_Cosmos       | ❌    | ✅     | supports non cosmos-SDK chains
+| Penumbra support       | ❌    | ✅     | supports Penumbra non-cosmos-SDK chain
 |                        |       |        |
 | Cfg_Static            | ✅    | ✅     | provides means for configuration prior to being started
 | Cfg_Dynamic           | ❌    | ❌     | provides means for configuration and monitoring during runtime


### PR DESCRIPTION
Penumbra (non-`cosmos-SDK`) support was added to the go-relayer in https://github.com/cosmos/relayer/pull/1144 on March 31, 2023.