### PR TITLE
Fix guide config files and balance outputs

### DIFF
--- a/guide/src/templates/files/hermes/local-chains/config.toml
+++ b/guide/src/templates/files/hermes/local-chains/config.toml
@@ -37,7 +37,7 @@ account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
 gas_price = { price = 0.001, denom = 'stake' }
-gas_multiplier = 1.1
+gas_multiplier = 1.2
 default_gas = 1000000
 max_gas = 10000000
 max_msg_num = 30
@@ -66,7 +66,7 @@ account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
 gas_price = { price = 0.001, denom = 'stake' }
-gas_multiplier = 1.1
+gas_multiplier = 1.2
 default_gas = 1000000
 max_gas = 10000000
 max_msg_num = 30
@@ -82,4 +82,3 @@ trust_threshold = { numerator = '2', denominator = '3' }
 #   ['ica*', '*'],
 #   ['transfer', 'channel-0'],
 # ]
-

--- a/guide/src/templates/files/hermes/more-chains/config_with_filters.toml
+++ b/guide/src/templates/files/hermes/more-chains/config_with_filters.toml
@@ -30,16 +30,22 @@ id = 'ibc-0'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27050'
 grpc_addr = 'http://localhost:27052'
-event_source = { mode = 'push', url = 'ws://localhost:27050/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27050/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'
@@ -53,16 +59,22 @@ id = 'ibc-1'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27060'
 grpc_addr = 'http://localhost:27062'
-event_source = { mode = 'push', url = 'ws://localhost:27060/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27060/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 
 [chains.packet_filter]
@@ -77,16 +89,22 @@ id = 'ibc-2'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27070'
 grpc_addr = 'http://localhost:27072'
-event_source = { mode = 'push', url = 'ws://localhost:27070/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27070/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'
@@ -100,16 +118,22 @@ id = 'ibc-3'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27080'
 grpc_addr = 'http://localhost:27082'
-event_source = { mode = 'push', url = 'ws://localhost:27080/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27080/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'

--- a/guide/src/templates/files/hermes/more-chains/config_without_filters.toml
+++ b/guide/src/templates/files/hermes/more-chains/config_without_filters.toml
@@ -30,61 +30,85 @@ id = 'ibc-0'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27050'
 grpc_addr = 'http://localhost:27052'
-event_source = { mode = 'push', url = 'ws://localhost:27050/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27050/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [[chains]]
 id = 'ibc-1'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27060'
 grpc_addr = 'http://localhost:27062'
-event_source = { mode = 'push', url = 'ws://localhost:27060/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27060/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [[chains]]
 id = 'ibc-2'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27070'
 grpc_addr = 'http://localhost:27072'
-event_source = { mode = 'push', url = 'ws://localhost:27070/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27070/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [[chains]]
 id = 'ibc-3'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27080'
 grpc_addr = 'http://localhost:27082'
-event_source = { mode = 'push', url = 'ws://localhost:27080/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27080/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
 key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }

--- a/guide/src/templates/files/hermes/more-chains/hermes_second_instance.toml
+++ b/guide/src/templates/files/hermes/more-chains/hermes_second_instance.toml
@@ -30,16 +30,22 @@ id = 'ibc-0'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27050'
 grpc_addr = 'http://localhost:27052'
-event_source = { mode = 'push', url = 'ws://localhost:27050/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27050/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
-key_name = 'wallet1'
+key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'
@@ -52,17 +58,22 @@ id = 'ibc-1'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27060'
 grpc_addr = 'http://localhost:27062'
-event_source = { mode = 'push', url = 'ws://localhost:27060/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27060/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
-key_name = 'wallet1'
+key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
-
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'
@@ -75,16 +86,22 @@ id = 'ibc-2'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27070'
 grpc_addr = 'http://localhost:27072'
-event_source = { mode = 'push', url = 'ws://localhost:27070/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27070/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
-key_name = 'wallet1'
+key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'
@@ -97,16 +114,22 @@ id = 'ibc-3'
 type = 'CosmosSdk'
 rpc_addr = 'http://localhost:27080'
 grpc_addr = 'http://localhost:27082'
-event_source = { mode = 'push', url = 'ws://localhost:27080/websocket', batch_delay = '500ms' }
+event_source = { mode = 'push', url = 'ws://localhost:27080/websocket', batch_delay = '200ms' }
 rpc_timeout = '15s'
+trusted_node = true
 account_prefix = 'cosmos'
-key_name = 'wallet1'
+key_name = 'wallet'
 store_prefix = 'ibc'
-gas_price = { price = 0.01, denom = 'stake' }
+gas_price = { price = 0.001, denom = 'stake' }
+gas_multiplier = 1.2
+default_gas = 1000000
 max_gas = 10000000
+max_msg_num = 30
+max_tx_size = 2097152
 clock_drift = '5s'
+max_block_time = '30s'
 trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+trust_threshold = { numerator = '2', denominator = '3' }
 
 [chains.packet_filter]
 policy = 'allow'

--- a/guide/src/tutorials/local-chains/start-relaying.md
+++ b/guide/src/tutorials/local-chains/start-relaying.md
@@ -105,8 +105,6 @@ Now, let's exchange `samoleans` between two chains.
     - Balances on ibc-1:
         ```
         balances:
-        - amount: "0"
-        denom: ibc/C1840BD16FCFA8F421DAA0DAAB08B9C323FC7685D0D7951DC37B3F9ECB08A199
         - amount: "100000000"
         denom: samoleans
         - amount: "99983879"

--- a/guide/src/tutorials/more-chains/start-relaying.md
+++ b/guide/src/tutorials/more-chains/start-relaying.md
@@ -165,8 +165,6 @@ Now, let's exchange `samoleans` between chains.
     - Balances on `ibc-2`:
         ```
         balances:
-        - amount: "0"
-        denom: ibc/C1840BD16FCFA8F421DAA0DAAB08B9C323FC7685D0D7951DC37B3F9ECB08A199
         - amount: "100000000"
         denom: samoleans
         - amount: "99977059"
@@ -247,8 +245,6 @@ A((ibc-3)) --> B((ibc-0)) --> C((ibc-1));
     - Balances on `ibc-0`:
         ```
         balances:
-        - amount: "0"
-        denom: ibc/563FDAE5A0D8C15013E4485134A2D2EE3317452278B56B2ED63DDB4EB677DF84
         - amount: "100000000"
         denom: samoleans
         - amount: "99978828"
@@ -306,8 +302,6 @@ A((ibc-3))-->B((ibc-2))-->C((ibc-1));
     - Balances at ibc-3:
         ```
         balances:
-        - amount: "0"
-        denom: ibc/C658F0EB9DE176E080B586D634004141239C3E55676462C976266DB54C56EBE4
         - amount: "100000000"
         denom: samoleans
         - amount: "99973935"
@@ -340,8 +334,6 @@ A((ibc-3))-->B((ibc-2))-->C((ibc-1));
     - Balances on `ibc-2`:
         ```
         balances:
-        - amount: "0"
-        denom: ibc/C1840BD16FCFA8F421DAA0DAAB08B9C323FC7685D0D7951DC37B3F9ECB08A199
         - amount: "100000000"
         denom: samoleans
         - amount: "99974602"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3618

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR updates the guide to reflect on changes in Hermes config file as well as the `query bank balances` from Gaia v12:

* Creating a client with `hermes create channel --a-chain ibc-0 --a-port transfer  --b-chain ibc-1 --b-port transfer --new-client-connection --yes` with `gas_multiplier = 1.1` will fail due to an out of gas error. The value has been updated to `gas_multiplier = 1.2`
* Other values in config.toml correctly reflect the values generated by `gm hermes config`
* Gaia v12 doesn't display the balance of tokens with `amount = "0"`

______

### PR author checklist:
- [ ] ~Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).~
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
