### PR TITLE
Recover from gas simulation failures on legacy chains (#3792)

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer-cli/3792-legacy-simulation.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/3792-legacy-simulation.md
@@ -1,0 +1,2 @@
+- Recover from gas simulation failures on legacy chains.
+  ([\#3792](https://github.com/informalsystems/hermes/issues/3792))

--- a/crates/relayer/src/chain/cosmos/estimate.rs
+++ b/crates/relayer/src/chain/cosmos/estimate.rs
@@ -163,6 +163,7 @@ fn can_recover_from_simulation_failure(e: &Error) -> bool {
             detail.is_client_state_height_too_low()
                 || detail.is_account_sequence_mismatch_that_can_be_ignored()
                 || detail.is_out_of_order_packet_sequence_error()
+                || detail.is_empty_tx_error()
         }
         _ => false,
     }

--- a/crates/relayer/src/error.rs
+++ b/crates/relayer/src/error.rs
@@ -677,6 +677,14 @@ impl GrpcStatusSubdetail {
             Some((expected, got)) => expected < got,
         }
     }
+
+    /// Check whether this gRPC error message contains the string "invalid empty tx".
+    ///
+    /// ## Note
+    /// This error may happen for older chains that does not properly support simulation.
+    pub fn is_empty_tx_error(&self) -> bool {
+        self.status.message().contains("invalid empty tx")
+    }
 }
 
 /// Assumes that the cosmos-sdk account sequence mismatch error message, that may be seen


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3792

## Description

Gas simulation fails on legacy chains such as emoney-3, preventing the relayer from making progress.

This PR treats "invalid empty tx: invalid request" simulation errors as recoverable and uses the configured gas settings.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules): No tests added, but found tested and found working against emoney-3 chain.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR. @romac 

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
