### PR TITLE
chore(docs): typo fix

### DIFF
--- a/docs/architecture/adr-002-ibc-relayer.md
+++ b/docs/architecture/adr-002-ibc-relayer.md
@@ -793,6 +793,6 @@ The IBC Events, input to the relay thread are described here.
 
 ## References
 
-> Are there any relevant PR comments, issues that led up to this, or articles referrenced for why we made the given design choice? If so link them here!
+> Are there any relevant PR comments, issues that led up to this, or articles referenced for why we made the given design choice? If so link them here!
 
 * {reference link}

--- a/docs/architecture/adr-003-handler-implementation.md
+++ b/docs/architecture/adr-003-handler-implementation.md
@@ -552,7 +552,7 @@ pub trait ClientKeeper {
 
 This way, only one implementation of the `ClientReader` and `ClientKeeper` trait is required,
 as it can delegate eg. the serialization of the underlying datatypes to the `Serialize` bound
-of the `Any...` wrappper.
+of the `Any...` wrapper.
 
 Both the `process` and `keep` function are defined to take a message generic over
 the actual client type:

--- a/docs/architecture/adr-template.md
+++ b/docs/architecture/adr-template.md
@@ -31,6 +31,6 @@ If the proposed change will be large, please also indicate a way to do the chang
 
 ## References
 
-> Are there any relevant PR comments, issues that led up to this, or articles referrenced for why we made the given design choice? If so link them here!
+> Are there any relevant PR comments, issues that led up to this, or articles referenced for why we made the given design choice? If so link them here!
 
 * {reference link}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -110,7 +110,7 @@ Used by Hermes to gather telemetry data and expose it via a Prometheus endpoint.
 
 Most of the components in the `ibc` crate (i.e. the `modules` directory) have basic unit testing coverage. These unit tests make use of mocked up chain components in order to ensure that message payloads are being sent and received as expected. 
 
-We also run end-to-end tests to more thoroughly test IBC modules in a more heterogenous fashion. 
+We also run end-to-end tests to more thoroughly test IBC modules in a more heterogeneous fashion. 
 
 ### Error Handling 
 

--- a/docs/spec/tla/packet-delay/Chain.tla
+++ b/docs/spec/tla/packet-delay/Chain.tla
@@ -90,7 +90,7 @@ SendPacket ==
         srcChannelID |-> chainStore.channelEnd.channelID,
         dstPortID |-> chainStore.channelEnd.counterpartyPortID,
         dstChannelID |-> chainStore.channelEnd.counterpartyChannelID] IN
-        \* update chain store with packet committment
+        \* update chain store with packet commitment
         /\ chainStore' = WritePacketCommitment(chainStore, packet)
         \* log sent packet
         /\ packetLog' = Append(packetLog, 


### PR DESCRIPTION
Hi, I found a few typos in the docs.

One of them isn't plain text but in a .tla file. Although I'm not familiar with this kind of file, I believe it's a comment so there shouldn't be any issue.

This is a minor change. Have a nice day
