### PR TITLE
feat: implement chan upgrade cancel and add timeout ack integration test

### DIFF
--- a/crates/relayer-cli/src/commands/tx.rs
+++ b/crates/relayer-cli/src/commands/tx.rs
@@ -56,6 +56,9 @@ pub enum TxCmd {
     /// Relay the channel upgrade attempt (ChannelUpgradeOpen)
     ChanUpgradeOpen(channel::TxChanUpgradeOpenCmd),
 
+    /// Relay the channel upgrade cancellation (ChannelUpgradeCancel)
+    ChanUpgradeCancel(channel::TxChanUpgradeCancelCmd),
+
     /// Send a fungible token transfer test transaction (ICS20 MsgTransfer)
     FtTransfer(transfer::TxIcs20MsgTransferCmd),
 

--- a/crates/relayer-types/src/core/ics04_channel/error.rs
+++ b/crates/relayer-types/src/core/ics04_channel/error.rs
@@ -126,6 +126,9 @@ define_error! {
         MissingUpgradeFields
             | _ | { "missing upgrade fields" },
 
+        MissingUpgradeErrorReceipt
+            | _ | { "missing upgrade error receipt" },
+
         MissingProposedUpgradeChannel
             | _ | { "missing proposed upgrade channel" },
 

--- a/crates/relayer-types/src/core/ics04_channel/events.rs
+++ b/crates/relayer-types/src/core/ics04_channel/events.rs
@@ -1078,6 +1078,108 @@ impl EventType for UpgradeOpen {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct UpgradeCancel {
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
+    pub counterparty_port_id: PortId,
+    pub counterparty_channel_id: Option<ChannelId>,
+    pub upgrade_connection_hops: Vec<ConnectionId>,
+    pub upgrade_version: Version,
+    pub upgrade_sequence: Sequence,
+    pub upgrade_ordering: Ordering
+}
+
+impl Display for UpgradeCancel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        if let Some(counterparty_channel_id) = &self.counterparty_channel_id {
+            write!(f, "UpgradeAttributes {{ port_id: {}, channel_id: {}, counterparty_port_id: {}, counterparty_channel_id: {counterparty_channel_id}, upgrade_connection_hops: [", self.port_id, self.channel_id, self.counterparty_port_id)?;
+        } else {
+            write!(f, "UpgradeAttributes {{ port_id: {}, channel_id: {}, counterparty_port_id: {}, counterparty_channel_id: None, upgrade_connection_hops: [", self.port_id, self.channel_id, self.counterparty_port_id)?;
+        }
+        for hop in self.upgrade_connection_hops.iter() {
+            write!(f, " {} ", hop)?;
+        }
+        write!(
+            f,
+            "], upgrade_version: {}, upgrade_sequence: {}, upgrade_ordering: {} }}",
+            self.upgrade_version, self.upgrade_sequence, self.upgrade_ordering
+        )
+    }
+}
+
+impl From<UpgradeCancel> for UpgradeAttributes {
+    fn from(ev: UpgradeCancel) -> Self {
+        Self {
+            port_id: ev.port_id,
+            channel_id: ev.channel_id,
+            counterparty_port_id: ev.counterparty_port_id,
+            counterparty_channel_id: ev.counterparty_channel_id,
+            upgrade_connection_hops: ev.upgrade_connection_hops,
+            upgrade_version: ev.upgrade_version,
+            upgrade_sequence: ev.upgrade_sequence,
+            upgrade_ordering: ev.upgrade_ordering,
+        }
+    }
+}
+
+impl From<UpgradeCancel> for abci::Event {
+    fn from(value: UpgradeCancel) -> Self {
+        let kind = UpgradeCancel::event_type().as_str().to_owned();
+        Self {
+            kind,
+            attributes: UpgradeAttributes::from(value).into(),
+        }
+    }
+}
+
+impl UpgradeCancel {
+    pub fn channel_id(&self) -> &ChannelId {
+        &self.channel_id
+    }
+
+    pub fn port_id(&self) -> &PortId {
+        &self.port_id
+    }
+
+    pub fn counterparty_port_id(&self) -> &PortId {
+        &self.counterparty_port_id
+    }
+
+    pub fn counterparty_channel_id(&self) -> Option<&ChannelId> {
+        self.counterparty_channel_id.as_ref()
+    }
+}
+
+impl TryFrom<UpgradeAttributes> for UpgradeCancel {
+    type Error = EventError;
+
+    fn try_from(attrs: UpgradeAttributes) -> Result<Self, Self::Error> {
+        Ok(Self {
+            port_id: attrs.port_id,
+            channel_id: attrs.channel_id,
+            counterparty_port_id: attrs.counterparty_port_id,
+            counterparty_channel_id: attrs.counterparty_channel_id,
+            upgrade_connection_hops: attrs.upgrade_connection_hops,
+            upgrade_version: attrs.upgrade_version,
+            upgrade_sequence: attrs.upgrade_sequence,
+            upgrade_ordering: attrs.upgrade_ordering,
+        })
+    }
+}
+
+impl From<UpgradeCancel> for IbcEvent {
+    fn from(v: UpgradeCancel) -> Self {
+        IbcEvent::UpgradeCancelChannel(v)
+    }
+}
+
+impl EventType for UpgradeCancel {
+    fn event_type() -> IbcEventType {
+        IbcEventType::UpgradeCancelChannel
+    }
+}
+
 macro_rules! impl_try_from_attribute_for_event {
     ($($event:ty),+) => {
         $(impl TryFrom<Attributes> for $event {

--- a/crates/relayer-types/src/core/ics04_channel/msgs.rs
+++ b/crates/relayer-types/src/core/ics04_channel/msgs.rs
@@ -28,6 +28,7 @@ pub mod chan_upgrade_confirm;
 pub mod chan_upgrade_init;
 pub mod chan_upgrade_open;
 pub mod chan_upgrade_try;
+pub mod chan_upgrade_cancel;
 
 // Packet specific messages.
 pub mod acknowledgement;

--- a/crates/relayer-types/src/core/ics04_channel/msgs/chan_upgrade_cancel.rs
+++ b/crates/relayer-types/src/core/ics04_channel/msgs/chan_upgrade_cancel.rs
@@ -1,0 +1,239 @@
+use ibc_proto::ibc::core::channel::v1::MsgChannelUpgradeCancel as RawMsgChannelUpgradeCancel;
+use ibc_proto::Protobuf;
+
+use crate::core::ics04_channel::upgrade::ErrorReceipt;
+use crate::core::ics04_channel::error::Error;
+use crate::core::ics23_commitment::commitment::CommitmentProofBytes;
+use crate::core::ics24_host::identifier::{ChannelId, PortId};
+use crate::signer::Signer;
+use crate::tx_msg::Msg;
+use crate::Height;
+
+pub const TYPE_URL: &str = "/ibc.core.channel.v1.MsgChannelUpgradeCancel";
+
+/// Message definition the `ChanUpgradeCancel` datagram.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MsgChannelUpgradeCancel {
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
+    pub error_receipt: ErrorReceipt,
+    /// The proof of the counterparty error receipt
+    pub proof_error_receipt: CommitmentProofBytes,
+    /// The height at which the proofs were queried.
+    pub proof_height: Height,
+    pub signer: Signer,
+}
+
+impl MsgChannelUpgradeCancel {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        port_id: PortId,
+        channel_id: ChannelId,
+        error_receipt: ErrorReceipt,
+        proof_error_receipt: CommitmentProofBytes,
+        proof_height: Height,
+        signer: Signer,
+    ) -> Self {
+        Self {
+            port_id,
+            channel_id,
+            error_receipt,
+            proof_error_receipt,
+            proof_height,
+            signer,
+        }
+    }
+}
+
+impl Msg for MsgChannelUpgradeCancel {
+    type ValidationError = Error;
+    type Raw = RawMsgChannelUpgradeCancel;
+
+    fn route(&self) -> String {
+        crate::keys::ROUTER_KEY.to_string()
+    }
+
+    fn type_url(&self) -> String {
+        TYPE_URL.to_string()
+    }
+}
+
+impl Protobuf<RawMsgChannelUpgradeCancel> for MsgChannelUpgradeCancel {}
+
+impl TryFrom<RawMsgChannelUpgradeCancel> for MsgChannelUpgradeCancel {
+    type Error = Error;
+
+    fn try_from(raw_msg: RawMsgChannelUpgradeCancel) -> Result<Self, Self::Error> {
+        let raw_error_receipt = raw_msg.error_receipt.ok_or(Error::missing_upgrade_error_receipt())?;
+        let error_receipt = ErrorReceipt::try_from(raw_error_receipt)?;
+
+        let proof_height = raw_msg
+            .proof_height
+            .ok_or_else(Error::missing_proof_height)?
+            .try_into()
+            .map_err(|_| Error::invalid_proof_height())?;
+
+        Ok(MsgChannelUpgradeCancel {
+            port_id: raw_msg.port_id.parse().map_err(Error::identifier)?,
+            channel_id: raw_msg.channel_id.parse().map_err(Error::identifier)?,
+            error_receipt: error_receipt,
+            proof_error_receipt: raw_msg
+                .proof_error_receipt
+                .try_into()
+                .map_err(Error::invalid_proof)?,
+            proof_height,
+            signer: raw_msg.signer.parse().map_err(Error::signer)?,
+        })
+    }
+}
+
+impl From<MsgChannelUpgradeCancel> for RawMsgChannelUpgradeCancel {
+    fn from(domain_msg: MsgChannelUpgradeCancel) -> Self {
+        RawMsgChannelUpgradeCancel {
+            port_id: domain_msg.port_id.to_string(),
+            channel_id: domain_msg.channel_id.to_string(),
+            error_receipt: Some(domain_msg.error_receipt.into()),
+            proof_error_receipt: domain_msg.proof_error_receipt.into(),
+            proof_height: Some(domain_msg.proof_height.into()),
+            signer: domain_msg.signer.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test_util {
+    use ibc_proto::ibc::core::channel::v1::{MsgChannelUpgradeCancel as RawMsgChannelUpgradeCancel, ErrorReceipt};
+    use ibc_proto::ibc::core::client::v1::Height as RawHeight;
+    use ibc_proto::ibc::core::channel::v1::ErrorReceipt as RawErrorReceipt;
+
+    use crate::core::ics24_host::identifier::{ChannelId, PortId};
+    use crate::test_utils::{get_dummy_bech32_account, get_dummy_proof};
+
+    /// Returns a dummy `RawMsgChannelUpgradeCnacel`, for testing only!
+    pub fn get_dummy_raw_msg_chan_upgrade_cancel() -> RawMsgChannelUpgradeCancel {
+        RawMsgChannelUpgradeCancel {
+            port_id: PortId::default().to_string(),
+            channel_id: ChannelId::default().to_string(),
+            error_receipt: Some(RawErrorReceipt {
+                sequence: 1,
+                message: "error message".to_string()
+            }),
+            proof_error_receipt: get_dummy_proof(),
+            proof_height: Some(RawHeight {
+                revision_number: 1,
+                revision_height: 1,
+            }),
+            signer: get_dummy_bech32_account(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use ibc_proto::ibc::core::channel::v1::MsgChannelUpgradeCancel as RawMsgChannelUpgradeCancel;
+
+    use crate::core::ics04_channel::msgs::chan_upgrade_cancel::test_util::get_dummy_raw_msg_chan_upgrade_cancel;
+    use crate::core::ics04_channel::msgs::chan_upgrade_cancel::MsgChannelUpgradeCancel;
+
+    #[test]
+    fn parse_channel_upgrade_try_msg() {
+        struct Test {
+            name: String,
+            raw: RawMsgChannelUpgradeCancel,
+            want_pass: bool,
+        }
+
+        let default_raw_msg = get_dummy_raw_msg_chan_upgrade_cancel();
+
+        let tests: Vec<Test> = vec![
+            Test {
+                name: "Good parameters".to_string(),
+                raw: default_raw_msg.clone(),
+                want_pass: true,
+            },
+            Test {
+                name: "Correct port ID".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    port_id: "p36".to_string(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: true,
+            },
+            Test {
+                name: "Port too short".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    port_id: "p".to_string(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Port too long".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    port_id: "abcdefsdfasdfasdfasdfasdfasdfadsfasdgafsgadfasdfasdfasdfsdfasdfaghijklmnopqrstuabcdefsdfasdfasdfasdfasdfasdfadsfasdgafsgadfasdfasdfasdfsdfasdfaghijklmnopqrstu".to_string(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Correct channel ID".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    channel_id: "channel-2".to_string(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: true,
+            },
+            Test {
+                name: "Channel name too short".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    channel_id: "c".to_string(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Channel name too long".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    channel_id: "channel-128391283791827398127398791283912837918273981273987912839".to_string(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Empty proof channel".to_string(),
+                raw: RawMsgChannelUpgradeCancel {
+                    proof_error_receipt: vec![],
+                    ..default_raw_msg
+                },
+                want_pass: false,
+            },
+        ]
+        .into_iter()
+        .collect();
+
+        for test in tests {
+            let res = RawMsgChannelUpgradeCancel::try_from(test.raw.clone());
+
+            assert_eq!(
+                test.want_pass,
+                res.is_ok(),
+                "RawMsgChannelUpgradeCancel::try_from failed for test {}, \nraw msg {:?} with err {:?}",
+                test.name,
+                test.raw,
+                res.err()
+            );
+        }
+    }
+
+    #[test]
+    fn to_and_from() {
+        let raw = get_dummy_raw_msg_chan_upgrade_cancel();
+        let msg = MsgChannelUpgradeCancel::try_from(raw.clone()).unwrap();
+        let raw_back = RawMsgChannelUpgradeCancel::from(msg.clone());
+        let msg_back = MsgChannelUpgradeCancel::try_from(raw_back.clone()).unwrap();
+        assert_eq!(raw, raw_back);
+        assert_eq!(msg, msg_back);
+    }
+}

--- a/crates/relayer-types/src/core/ics04_channel/upgrade.rs
+++ b/crates/relayer-types/src/core/ics04_channel/upgrade.rs
@@ -1,4 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::Upgrade as RawUpgrade;
+use ibc_proto::ibc::core::channel::v1::ErrorReceipt as RawErrorReceipt;
 use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::Error as ChannelError;
@@ -45,6 +46,34 @@ impl From<Upgrade> for RawUpgrade {
             fields: Some(value.fields.into()),
             timeout,
             latest_sequence_send: value.latest_sequence_send.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ErrorReceipt {
+    pub sequence: Sequence,
+    pub message: String,
+}
+
+impl Protobuf<RawErrorReceipt> for ErrorReceipt {}
+
+impl TryFrom<RawErrorReceipt> for ErrorReceipt {
+    type Error = ChannelError;
+
+    fn try_from(value: RawErrorReceipt) -> Result<Self, Self::Error> {
+        Ok(Self {
+            sequence: value.sequence.into(),
+            message: value.message,
+        })
+    }
+}
+
+impl From<ErrorReceipt> for RawErrorReceipt {
+    fn from(value: ErrorReceipt) -> Self {
+        Self {
+            sequence: value.sequence.into(),
+            message: value.message,
         }
     }
 }

--- a/crates/relayer-types/src/core/ics24_host/path.rs
+++ b/crates/relayer-types/src/core/ics24_host/path.rs
@@ -43,6 +43,14 @@ pub enum Path {
     Receipts(ReceiptsPath),
     Upgrade(ClientUpgradePath),
     ChannelUpgrade(ChannelUpgradePath),
+    ChannelUpgradeError(ChannelUpgradeErrorPath),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display(fmt = "channelUpgrades/upgradeError/ports/{port_id}/channels/{channel_id}")]
+pub struct ChannelUpgradeErrorPath {
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]

--- a/crates/relayer-types/src/events.rs
+++ b/crates/relayer-types/src/events.rs
@@ -134,6 +134,7 @@ const CHANNEL_UPGRADE_TRY_EVENT: &str = "channel_upgrade_try";
 const CHANNEL_UPGRADE_ACK_EVENT: &str = "channel_upgrade_ack";
 const CHANNEL_UPGRADE_CONFIRM_EVENT: &str = "channel_upgrade_confirm";
 const CHANNEL_UPGRADE_OPEN_EVENT: &str = "channel_upgrade_open";
+const CHANNEL_UPGRADE_CANCEL_EVENT: &str = "channel_upgrade_cancel";
 /// Packet event types
 const SEND_PACKET_EVENT: &str = "send_packet";
 const RECEIVE_PACKET_EVENT: &str = "receive_packet";
@@ -170,6 +171,7 @@ pub enum IbcEventType {
     UpgradeAckChannel,
     UpgradeConfirmChannel,
     UpgradeOpenChannel,
+    UpgradeCancelChannel,
     SendPacket,
     ReceivePacket,
     WriteAck,
@@ -207,6 +209,7 @@ impl IbcEventType {
             IbcEventType::UpgradeAckChannel => CHANNEL_UPGRADE_ACK_EVENT,
             IbcEventType::UpgradeConfirmChannel => CHANNEL_UPGRADE_CONFIRM_EVENT,
             IbcEventType::UpgradeOpenChannel => CHANNEL_UPGRADE_OPEN_EVENT,
+            IbcEventType::UpgradeCancelChannel => CHANNEL_UPGRADE_CANCEL_EVENT,
             IbcEventType::SendPacket => SEND_PACKET_EVENT,
             IbcEventType::ReceivePacket => RECEIVE_PACKET_EVENT,
             IbcEventType::WriteAck => WRITE_ACK_EVENT,
@@ -291,6 +294,7 @@ pub enum IbcEvent {
     UpgradeAckChannel(ChannelEvents::UpgradeAck),
     UpgradeConfirmChannel(ChannelEvents::UpgradeConfirm),
     UpgradeOpenChannel(ChannelEvents::UpgradeOpen),
+    UpgradeCancelChannel(ChannelEvents::UpgradeCancel),
 
     SendPacket(ChannelEvents::SendPacket),
     ReceivePacket(ChannelEvents::ReceivePacket),
@@ -335,6 +339,7 @@ impl Display for IbcEvent {
             IbcEvent::UpgradeAckChannel(ev) => write!(f, "UpgradeAckChannel({ev})"),
             IbcEvent::UpgradeConfirmChannel(ev) => write!(f, "UpgradeConfirmChannel({ev})"),
             IbcEvent::UpgradeOpenChannel(ev) => write!(f, "UpgradeOpenChannel({ev})"),
+            IbcEvent::UpgradeCancelChannel(ev) => write!(f, "UpgradeCancelChannel({ev})"),
 
             IbcEvent::SendPacket(ev) => write!(f, "SendPacket({ev})"),
             IbcEvent::ReceivePacket(ev) => write!(f, "ReceivePacket({ev})"),
@@ -379,6 +384,7 @@ impl TryFrom<IbcEvent> for abci::Event {
             IbcEvent::UpgradeAckChannel(event) => event.into(),
             IbcEvent::UpgradeConfirmChannel(event) => event.into(),
             IbcEvent::UpgradeOpenChannel(event) => event.into(),
+            IbcEvent::UpgradeCancelChannel(event) => event.into(),
             IbcEvent::SendPacket(event) => event.try_into().map_err(Error::channel)?,
             IbcEvent::ReceivePacket(event) => event.try_into().map_err(Error::channel)?,
             IbcEvent::WriteAcknowledgement(event) => event.try_into().map_err(Error::channel)?,
@@ -426,6 +432,7 @@ impl IbcEvent {
             IbcEvent::UpgradeAckChannel(_) => IbcEventType::UpgradeAckChannel,
             IbcEvent::UpgradeConfirmChannel(_) => IbcEventType::UpgradeConfirmChannel,
             IbcEvent::UpgradeOpenChannel(_) => IbcEventType::UpgradeOpenChannel,
+            IbcEvent::UpgradeCancelChannel(_) => IbcEventType::UpgradeCancelChannel,
             IbcEvent::SendPacket(_) => IbcEventType::SendPacket,
             IbcEvent::ReceivePacket(_) => IbcEventType::ReceivePacket,
             IbcEvent::WriteAcknowledgement(_) => IbcEventType::WriteAck,

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -20,7 +20,7 @@ use ibc_proto::cosmos::staking::v1beta1::Params as StakingParams;
 use ibc_proto::ibc::apps::fee::v1::{
     QueryIncentivizedPacketRequest, QueryIncentivizedPacketResponse,
 };
-use ibc_proto::ibc::core::channel::v1::QueryUpgradeRequest;
+use ibc_proto::ibc::core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest};
 use ibc_proto::interchain_security::ccv::v1::ConsumerParams as CcvConsumerParams;
 use ibc_proto::Protobuf;
 use ibc_relayer_types::applications::ics31_icq::response::CrossChainQueryResponse;
@@ -43,13 +43,13 @@ use ibc_relayer_types::core::ics24_host::identifier::{
     ChainId, ChannelId, ClientId, ConnectionId, PortId,
 };
 use ibc_relayer_types::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ChannelUpgradePath, ClientConsensusStatePath, ClientStatePath,
-    CommitmentsPath, ConnectionsPath, ReceiptsPath, SeqRecvsPath,
+    AcksPath, ChannelEndsPath, ChannelUpgradePath, ChannelUpgradeErrorPath, ClientConsensusStatePath,
+    ClientStatePath, CommitmentsPath, ConnectionsPath, ReceiptsPath, SeqRecvsPath,
 };
 use ibc_relayer_types::core::ics24_host::{
     ClientUpgradePath, Path, IBC_QUERY_PATH, SDK_UPGRADE_QUERY_PATH,
 };
-use ibc_relayer_types::core::{ics02_client::height::Height, ics04_channel::upgrade::Upgrade};
+use ibc_relayer_types::core::{ics02_client::height::Height, ics04_channel::upgrade::Upgrade, ics04_channel::upgrade::ErrorReceipt};
 use ibc_relayer_types::signer::Signer;
 use ibc_relayer_types::Height as ICSHeight;
 
@@ -2312,6 +2312,29 @@ impl ChainEndpoint for CosmosSdkChain {
         let upgrade = Upgrade::decode_vec(&res.value).map_err(Error::decode)?;
 
         Ok((upgrade, Some(proof)))
+    }
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error> {
+        let port_id = PortId::from_str(&request.port_id)
+            .map_err(|_| Error::invalid_port_string(request.port_id))?;
+        let channel_id = ChannelId::from_str(&request.channel_id)
+            .map_err(|_| Error::invalid_channel_string(request.channel_id))?;
+        let res = self.query(
+            ChannelUpgradeErrorPath {
+                port_id,
+                channel_id,
+            },
+            QueryHeight::Specific(height),
+            true,
+        )?;
+        let proof = res.proof.ok_or_else(Error::empty_response_proof)?;
+        let error_receipt = ErrorReceipt::decode_vec(&res.value).map_err(Error::decode)?;
+
+        Ok((error_receipt, Some(proof)))
     }
 }
 

--- a/crates/relayer/src/chain/endpoint.rs
+++ b/crates/relayer/src/chain/endpoint.rs
@@ -1,8 +1,8 @@
 use alloc::sync::Arc;
 use core::convert::TryFrom;
-use ibc_proto::ibc::core::channel::v1::QueryUpgradeRequest;
+use ibc_proto::ibc::core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest};
 use ibc_relayer_types::core::ics02_client::height::Height;
-use ibc_relayer_types::core::ics04_channel::upgrade::Upgrade;
+use ibc_relayer_types::core::ics04_channel::upgrade::{Upgrade, ErrorReceipt};
 
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -696,4 +696,10 @@ pub trait ChainEndpoint: Sized {
         request: QueryUpgradeRequest,
         height: Height,
     ) -> Result<(Upgrade, Option<MerkleProof>), Error>;
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error>;
 }

--- a/crates/relayer/src/chain/handle.rs
+++ b/crates/relayer/src/chain/handle.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 use core::fmt::{self, Debug, Display};
-use ibc_relayer_types::core::ics04_channel::upgrade::Upgrade;
+use ibc_relayer_types::core::ics04_channel::upgrade::{Upgrade, ErrorReceipt};
 
 use crossbeam_channel as channel;
 use tracing::Span;
@@ -8,7 +8,7 @@ use tracing::Span;
 use ibc_proto::ibc::apps::fee::v1::{
     QueryIncentivizedPacketRequest, QueryIncentivizedPacketResponse,
 };
-use ibc_proto::ibc::core::channel::v1::QueryUpgradeRequest;
+use ibc_proto::ibc::core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest};
 use ibc_relayer_types::{
     applications::ics31_icq::response::CrossChainQueryResponse,
     core::{
@@ -379,6 +379,12 @@ pub enum ChainRequest {
         height: Height,
         reply_to: ReplyTo<(Upgrade, Option<MerkleProof>)>,
     },
+
+    QueryUpgradeError {
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+        reply_to: ReplyTo<(ErrorReceipt, Option<MerkleProof>)>,
+    },
 }
 
 pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
@@ -698,4 +704,10 @@ pub trait ChainHandle: Clone + Display + Send + Sync + Debug + 'static {
         request: QueryUpgradeRequest,
         height: Height,
     ) -> Result<(Upgrade, Option<MerkleProof>), Error>;
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error>;
 }

--- a/crates/relayer/src/chain/handle/base.rs
+++ b/crates/relayer/src/chain/handle/base.rs
@@ -5,7 +5,7 @@ use tracing::Span;
 
 use ibc_proto::ibc::{
     apps::fee::v1::{QueryIncentivizedPacketRequest, QueryIncentivizedPacketResponse},
-    core::channel::v1::QueryUpgradeRequest,
+    core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest},
 };
 use ibc_relayer_types::{
     applications::ics31_icq::response::CrossChainQueryResponse,
@@ -16,7 +16,7 @@ use ibc_relayer_types::{
         ics04_channel::channel::{ChannelEnd, IdentifiedChannelEnd},
         ics04_channel::{
             packet::{PacketMsgType, Sequence},
-            upgrade::Upgrade,
+            upgrade::{Upgrade, ErrorReceipt},
         },
         ics23_commitment::{commitment::CommitmentPrefix, merkle::MerkleProof},
         ics24_host::identifier::ChainId,
@@ -532,6 +532,18 @@ impl ChainHandle for BaseChainHandle {
         height: Height,
     ) -> Result<(Upgrade, Option<MerkleProof>), Error> {
         self.send(|reply_to| ChainRequest::QueryUpgrade {
+            request,
+            height,
+            reply_to,
+        })
+    }
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error> {
+        self.send(|reply_to| ChainRequest::QueryUpgradeError {
             request,
             height,
             reply_to,

--- a/crates/relayer/src/chain/handle/cache.rs
+++ b/crates/relayer/src/chain/handle/cache.rs
@@ -1,11 +1,12 @@
 use core::fmt::{Display, Error as FmtError, Formatter};
 use crossbeam_channel as channel;
 use ibc_relayer_types::core::ics02_client::header::AnyHeader;
+use ibc_relayer_types::core::ics04_channel::upgrade::ErrorReceipt;
 use tracing::Span;
 
 use ibc_proto::ibc::apps::fee::v1::QueryIncentivizedPacketRequest;
 use ibc_proto::ibc::apps::fee::v1::QueryIncentivizedPacketResponse;
-use ibc_proto::ibc::core::channel::v1::QueryUpgradeRequest;
+use ibc_proto::ibc::core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest};
 use ibc_relayer_types::applications::ics31_icq::response::CrossChainQueryResponse;
 use ibc_relayer_types::core::ics02_client::events::UpdateClient;
 use ibc_relayer_types::core::ics03_connection::connection::ConnectionEnd;
@@ -524,5 +525,13 @@ impl<Handle: ChainHandle> ChainHandle for CachingChainHandle<Handle> {
         height: Height,
     ) -> Result<(Upgrade, Option<MerkleProof>), Error> {
         self.inner.query_upgrade(request, height)
+    }
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error> {
+        self.inner.query_upgrade_error(request, height)
     }
 }

--- a/crates/relayer/src/chain/handle/counting.rs
+++ b/crates/relayer/src/chain/handle/counting.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use crossbeam_channel as channel;
-use ibc_proto::ibc::core::channel::v1::QueryUpgradeRequest;
-use ibc_relayer_types::core::ics04_channel::upgrade::Upgrade;
+use ibc_proto::ibc::core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest};
+use ibc_relayer_types::core::ics04_channel::upgrade::{Upgrade, ErrorReceipt};
 use tracing::{debug, Span};
 
 use ibc_proto::ibc::apps::fee::v1::{
@@ -519,5 +519,14 @@ impl<Handle: ChainHandle> ChainHandle for CountingChainHandle<Handle> {
     ) -> Result<(Upgrade, Option<MerkleProof>), Error> {
         self.inc_metric("query_upgrade");
         self.inner.query_upgrade(request, height)
+    }
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error> {
+        self.inc_metric("query_upgrade_error");
+        self.inner.query_upgrade_error(request, height)
     }
 }

--- a/crates/relayer/src/chain/runtime.rs
+++ b/crates/relayer/src/chain/runtime.rs
@@ -7,7 +7,7 @@ use tracing::{error, Span};
 
 use ibc_proto::ibc::{
     apps::fee::v1::{QueryIncentivizedPacketRequest, QueryIncentivizedPacketResponse},
-    core::channel::v1::QueryUpgradeRequest,
+    core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest},
 };
 use ibc_relayer_types::{
     applications::ics31_icq::response::CrossChainQueryResponse,
@@ -21,7 +21,7 @@ use ibc_relayer_types::{
         ics04_channel::{
             channel::{ChannelEnd, IdentifiedChannelEnd},
             packet::{PacketMsgType, Sequence},
-            upgrade::Upgrade,
+            upgrade::{Upgrade, ErrorReceipt},
         },
         ics23_commitment::{commitment::CommitmentPrefix, merkle::MerkleProof},
         ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId},
@@ -359,6 +359,10 @@ where
 
                         ChainRequest::QueryUpgrade { request, height, reply_to } => {
                             self.query_upgrade(request, height, reply_to)?
+                        },
+
+                        ChainRequest::QueryUpgradeError { request, height, reply_to } => {
+                            self.query_upgrade_error(request, height, reply_to)?
                         },
                     }
                 },
@@ -879,6 +883,18 @@ where
         reply_to: ReplyTo<(Upgrade, Option<MerkleProof>)>,
     ) -> Result<(), Error> {
         let result = self.chain.query_upgrade(request, height);
+        reply_to.send(result).map_err(Error::send)?;
+
+        Ok(())
+    }
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+        reply_to: ReplyTo<(ErrorReceipt, Option<MerkleProof>)>,
+    ) -> Result<(), Error> {
+        let result = self.chain.query_upgrade_error(request, height);
         reply_to.send(result).map_err(Error::send)?;
 
         Ok(())

--- a/crates/relayer/src/channel/error.rs
+++ b/crates/relayer/src/channel/error.rs
@@ -70,6 +70,9 @@ define_error! {
         MissingUpgradeProof
             |_| { "missing upgrade proof" },
 
+        MissingUpgradeErrorReceiptProof
+            |_| { "missing upgrade error receipt proof" },
+
         MalformedProof
             [ ProofError ]
             |_| { "malformed proof" },

--- a/guide/src/templates/commands/hermes/tx/chan-upgrade-cancel_1.md
+++ b/guide/src/templates/commands/hermes/tx/chan-upgrade-cancel_1.md
@@ -1,0 +1,1 @@
+[[#BINARY hermes]][[#GLOBALOPTIONS]] tx chan-upgrade-cancel --dst-chain [[#DST_CHAIN_ID]] --src-chain [[#SRC_CHAIN_ID]] --dst-connection [[#DST_CONNECTION_ID]] --dst-port [[#DST_PORT_ID]] --src-port [[#SRC_PORT_ID]] --src-channel [[#SRC_CHANNEL_ID]] --dst-channel [[#DST_CHANNEL_ID]]

--- a/guide/src/templates/help_templates/tx.md
+++ b/guide/src/templates/help_templates/tx.md
@@ -18,6 +18,7 @@ SUBCOMMANDS:
     chan-upgrade-confirm    Relay the channel upgrade attempt (ChannelUpgradeConfirm)
     chan-upgrade-open       Relay the channel upgrade attempt (ChannelUpgradeOpen)
     chan-upgrade-try        Relay the channel upgrade attempt (ChannelUpgradeTry)
+    chan-upgrade-cancel     Relay the channel upgrade cancellation (ChannelUpgradeCancel)
     conn-ack                Relay acknowledgment of a connection attempt (ConnectionOpenAck)
     conn-confirm            Confirm opening of a connection (ConnectionOpenConfirm)
     conn-init               Initialize a connection (ConnectionOpenInit)

--- a/guide/src/templates/help_templates/tx/chan-upgrade-cancel.md
+++ b/guide/src/templates/help_templates/tx/chan-upgrade-cancel.md
@@ -1,0 +1,30 @@
+DESCRIPTION:
+Relay the channel upgrade cancellation (ChannelUpgradeCancel)
+
+USAGE:
+    hermes tx chan-upgrade-cancel --dst-chain <DST_CHAIN_ID> --src-chain <SRC_CHAIN_ID> --dst-connection <DST_CONNECTION_ID> --dst-port <DST_PORT_ID> --src-port <SRC_PORT_ID> --src-channel <SRC_CHANNEL_ID> --dst-channel <DST_CHANNEL_ID>
+
+OPTIONS:
+    -h, --help    Print help information
+
+REQUIRED:
+        --dst-chain <DST_CHAIN_ID>
+            Identifier of the destination chain
+
+        --dst-channel <DST_CHANNEL_ID>
+            Identifier of the destination channel (optional) [aliases: dst-chan]
+
+        --dst-connection <DST_CONNECTION_ID>
+            Identifier of the destination connection [aliases: dst-conn]
+
+        --dst-port <DST_PORT_ID>
+            Identifier of the destination port
+
+        --src-chain <SRC_CHAIN_ID>
+            Identifier of the source chain
+
+        --src-channel <SRC_CHANNEL_ID>
+            Identifier of the source channel (required) [aliases: src-chan]
+
+        --src-port <SRC_PORT_ID>
+            Identifier of the source port

--- a/tools/integration-test/src/tests/channel_upgrade/upgrade_handshake_steps.rs
+++ b/tools/integration-test/src/tests/channel_upgrade/upgrade_handshake_steps.rs
@@ -11,6 +11,9 @@
 //!
 //! - `ChannelUpgradeHandshakeFromConfirm` tests that the channel worker will finish the
 //!   upgrade handshake if the channel is being upgraded and is at the Confirm step.
+//! 
+//! - `ChannelUpgradeHandshakeTimeoutOnAck` tests that the channel worker will finish the
+//!   cancel the upgrade handshake if the Ack step fails due to an upgrade timeout.
 
 use ibc_relayer::chain::requests::{IncludeProof, QueryChannelRequest, QueryHeight};
 use ibc_relayer_types::core::ics04_channel::version::Version;
@@ -20,7 +23,7 @@ use ibc_test_framework::relayer::channel::{
     assert_eventually_channel_established, assert_eventually_channel_upgrade_ack,
     assert_eventually_channel_upgrade_confirm, assert_eventually_channel_upgrade_init,
     assert_eventually_channel_upgrade_open, assert_eventually_channel_upgrade_try,
-    ChannelUpgradableAttributes,
+    assert_eventually_channel_upgrade_cancel, ChannelUpgradableAttributes,
 };
 
 #[test]
@@ -41,6 +44,11 @@ fn test_channel_upgrade_handshake_from_ack() -> Result<(), Error> {
 #[test]
 fn test_channel_upgrade_handshake_from_confirm() -> Result<(), Error> {
     run_binary_channel_test(&ChannelUpgradeHandshakeFromConfirm)
+}
+
+#[test]
+fn test_channel_upgrade_handshake_timeout_on_ack() -> Result<(), Error> {
+    run_binary_channel_test(&ChannelUpgradeHandshakeTimeoutOnAck)
 }
 
 const MAX_DEPOSIT_PERIOD: &str = "10s";
@@ -613,6 +621,145 @@ impl BinaryChannelTest for ChannelUpgradeHandshakeFromConfirm {
     }
 }
 
+struct ChannelUpgradeHandshakeTimeoutOnAck;
+
+impl BinaryChannelTest for ChannelUpgradeHandshakeTimeoutOnAck {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        _relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channels: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        info!("Check that channels are both in OPEN State");
+
+        assert_eventually_channel_established(
+            &chains.handle_b,
+            &chains.handle_a,
+            &channels.channel_id_b.as_ref(),
+            &channels.port_b.as_ref(),
+        )?;
+
+        let channel_end_a = chains
+            .handle_a
+            .query_channel(
+                QueryChannelRequest {
+                    port_id: channels.port_a.0.clone(),
+                    channel_id: channels.channel_id_a.0.clone(),
+                    height: QueryHeight::Latest,
+                },
+                IncludeProof::No,
+            )
+            .map(|(channel_end, _)| channel_end)
+            .map_err(|e| eyre!("Error querying ChannelEnd A: {e}"))?;
+
+        let channel_end_b = chains
+            .handle_b
+            .query_channel(
+                QueryChannelRequest {
+                    port_id: channels.port_b.0.clone(),
+                    channel_id: channels.channel_id_b.0.clone(),
+                    height: QueryHeight::Latest,
+                },
+                IncludeProof::No,
+            )
+            .map(|(channel_end, _)| channel_end)
+            .map_err(|e| eyre!("Error querying ChannelEnd B: {e}"))?;
+
+        let old_version = channel_end_a.version;
+        let old_ordering = channel_end_a.ordering;
+        let old_connection_hops_a = channel_end_a.connection_hops;
+        let old_connection_hops_b = channel_end_b.connection_hops;
+
+        let channel = channels.channel;
+        let new_version = Version::ics20_with_fee();
+
+        let old_attrs = ChannelUpgradableAttributes::new(
+            old_version.clone(),
+            old_version.clone(),
+            old_ordering,
+            old_connection_hops_a.clone(),
+            old_connection_hops_b.clone(),
+        );
+
+        info!("Will update channel params to set a short upgrade timeout...");
+
+        chains.node_a.chain_driver().update_channel_params(
+            5000000000,
+            chains.handle_a().get_signer().unwrap().as_ref(),
+        )?;
+
+        info!("Will initialise upgrade handshake with governance proposal...");
+
+        chains.node_a.chain_driver().initialise_channel_upgrade(
+            channel.src_port_id().as_str(),
+            channel.src_channel_id().unwrap().as_str(),
+            old_ordering.as_str(),
+            old_connection_hops_a.first().unwrap().as_str(),
+            &serde_json::to_string(&new_version.0).unwrap(),
+            chains.handle_a().get_signer().unwrap().as_ref(),
+        )?;
+
+        info!("Check that the step ChanUpgradeInit was correctly executed...");
+
+        assert_eventually_channel_upgrade_init(
+            &chains.handle_a,
+            &chains.handle_b,
+            &channels.channel_id_a.as_ref(),
+            &channels.port_a.as_ref(),
+            &old_attrs,
+        )?;
+
+        info!("Will run ChanUpgradeTry step...");
+
+        channel.build_chan_upgrade_try_and_send()?;
+
+        info!("Check that the step ChanUpgradeTry was correctly executed...");
+
+        assert_eventually_channel_upgrade_try(
+            &chains.handle_b,
+            &chains.handle_a,
+            &channels.channel_id_b.as_ref(),
+            &channels.port_b.as_ref(),
+            &old_attrs.flipped(),
+        )?;
+
+        // wait enough time so that ACK fails due to upgrade timeout
+        sleep(Duration::from_secs(10));
+
+        info!("Will run ChanUpgradeAck step...");
+
+        channel.flipped().build_chan_upgrade_ack_and_send()?;
+
+        info!("Check that the step ChanUpgradeAck was correctly executed...");
+
+        // ACK should fail because the upgrade has timed out
+        assert_eventually_channel_upgrade_ack(
+            &chains.handle_a,
+            &chains.handle_b,
+            &channels.channel_id_a.as_ref(),
+            &channels.port_a.as_ref(),
+            &old_attrs,
+        )?;
+
+        info!("Will run ChanUpgradeCancel step...");
+
+        channel.build_chan_upgrade_cancel_and_send()?;
+
+        info!("Check that the step ChanUpgradeCancel was correctly executed...");
+
+        assert_eventually_channel_upgrade_cancel(
+            &chains.handle_b,
+            &chains.handle_a,
+            &channels.channel_id_b.as_ref(),
+            &channels.port_b.as_ref(),
+            &old_attrs.flipped(),
+        )?;
+
+        Ok(())
+    }
+}
+
 impl HasOverrides for ChannelUpgradeManualHandshake {
     type Overrides = ChannelUpgradeTestOverrides;
 
@@ -638,6 +785,14 @@ impl HasOverrides for ChannelUpgradeHandshakeFromAck {
 }
 
 impl HasOverrides for ChannelUpgradeHandshakeFromConfirm {
+    type Overrides = ChannelUpgradeTestOverrides;
+
+    fn get_overrides(&self) -> &ChannelUpgradeTestOverrides {
+        &ChannelUpgradeTestOverrides
+    }
+}
+
+impl HasOverrides for ChannelUpgradeHandshakeTimeoutOnAck {
     type Overrides = ChannelUpgradeTestOverrides;
 
     fn get_overrides(&self) -> &ChannelUpgradeTestOverrides {

--- a/tools/test-framework/src/relayer/chain.rs
+++ b/tools/test-framework/src/relayer/chain.rs
@@ -21,9 +21,9 @@
 */
 
 use crossbeam_channel as channel;
-use ibc_proto::ibc::core::channel::v1::QueryUpgradeRequest;
+use ibc_proto::ibc::core::channel::v1::{QueryUpgradeRequest, QueryUpgradeErrorRequest};
 use ibc_relayer::chain::cosmos::version::Specs;
-use ibc_relayer_types::core::ics04_channel::upgrade::Upgrade;
+use ibc_relayer_types::core::ics04_channel::upgrade::{Upgrade, ErrorReceipt};
 use tracing::Span;
 
 use ibc_proto::ibc::apps::fee::v1::{
@@ -444,5 +444,13 @@ where
         height: Height,
     ) -> Result<(Upgrade, Option<MerkleProof>), Error> {
         self.value().query_upgrade(request, height)
+    }
+
+    fn query_upgrade_error(
+        &self,
+        request: QueryUpgradeErrorRequest,
+        height: Height,
+    ) -> Result<(ErrorReceipt, Option<MerkleProof>), Error> {
+        self.value().query_upgrade_error(request, height)
     }
 }

--- a/tools/test-framework/src/relayer/channel.rs
+++ b/tools/test-framework/src/relayer/channel.rs
@@ -503,16 +503,16 @@ fn assert_channel_upgrade_state<ChainA: ChainHandle, ChainB: ChainHandle>(
         )));
     }
 
-    // if !channel_end_a
-    //     .value()
-    //     .upgraded_sequence.eq(&Sequence::from(5))
-    // {
-    //     return Err(Error::generic(eyre!(
-    //         "expected channel end A upgrade sequence to be `{}`, but it is instead `{}`",
-    //         upgrade_attrs.ordering(),
-    //         channel_end_a.value().upgraded_sequence
-    //     )));
-    // }
+    if !channel_end_a
+        .value()
+        .upgraded_sequence.eq(&Sequence::from(5))
+    {
+        return Err(Error::generic(eyre!(
+            "expected channel end A upgrade sequence to be `{}`, but it is instead `{}`",
+            upgrade_attrs.ordering(),
+            channel_end_a.value().upgraded_sequence
+        )));
+    }
 
     if !channel_end_a
         .value()


### PR DESCRIPTION
…out on upgrade ack

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This PR:
- Implements the logic for submitting `MsgChannelUpgradeCancel`.
- Adds an integration test for the scenario where the upgrade is aborted on ACK due to a timeout (not passing yet, I will sync with @ljoss17 to ask some questions).

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
