### PR TITLE
update `get_key` take `&self` instead of `&mut self`

### DIFF
--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -941,7 +941,7 @@ impl ChainEndpoint for CosmosSdkChain {
         &mut self.keybase
     }
 
-    fn get_key(&mut self) -> Result<Self::SigningKeyPair, Error> {
+    fn get_key(&self) -> Result<Self::SigningKeyPair, Error> {
         // Get the key from key seed file
         let key_pair = self
             .keybase()

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -112,7 +112,7 @@ pub trait ChainEndpoint: Sized {
     fn get_signer(&self) -> Result<Signer, Error>;
 
     /// Get the signing key pair
-    fn get_key(&mut self) -> Result<Self::SigningKeyPair, Error>;
+    fn get_key(&self) -> Result<Self::SigningKeyPair, Error>;
 
     fn add_key(&mut self, key_name: &str, key_pair: Self::SigningKeyPair) -> Result<(), Error> {
         self.keybase_mut()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description

Updates the `get_key` method on the `ChainEndpoint` trait to take `&self` instead of `&mut self`, as it wasn't needed for self to be mutable. it's also expected that a function named as `get` doesn't mutate self. this also allows `get_key` to be used in methods that take `&self`.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).
