### PR TITLE
Add `broadcast_errors` metric

### DIFF
--- a/.changelog/unreleased/features/ibc-telemetry/3708-add-broadcast-errors.md
+++ b/.changelog/unreleased/features/ibc-telemetry/3708-add-broadcast-errors.md
@@ -1,0 +1,3 @@
+- Add a new metric `broadcast_errors`` which
+  records the errors observed when broadcasting Txs
+  ([\#3708](https://github.com/informalsystems/hermes/issues/3708))

--- a/crates/relayer/src/chain/cosmos/retry.rs
+++ b/crates/relayer/src/chain/cosmos/retry.rs
@@ -107,6 +107,13 @@ async fn do_send_tx_with_account_sequence_retry(
                 refreshing account sequence number and retrying once"
             );
 
+            telemetry!(
+                broadcast_errors,
+                &account.address.to_string(),
+                response.code.into(),
+                &response.log,
+            );
+
             refresh_account_and_retry_send_tx_with_account_sequence(
                 rpc_client, config, key_pair, account, tx_memo, messages,
             )
@@ -145,6 +152,13 @@ async fn do_send_tx_with_account_sequence_retry(
                         ?response,
                         diagnostic = ?sdk_error_from_tx_sync_error_code(code.into()),
                         "failed to broadcast tx with unrecoverable error"
+                    );
+
+                    telemetry!(
+                        broadcast_errors,
+                        &account.address.to_string(),
+                        code.into(),
+                        &response.log
                     );
 
                     Ok(response)

--- a/crates/telemetry/src/state.rs
+++ b/crates/telemetry/src/state.rs
@@ -197,6 +197,9 @@ pub struct TelemetryState {
 
     /// Sum of rewarded fees over the past FEE_LIFETIME seconds
     period_fees: ObservableGauge<u64>,
+
+    /// Number of errors observed by Hermes when broadcasting a Tx
+    broadcast_errors: Counter<u64>,
 }
 
 impl TelemetryState {
@@ -370,6 +373,13 @@ impl TelemetryState {
             period_fees: meter
                 .u64_observable_gauge("ics29_period_fees")
                 .with_description("Amount of ICS29 fees rewarded over the past 7 days")
+                .init(),
+
+            broadcast_errors: meter
+                .u64_counter("broadcast_errors")
+                .with_description(
+                    "Number of errors observed by Hermes when broadcasting a Tx",
+                )
                 .init(),
         }
     }
@@ -1068,6 +1078,20 @@ impl TelemetryState {
     // the rewarded fees from ICS29.
     pub fn add_visible_fee_address(&self, address: String) {
         self.visible_fee_addresses.insert(address);
+    }
+
+    /// Add an error and its description to the list of errors observed after broadcasting
+    /// a Tx with a specific account.
+    pub fn broadcast_errors(&self, address: &String, error_code: u32, error_description: &String) {
+        let cx = Context::current();
+
+        let labels = &[
+            KeyValue::new("account", address.to_string()),
+            KeyValue::new("error_code", error_code.to_string()),
+            KeyValue::new("error_description", error_description.to_string()),
+        ];
+
+        self.broadcast_errors.add(&cx, 1, labels);
     }
 }
 

--- a/guide/src/documentation/telemetry/operators.md
+++ b/guide/src/documentation/telemetry/operators.md
@@ -142,6 +142,7 @@ the `backlog_oldest_sequence` that is blocked.
 | `tx_latency_submitted`         | Latency for all transactions submitted to a chain (i.e., difference between the moment when Hermes received an event until the corresponding transaction(s) were submitted), per chain, counterparty chain, channel and port | `u64` ValueRecorder | None                       |
 | `cleared_send_packet_count_total`    | Number of SendPacket events received during the initial and periodic clearing, per chain, counterparty chain, channel and port                                              | `u64` Counter       | Packet workers enabled, and periodic packet clearing or clear on start enabled |
 | `cleared_acknowledgment_count_total` | Number of WriteAcknowledgement events received during the initial and periodic clearing, per chain, counterparty chain, channel and port                                    | `u64` Counter       | Packet workers enabled, and periodic packet clearing or clear on start enabled |
+| `broadcast_errors_total`        | Number of errors observed by Hermes when broadcasting a Tx, per error type and account                                                                                                         | `u64` Counter       | Packet workers enabled |
 
 Notes:
 - The two metrics `cleared_send_packet_count_total` and `cleared_acknowledgment_count_total` are only populated if `tx_confirmation = true`.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3708

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR adds a metric to the telemetry which records the number of times an error has been observed when broadcasting a Tx.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
