### PR TITLE
Remove duplicate changelog entries

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer-cli/3697-fix-evidence-report.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer-cli/3697-fix-evidence-report.md
@@ -1,4 +1,0 @@
-- Fix a bug in the `evidence` command which would sometimes
-  prevent the detected misbehaviour evidence from being submitted,
-  instead erroring out with a validator set hash mismatch.
-  ([\#3697](https://github.com/informalsystems/hermes/pull/3697))

--- a/.changelog/unreleased/bug-fixes/ibc-relayer/3703-avoid-returning-stopped-worker.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/3703-avoid-returning-stopped-worker.md
@@ -1,3 +1,0 @@
-- Avoid retrieving a worker which is being removed by the idle worker clean-up
-  process.
-  process ([\#3703](https://github.com/informalsystems/hermes/issues/3703))

--- a/.changelog/unreleased/bug-fixes/ibc-telemetry/3720-fix-broadcasting-errors-metric.md
+++ b/.changelog/unreleased/bug-fixes/ibc-telemetry/3720-fix-broadcasting-errors-metric.md
@@ -1,3 +1,0 @@
-- Fix the issue where `broadcast_errors` metric would not correctly batch
-  the same errors together.
-  together ([\#3720](https://github.com/informalsystems/hermes/issues/3720))

--- a/.changelog/unreleased/bug-fixes/ibc-telemetry/3723-fix-backlog-metrics.md
+++ b/.changelog/unreleased/bug-fixes/ibc-telemetry/3723-fix-backlog-metrics.md
@@ -1,4 +1,0 @@
-- Update the values of `backlog` metrics when clearing packets.
-  Change the `backlog_oldest_timestamp` to `backlog_latest_update_timestamp`
-  which shows the last time the `backlog` metrics have been updated.
-  ([\#3723](https://github.com/informalsystems/hermes/issues/3723))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

Following backport of `v1.7.4` in `master` some changelog entries are duplicate in the `unreleased` section.
This PR removes the duplicate entries.

Correct entries:
* https://github.com/informalsystems/hermes/blob/7a3e4d0d322da1313663c8b0de2d63a83eb11622/.changelog/v1.7.4/bug-fixes/ibc-relayer-cli/3697-fix-evidence-report.md
* https://github.com/informalsystems/hermes/blob/7a3e4d0d322da1313663c8b0de2d63a83eb11622/.changelog/v1.7.4/bug-fixes/ibc-relayer/3703-avoid-returning-stopped-worker.md
* https://github.com/informalsystems/hermes/blob/7a3e4d0d322da1313663c8b0de2d63a83eb11622/.changelog/v1.7.4/bug-fixes/ibc-telemetry/3720-fix-broadcasting-errors-metric.md
* https://github.com/informalsystems/hermes/blob/7a3e4d0d322da1313663c8b0de2d63a83eb11622/.changelog/v1.7.4/bug-fixes/ibc-telemetry/3723-fix-backlog-metrics.md

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
