### PR TITLE
Use `CosmosSdk` as the chain type if omitted, for backward compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,7 @@ dependencies = [
  "ibc-telemetry",
  "itertools 0.10.5",
  "moka",
+ "monostate",
  "num-bigint",
  "num-rational",
  "once_cell",
@@ -1884,6 +1885,27 @@ dependencies = [
  "thiserror",
  "triomphe",
  "uuid 1.6.1",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878c2a1f1c70e5724fa28f101ca787b6a7e8ad5c5e4ae4ca3b0fa4a419fa9075"
+dependencies = [
+ "monostate-impl",
+ "serde",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f686d68a09079e63b1d2c64aa305095887ce50565f00a922ebfaeeee0d9ba6ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/config.toml
+++ b/config.toml
@@ -140,7 +140,8 @@ port = 5555
 # Specify the chain ID. Required
 id = 'ibc-0'
 
-# Specify the chain type, currently only `"CosmosSdk"` is supported.
+# Specify the chain type, currently only `CosmosSdk` is supported.
+# Default: CosmosSdk
 type = "CosmosSdk"
 
 # Whether or not this is a CCV consumer chain. Default: false
@@ -408,7 +409,6 @@ memo_prefix = ''
 
 [[chains]]
 id = 'ibc-1'
-type = "CosmosSdk"
 rpc_addr = 'http://127.0.0.1:26557'
 grpc_addr = 'http://127.0.0.1:9091'
 event_source = { mode = 'push', url = 'ws://127.0.0.1:26557/websocket', batch_delay = '500ms' }

--- a/crates/relayer-cli/src/chain_registry.rs
+++ b/crates/relayer-cli/src/chain_registry.rs
@@ -121,6 +121,7 @@ where
     };
 
     Ok(ChainConfig::CosmosSdk(CosmosSdkConfig {
+        r#type: Default::default(),
         id: chain_data.chain_id,
         rpc_addr: rpc_data.rpc_address,
         grpc_addr: grpc_address,

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -70,6 +70,7 @@ strum = { version = "0.25", features = ["derive"] }
 tokio-stream = "0.1.14"
 once_cell = "1.19.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"] }
+monostate = "0.1.11"
 
 [dependencies.byte-unit]
 version = "4.0.19"

--- a/crates/relayer/src/chain/cosmos/config.rs
+++ b/crates/relayer/src/chain/cosmos/config.rs
@@ -2,6 +2,7 @@ use core::time::Duration;
 use std::path::PathBuf;
 
 use byte_unit::Byte;
+use monostate::MustBe;
 use serde_derive::{Deserialize, Serialize};
 use tendermint_rpc::Url;
 
@@ -23,6 +24,11 @@ pub mod error;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CosmosSdkConfig {
+    /// The type of this chain, must be "CosmosSdk"
+    /// This is the default if not specified.
+    #[serde(default)]
+    pub r#type: MustBe!("CosmosSdk"),
+
     /// The chain's network identifier
     pub id: ChainId,
 

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -763,6 +763,7 @@ mod tests {
 
     use super::{load, parse_gas_prices, store_writer};
     use crate::config::GasPrice;
+    use monostate::MustBe;
     use test_log::test;
 
     #[test]
@@ -832,7 +833,11 @@ mod tests {
 
         let config = load(path).expect("could not parse config");
 
-        dbg!(config);
+        match config.chains[0] {
+            super::ChainConfig::CosmosSdk(ref config) => {
+                assert_eq!(config.r#type, MustBe!("CosmosSdk"));
+            }
+        }
     }
 
     #[test]

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -824,6 +824,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_default_chain_type() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/config/fixtures/relayer_conf_example_default_chain_type.toml"
+        );
+
+        let config = load(path).expect("could not parse config");
+
+        dbg!(config);
+    }
+
+    #[test]
     fn serialize_valid_config() {
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -16,7 +16,7 @@ use core::time::Duration;
 use std::{fs, fs::File, io::Write, ops::Range, path::Path};
 
 use byte_unit::Byte;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tendermint::block::Height as BlockHeight;
 use tendermint_rpc::Url;
 use tendermint_rpc::WebSocketClientUrl;
@@ -603,9 +603,18 @@ pub enum EventSourceMode {
     },
 }
 
+// NOTE:
+// To work around a limitation of serde, which does not allow
+// to specify a default variant if not tag is present,
+// every underlying chain config MUST have a field `r#type` of
+// type `monotstate::MustBe!("VariantName")`.
+//
+// For chains other than CosmosSdk, this field MUST NOT be annotated
+// with `#[serde(default)]`.
+//
+// See https://github.com/serde-rs/serde/issues/2231
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum ChainConfig {
     CosmosSdk(CosmosSdkConfig),
 }

--- a/crates/relayer/tests/config/fixtures/relayer_conf_example_default_chain_type.toml
+++ b/crates/relayer/tests/config/fixtures/relayer_conf_example_default_chain_type.toml
@@ -1,0 +1,56 @@
+[global]
+log_level = 'error'
+
+[mode]
+
+[mode.clients]
+enabled = true
+refresh = true
+misbehaviour = true
+
+[mode.connections]
+enabled = false
+
+[mode.channels]
+enabled = false
+
+[mode.packets]
+enabled = true
+clear_interval = 100
+clear_on_start = true
+tx_confirmation = true
+
+[[chains]]
+id = 'chain_A'
+rpc_addr = 'http://127.0.0.1:26657'
+grpc_addr = 'http://127.0.0.1:9090'
+event_source = { mode = 'push', url = 'ws://localhost:26657/websocket', batch_delay = '500ms' }
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+max_gas = 200000
+gas_price = { price = 0.001, denom = 'stake' }
+max_msg_num = 4
+max_tx_size = 1048576
+max_grpc_decoding_size = '4MiB'
+clock_drift = '5s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'cosmos' }
+
+[[chains]]
+id = 'chain_B'
+rpc_addr = 'http://127.0.0.1:26557'
+grpc_addr = 'http://127.0.0.1:9090'
+event_source = { mode = 'push', url = 'ws://localhost:26557/websocket', batch_delay = '500ms' }
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+gas_price = { price = 0.001, denom = 'stake' }
+max_grpc_decoding_size = '5.91 MB'
+clock_drift = '5s'
+trusting_period = '14days'
+trust_threshold = { numerator = '1', denominator = '3' }
+address_type = { derivation = 'ethermint', proto_type = { pk_type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey' } }

--- a/tools/test-framework/src/types/single/node.rs
+++ b/tools/test-framework/src/types/single/node.rs
@@ -155,6 +155,7 @@ impl FullNode {
         };
 
         Ok(config::ChainConfig::CosmosSdk(CosmosSdkConfig {
+            r#type: Default::default(),
             id: self.chain_driver.chain_id.clone(),
             rpc_addr: Url::from_str(&self.chain_driver.rpc_address())?,
             grpc_addr: Url::from_str(&self.chain_driver.grpc_address())?,


### PR DESCRIPTION
[This PR](https://github.com/informalsystems/hermes/pull/3644) changed the `ChainConfig` type to an enum to allow for settings which are specific to a type of chain (eg. Penumbra, Namada, CosmosSdk), but that had the effect of making the `type` key in the `[[chain]]` config required. So when we release this as is, it will require all operators to update their config to add `type = "CosmosSdk"`.

---

To avoid breaking operators' configurations, we need to make the `CosmosSdk` the default value for the `type` setting.

Doing this requires a bit of hack, due to serde's lack of support for specifying a default variant when a tag is not provided.

See the doc comment on the `ChainConfig` struct for more details.

The idea is to use an untagged enum, but to ensure that each underlying variant has a `type` field which can only be deserialized from a single value. For this, the `mono state` crate provides a `MustBe!` macro which expands into a type that can only be deserialized from the given string, eg. `MustBe!("Hello")` can only be deserialized from the string `Hello`.

With this in place, we can make one of the variant the default one by annotating its `type` field with `#[serde(default)]`.

In a nutshell:

```rust
use monostate::MustBe;
use serde::{Deserialize, Serialize};

#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
pub struct CosmosSdkConfig {
    #[serde(default)]
    r#type: MustBe!("CosmosSdk"),

    id: String,
}

#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
pub struct NamadaConfig {
    r#type: MustBe!("Namada"),

    id: String,
}

#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
#[serde(untagged)]
enum ChainConfig {
    CosmosSdk(CosmosSdkConfig),
    Namada(NamadaConfig),
}
```



______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
