### PR TITLE
Remove unused code for encoding a `Packet` into a `Vec<abci::EventAttribute>`

### DIFF
--- a/crates/relayer-types/src/core/ics04_channel/events.rs
+++ b/crates/relayer-types/src/core/ics04_channel/events.rs
@@ -85,46 +85,6 @@ impl From<Attributes> for Vec<abci::EventAttribute> {
     }
 }
 
-/// Convert attributes to Tendermint ABCI tags
-impl TryFrom<Packet> for Vec<abci::EventAttribute> {
-    type Error = Error;
-    fn try_from(p: Packet) -> Result<Self, Self::Error> {
-        let mut attributes = vec![];
-        let src_port = (PKT_SRC_PORT_ATTRIBUTE_KEY, p.source_port.to_string()).into();
-        attributes.push(src_port);
-        let src_channel = (PKT_SRC_CHANNEL_ATTRIBUTE_KEY, p.source_channel.to_string()).into();
-        attributes.push(src_channel);
-        let dst_port = (PKT_DST_PORT_ATTRIBUTE_KEY, p.destination_port.to_string()).into();
-        attributes.push(dst_port);
-        let dst_channel = (
-            PKT_DST_CHANNEL_ATTRIBUTE_KEY,
-            p.destination_channel.to_string(),
-        )
-            .into();
-        attributes.push(dst_channel);
-        let sequence = (PKT_SEQ_ATTRIBUTE_KEY, p.sequence.to_string()).into();
-        attributes.push(sequence);
-        let timeout_height = (
-            PKT_TIMEOUT_HEIGHT_ATTRIBUTE_KEY,
-            p.timeout_height.to_event_attribute_value(),
-        )
-            .into();
-        attributes.push(timeout_height);
-        let timeout_timestamp = (
-            PKT_TIMEOUT_TIMESTAMP_ATTRIBUTE_KEY,
-            p.timeout_timestamp.nanoseconds().to_string(),
-        )
-            .into();
-        attributes.push(timeout_timestamp);
-        let val = str::from_utf8(&p.data).expect("hex-encoded string should always be valid UTF-8");
-        let packet_data = (PKT_DATA_ATTRIBUTE_KEY, val).into();
-        attributes.push(packet_data);
-        let ack = (PKT_ACK_ATTRIBUTE_KEY, "").into();
-        attributes.push(ack);
-        Ok(attributes)
-    }
-}
-
 pub trait EventType {
     fn event_type() -> IbcEventType;
 }
@@ -546,17 +506,6 @@ impl From<SendPacket> for IbcEvent {
     }
 }
 
-impl TryFrom<SendPacket> for abci::Event {
-    type Error = Error;
-
-    fn try_from(v: SendPacket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            kind: IbcEventType::SendPacket.as_str().to_owned(),
-            attributes: v.packet.try_into()?,
-        })
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ReceivePacket {
     pub packet: Packet,
@@ -586,17 +535,6 @@ impl Display for ReceivePacket {
 impl From<ReceivePacket> for IbcEvent {
     fn from(v: ReceivePacket) -> Self {
         IbcEvent::ReceivePacket(v)
-    }
-}
-
-impl TryFrom<ReceivePacket> for abci::Event {
-    type Error = Error;
-
-    fn try_from(v: ReceivePacket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            kind: IbcEventType::ReceivePacket.as_str().to_owned(),
-            attributes: v.packet.try_into()?,
-        })
     }
 }
 
@@ -639,21 +577,6 @@ impl From<WriteAcknowledgement> for IbcEvent {
     }
 }
 
