### PR TITLE
Add config option for number of events queried at once when clearing pending packets

### DIFF
--- a/.changelog/unreleased/features/ibc-relayer-cli/3743-query_packets_chunk_size.md
+++ b/.changelog/unreleased/features/ibc-relayer-cli/3743-query_packets_chunk_size.md
@@ -1,0 +1,6 @@
+- Add a `query_packets_chunk_size` config option and a `--query-
+  packets-chunk-size flag to the `clear packets` CLI to configure how
+  many packets to query at once from the chain when clearing pending
+  packets. Lower this setting if one or more of packets you are
+  trying to clear are huge and make the packet query time out or fail.
+  ([\#3743](https://github.com/informalsystems/hermes/issues/3743))

--- a/config.toml
+++ b/config.toml
@@ -296,6 +296,10 @@ max_msg_num = 30
 # Default: 2097152 (2 MiB)
 max_tx_size = 2097152
 
+# How many packets to fetch at once from the chain when clearing packets.
+# Default: 50
+query_packets_chunk_size = 50
+
 # Specify the maximum amount of time to tolerate a clock drift.
 # The clock drift parameter defines how much new (untrusted) header's time
 # can drift into the future. Default: 5s

--- a/crates/relayer-cli/src/chain_registry.rs
+++ b/crates/relayer-cli/src/chain_registry.rs
@@ -145,6 +145,7 @@ where
         max_msg_num: MaxMsgNum::default(),
         max_tx_size: MaxTxSize::default(),
         max_grpc_decoding_size: default::max_grpc_decoding_size(),
+        query_packets_chunk_size: default::query_packets_chunk_size(),
         clock_drift: default::clock_drift(),
         max_block_time: default::max_block_time(),
         trusting_period: None,

--- a/crates/relayer-cli/src/commands/clear.rs
+++ b/crates/relayer-cli/src/commands/clear.rs
@@ -63,6 +63,12 @@ pub struct ClearPacketsCmd {
         help = "use the given signing key for the counterparty chain (default: `counterparty_key_name` config)"
     )]
     counterparty_key_name: Option<String>,
+
+    #[clap(
+        long = "query-packets-chunk-size",
+        help = "number of packets to fetch at once from the chain (default: `query_packets_chunk_size` config)"
+    )]
+    query_packets_chunk_size: Option<usize>,
 }
 
 impl Override<Config> for ClearPacketsCmd {
@@ -107,6 +113,17 @@ impl Runnable for ClearPacketsCmd {
             match chains.dst.config() {
                 Ok(mut dst_chain_cfg) => {
                     dst_chain_cfg.set_key_name(counterparty_key_name.to_string());
+                }
+                Err(e) => Output::error(e).exit(),
+            }
+        }
+
+        // If `query_packets_chunk_size` is provided, overwrite the chain's
+        // `query_packets_chunk_size` parameter
+        if let Some(chunk_size) = self.query_packets_chunk_size {
+            match chains.src.config() {
+                Ok(mut src_chain_cfg) => {
+                    src_chain_cfg.set_query_packets_chunk_size(chunk_size);
                 }
                 Err(e) => Output::error(e).exit(),
             }
@@ -180,6 +197,7 @@ mod tests {
                 channel_id: ChannelId::from_str("channel-07").unwrap(),
                 key_name: None,
                 counterparty_key_name: None,
+                query_packets_chunk_size: None
             },
             ClearPacketsCmd::parse_from([
                 "test",
@@ -201,7 +219,8 @@ mod tests {
                 port_id: PortId::from_str("port_id").unwrap(),
                 channel_id: ChannelId::from_str("channel-07").unwrap(),
                 key_name: None,
-                counterparty_key_name: None
+                counterparty_key_name: None,
+                query_packets_chunk_size: None
             },
             ClearPacketsCmd::parse_from([
                 "test",
@@ -224,6 +243,7 @@ mod tests {
                 channel_id: ChannelId::from_str("channel-07").unwrap(),
                 key_name: Some("key_name".to_owned()),
                 counterparty_key_name: None,
+                query_packets_chunk_size: None
             },
             ClearPacketsCmd::parse_from([
                 "test",
@@ -248,6 +268,7 @@ mod tests {
                 channel_id: ChannelId::from_str("channel-07").unwrap(),
                 key_name: None,
                 counterparty_key_name: Some("counterparty_key_name".to_owned()),
+                query_packets_chunk_size: None
             },
             ClearPacketsCmd::parse_from([
                 "test",
@@ -259,6 +280,33 @@ mod tests {
                 "channel-07",
                 "--counterparty-key-name",
                 "counterparty_key_name"
+            ])
+        )
+    }
+
+    #[test]
+    fn test_clear_packets_query_packets_chunk_size() {
+        assert_eq!(
+            ClearPacketsCmd {
+                chain_id: ChainId::from_string("chain_id"),
+                port_id: PortId::from_str("port_id").unwrap(),
+                channel_id: ChannelId::from_str("channel-07").unwrap(),
+                key_name: None,
+                counterparty_key_name: Some("counterparty_key_name".to_owned()),
+                query_packets_chunk_size: Some(100),
+            },
+            ClearPacketsCmd::parse_from([
+                "test",
+                "--chain",
+                "chain_id",
+                "--port",
+                "port_id",
+                "--channel",
+                "channel-07",
+                "--counterparty-key-name",
+                "counterparty_key_name",
+                "--query-packets-chunk-size",
+                "100"
             ])
         )
     }

--- a/crates/relayer/src/chain/cosmos/config.rs
+++ b/crates/relayer/src/chain/cosmos/config.rs
@@ -61,12 +61,19 @@ pub struct CosmosSdkConfig {
     pub gas_multiplier: Option<GasMultiplier>,
 
     pub fee_granter: Option<String>,
+
     #[serde(default)]
     pub max_msg_num: MaxMsgNum,
+
     #[serde(default)]
     pub max_tx_size: MaxTxSize,
+
     #[serde(default = "default::max_grpc_decoding_size")]
     pub max_grpc_decoding_size: Byte,
+
+    /// How many packets to fetch at once from the chain when clearing packets
+    #[serde(default = "default::query_packets_chunk_size")]
+    pub query_packets_chunk_size: usize,
 
     /// A correction parameter that helps deal with clocks that are only approximately synchronized
     /// between the source and destination chains for a client.

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -660,6 +660,12 @@ impl ChainConfig {
             Self::CosmosSdk(config) => config.query_packets_chunk_size,
         }
     }
+
+    pub fn set_query_packets_chunk_size(&mut self, query_packets_chunk_size: usize) {
+        match self {
+            Self::CosmosSdk(config) => config.query_packets_chunk_size = query_packets_chunk_size,
+        }
+    }
 }
 
 /// Attempt to load and parse the TOML config file as a `Config`.

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -160,6 +160,10 @@ pub mod default {
         100
     }
 
+    pub fn query_packets_chunk_size() -> usize {
+        50
+    }
+
     pub fn rpc_timeout() -> Duration {
         Duration::from_secs(10)
     }
@@ -648,6 +652,12 @@ impl ChainConfig {
     pub fn clear_interval(&self) -> Option<u64> {
         match self {
             Self::CosmosSdk(config) => config.clear_interval,
+        }
+    }
+
+    pub fn query_packets_chunk_size(&self) -> usize {
+        match self {
+            Self::CosmosSdk(config) => config.query_packets_chunk_size,
         }
     }
 }

--- a/crates/relayer/src/link/cli.rs
+++ b/crates/relayer/src/link/cli.rs
@@ -111,9 +111,16 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
             None => Qualified::SmallerEqual(src_response_height),
         };
 
+        let chunk_size = self
+            .a_to_b
+            .src_chain()
+            .config()
+            .map_or(50, |cfg| cfg.query_packets_chunk_size());
+
         self.relay_packet_messages(
             sequences,
             query_height,
+            chunk_size,
             query_send_packet_events,
             TrackingId::new_static("packet-recv"),
         )
@@ -163,9 +170,16 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
             None => Qualified::SmallerEqual(src_response_height),
         };
 
+        let chunk_size = self
+            .a_to_b
+            .src_chain()
+            .config()
+            .map_or(50, |cfg| cfg.query_packets_chunk_size());
+
         self.relay_packet_messages(
             sequences,
             query_height,
+            chunk_size,
             query_write_ack_events,
             TrackingId::new_static("packet-ack"),
         )
@@ -175,6 +189,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
         &self,
         sequences: Vec<Sequence>,
         query_height: Qualified<Height>,
+        chunk_size: usize,
         query_fn: QueryFn,
         tracking_id: TrackingId,
     ) -> Result<Vec<IbcEvent>, LinkError>
@@ -191,6 +206,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
             query_height,
             self.a_to_b.src_chain(),
             &self.a_to_b.path_id,
+            chunk_size,
             query_fn,
         );
 

--- a/crates/relayer/src/link/packet_events.rs
+++ b/crates/relayer/src/link/packet_events.rs
@@ -14,15 +14,13 @@ use crate::event::IbcEventWithHeight;
 use crate::path::PathIdentifiers;
 use crate::util::collate::CollatedIterExt;
 
-/// Limit on how many query results should be expected.
-pub const CHUNK_LENGTH: usize = 50;
-
 /// Returns an iterator on batches of packet events.
 pub fn query_packet_events_with<'a, ChainA, QueryFn>(
     sequences: &'a [Sequence],
     query_height: Qualified<Height>,
     src_chain: &'a ChainA,
     path: &'a PathIdentifiers,
+    chunk_size: usize,
     query_fn: QueryFn,
 ) -> impl Iterator<Item = Vec<IbcEventWithHeight>> + 'a
 where
@@ -38,7 +36,7 @@ where
     let events_total = sequences.len();
     let mut events_left = events_total;
 
-    sequences.chunks(CHUNK_LENGTH).map_while(move |chunk| {
+    sequences.chunks(chunk_size).map_while(move |chunk| {
         match query_fn(src_chain, path, chunk, query_height) {
             Ok(events) => {
                 events_left -= chunk.len();

--- a/guide/src/templates/help_templates/clear/packets.md
+++ b/guide/src/templates/help_templates/clear/packets.md
@@ -16,6 +16,10 @@ OPTIONS:
         --key-name <KEY_NAME>
             use the given signing key for the specified chain (default: `key_name` config)
 
+        --query-packets-chunk-size <QUERY_PACKETS_CHUNK_SIZE>
+            number of packets to fetch at once from the chain (default: `query_packets_chunk_size`
+            config)
+
 REQUIRED:
         --chain <CHAIN_ID>        Identifier of the chain
         --channel <CHANNEL_ID>    Identifier of the channel

--- a/tools/test-framework/src/types/single/node.rs
+++ b/tools/test-framework/src/types/single/node.rs
@@ -178,6 +178,7 @@ impl FullNode {
             max_msg_num: Default::default(),
             max_tx_size: Default::default(),
             max_grpc_decoding_size: config::default::max_grpc_decoding_size(),
+            query_packets_chunk_size: config::default::query_packets_chunk_size(),
             max_block_time: Duration::from_secs(30),
             clock_drift: Duration::from_secs(5),
             trusting_period: Some(Duration::from_secs(14 * 24 * 3600)),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3743 

## Description


- Add `query_packets_chunk_size` config option
- Add `--query-packets-chunk-size` flag to `clear packets` CLI

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