-impl TryFrom<WriteAcknowledgement> for abci::Event {
-    type Error = Error;
-
-    fn try_from(v: WriteAcknowledgement) -> Result<Self, Self::Error> {
-        let mut attributes: Vec<_> = v.packet.try_into()?;
-        let val = str::from_utf8(&v.ack).expect("hex-encoded string should always be valid UTF-8");
-        let ack = (PKT_ACK_ATTRIBUTE_KEY, val).into();
-        attributes.push(ack);
-        Ok(Self {
-            kind: IbcEventType::WriteAck.as_str().to_owned(),
-            attributes,
-        })
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct AcknowledgePacket {
     pub packet: Packet,
@@ -677,17 +600,6 @@ impl Display for AcknowledgePacket {
 impl From<AcknowledgePacket> for IbcEvent {
     fn from(v: AcknowledgePacket) -> Self {
         IbcEvent::AcknowledgePacket(v)
-    }
-}
-
-impl TryFrom<AcknowledgePacket> for abci::Event {
-    type Error = Error;
-
-    fn try_from(v: AcknowledgePacket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            kind: IbcEventType::AckPacket.as_str().to_owned(),
-            attributes: v.packet.try_into()?,
-        })
     }
 }
 
@@ -723,17 +635,6 @@ impl From<TimeoutPacket> for IbcEvent {
     }
 }
 
-impl TryFrom<TimeoutPacket> for abci::Event {
-    type Error = Error;
-
-    fn try_from(v: TimeoutPacket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            kind: IbcEventType::Timeout.as_str().to_owned(),
-            attributes: v.packet.try_into()?,
-        })
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct TimeoutOnClosePacket {
     pub packet: Packet,
@@ -763,16 +664,5 @@ impl Display for TimeoutOnClosePacket {
 impl From<TimeoutOnClosePacket> for IbcEvent {
     fn from(v: TimeoutOnClosePacket) -> Self {
         IbcEvent::TimeoutOnClosePacket(v)
-    }
-}
-
-impl TryFrom<TimeoutOnClosePacket> for abci::Event {
-    type Error = Error;
-
-    fn try_from(v: TimeoutOnClosePacket) -> Result<Self, Self::Error> {
-        Ok(Self {
-            kind: IbcEventType::TimeoutOnClose.as_str().to_owned(),
-            attributes: v.packet.try_into()?,
-        })
     }
 }

--- a/crates/relayer-types/src/events.rs
+++ b/crates/relayer-types/src/events.rs
@@ -1,11 +1,10 @@
-use crate::utils::pretty::PrettySlice;
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use std::fmt::{Display, Error as FmtError, Formatter};
+use std::str::FromStr;
 
 use flex_error::{define_error, TraceError};
 use serde_derive::{Deserialize, Serialize};
-use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
-use std::fmt::{Display, Error as FmtError, Formatter};
-use std::str::FromStr;
 use tendermint::abci;
 
 use crate::applications::ics29_fee::error::Error as FeeError;
@@ -24,6 +23,7 @@ use crate::core::ics04_channel::events::Attributes as ChannelAttributes;
 use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics24_host::error::ValidationError;
 use crate::timestamp::ParseTimestampError;
+use crate::utils::pretty::PrettySlice;
 
 define_error! {
     Error {
@@ -322,42 +322,6 @@ impl Display for IbcEvent {
 
             IbcEvent::ChainError(ev) => write!(f, "ChainError({ev})"),
         }
-    }
-}
-
-impl TryFrom<IbcEvent> for abci::Event {
-    type Error = Error;
-
-    fn try_from(event: IbcEvent) -> Result<Self, Self::Error> {
-        Ok(match event {
-            IbcEvent::CreateClient(event) => event.into(),
-            IbcEvent::UpdateClient(event) => event.into(),
-            IbcEvent::UpgradeClient(event) => event.into(),
-            IbcEvent::ClientMisbehaviour(event) => event.into(),
-            IbcEvent::OpenInitConnection(event) => event.into(),
-            IbcEvent::OpenTryConnection(event) => event.into(),
-            IbcEvent::OpenAckConnection(event) => event.into(),
-            IbcEvent::OpenConfirmConnection(event) => event.into(),
-            IbcEvent::OpenInitChannel(event) => event.into(),
-            IbcEvent::OpenTryChannel(event) => event.into(),
-            IbcEvent::OpenAckChannel(event) => event.into(),
-            IbcEvent::OpenConfirmChannel(event) => event.into(),
-            IbcEvent::CloseInitChannel(event) => event.into(),
-            IbcEvent::CloseConfirmChannel(event) => event.into(),
-            IbcEvent::SendPacket(event) => event.try_into().map_err(Error::channel)?,
-            IbcEvent::ReceivePacket(event) => event.try_into().map_err(Error::channel)?,
-            IbcEvent::WriteAcknowledgement(event) => event.try_into().map_err(Error::channel)?,
-            IbcEvent::AcknowledgePacket(event) => event.try_into().map_err(Error::channel)?,
-            IbcEvent::TimeoutPacket(event) => event.try_into().map_err(Error::channel)?,
-            IbcEvent::TimeoutOnClosePacket(event) => event.try_into().map_err(Error::channel)?,
-            IbcEvent::IncentivizedPacket(event) => event.into(),
-            IbcEvent::CrossChainQueryPacket(event) => event.into(),
-            IbcEvent::DistributeFeePacket(event) => event.into(),
-            IbcEvent::AppModule(event) => event.try_into()?,
-            IbcEvent::NewBlock(_) | IbcEvent::ChainError(_) => {
-                return Err(Error::incorrect_event_type(event.to_string()));
-            }
-        })
     }
 }
 

--- a/crates/relayer/src/event.rs
+++ b/crates/relayer/src/event.rs
@@ -465,8 +465,6 @@ mod tests {
     use ibc_proto::Protobuf;
     use ibc_relayer_types::clients::ics07_tendermint::header::test_util::get_dummy_ics07_header;
     use ibc_relayer_types::core::ics02_client::header::{decode_header, AnyHeader};
-    use ibc_relayer_types::core::ics04_channel::packet::Sequence;
-    use ibc_relayer_types::timestamp::Timestamp;
 
     #[test]
     fn extract_header() {
@@ -556,52 +554,6 @@ mod tests {
                     IbcEvent::CloseConfirmChannel(e) => {
                         assert_eq!(ChannelAttributes::from(e), close_confirm.clone().into())
                     }
-                    _ => panic!("unexpected event type"),
-                },
-                None => panic!("converted event was wrong"),
-            }
-        }
-    }
-
-    #[test]
-    fn packet_event_to_abci_event() {
-        let packet = Packet {
-            sequence: Sequence::from(10),
-            source_port: "a_test_port".parse().unwrap(),
-            source_channel: "channel-0".parse().unwrap(),
-            destination_port: "b_test_port".parse().unwrap(),
-            destination_channel: "channel-1".parse().unwrap(),
-            data: "test_data".as_bytes().to_vec(),
-            timeout_height: Height::new(1, 10).unwrap().into(),
-            timeout_timestamp: Timestamp::now(),
-        };
-        let mut abci_events = vec![];
-        let send_packet = channel_events::SendPacket {
-            packet: packet.clone(),
-        };
-        abci_events.push(AbciEvent::try_from(send_packet.clone()).unwrap());
-        let write_ack = channel_events::WriteAcknowledgement {
-            packet: packet.clone(),
-            ack: "test_ack".as_bytes().to_vec(),
-        };
-        abci_events.push(AbciEvent::try_from(write_ack.clone()).unwrap());
-        let ack_packet = channel_events::AcknowledgePacket {
-            packet: packet.clone(),
-        };
-        abci_events.push(AbciEvent::try_from(ack_packet.clone()).unwrap());
-        let timeout_packet = channel_events::TimeoutPacket { packet };
-        abci_events.push(AbciEvent::try_from(timeout_packet.clone()).unwrap());
-
-        for abci_event in abci_events {
-            match ibc_event_try_from_abci_event(&abci_event).ok() {
-                Some(ibc_event) => match ibc_event {
-                    IbcEvent::SendPacket(e) => assert_eq!(e.packet, send_packet.packet),
-                    IbcEvent::WriteAcknowledgement(e) => {
-                        assert_eq!(e.packet, write_ack.packet);
-                        assert_eq!(e.ack, write_ack.ack);
-                    }
-                    IbcEvent::AcknowledgePacket(e) => assert_eq!(e.packet, ack_packet.packet),
-                    IbcEvent::TimeoutPacket(e) => assert_eq!(e.packet, timeout_packet.packet),
                     _ => panic!("unexpected event type"),
                 },
                 None => panic!("converted event was wrong"),


### PR DESCRIPTION
Closes: #XXX

## Description

While working on #3768, I noticed that neither the `TryFrom<Packet>` impl for `Vec<abci::EventAttribute>` nor the impls that depend on are not used anywhere in the codebase, except for one test.

The code is also quite messy and does not serve any purpose for Hermes, so I propose to remove it.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).

