### PR TITLE
Add memo and/or receiver filter metric

### DIFF
--- a/.changelog/unreleased/features/ibc-telemetry/3794-memo-receiver-filter-metric.md
+++ b/.changelog/unreleased/features/ibc-telemetry/3794-memo-receiver-filter-metric.md
@@ -1,0 +1,3 @@
+- Add a new metric `filtered_packets` which counts the number of
+  packets filtered due to having a memo or receiver field too big
+  ([\#3794](https://github.com/informalsystems/hermes/issues/3794))

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -568,6 +568,16 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
                     self.max_memo_size,
                     self.max_receiver_size,
                 ) {
+                    telemetry!(
+                        filtered_packets,
+                        &self.src_chain().id(),
+                        &self.dst_chain().id(),
+                        &packet.source_channel,
+                        &packet.destination_channel,
+                        &packet.source_port,
+                        &packet.destination_port,
+                        1
+                    );
                     continue;
                 }
             }

--- a/crates/telemetry/src/state.rs
+++ b/crates/telemetry/src/state.rs
@@ -201,7 +201,7 @@ pub struct TelemetryState {
     /// Number of errors observed by Hermes when broadcasting a Tx
     broadcast_errors: Counter<u64>,
 
-    /// Number of Packets filtered because the memo and/or the receiver were too big
+    /// Number of ICS-20 packets filtered because the memo and/or the receiver fields were exceeding the configured limits
     filtered_packets: Counter<u64>,
 }
 
@@ -387,7 +387,7 @@ impl TelemetryState {
 
                 filtered_packets: meter
                 .u64_counter("filtered_packets")
-                .with_description("Number of Packets filtered because the memo and/or the receiver were too big")
+                .with_description("Number of ICS-20 packets filtered because the memo and/or the receiver fields were exceeding the configured limits")
                 .init(),
         }
     }

--- a/guide/src/documentation/telemetry/operators.md
+++ b/guide/src/documentation/telemetry/operators.md
@@ -142,6 +142,7 @@ If this metric is increasing, it signals that the packet queue is increasing and
 | `cleared_send_packet_count_total`    | Number of SendPacket events received during the initial and periodic clearing, per chain, counterparty chain, channel and port                                              | `u64` Counter       | Packet workers enabled, and periodic packet clearing or clear on start enabled |
 | `cleared_acknowledgment_count_total` | Number of WriteAcknowledgement events received during the initial and periodic clearing, per chain, counterparty chain, channel and port                                    | `u64` Counter       | Packet workers enabled, and periodic packet clearing or clear on start enabled |
 | `broadcast_errors_total`        | Number of errors observed by Hermes when broadcasting a Tx, per error type and account                                                                                                         | `u64` Counter       | Packet workers enabled |
+| `filtered_packets`        | Number of Packets filtered because the memo and/or the receiver were too big | `u64` Counter | Packet workers enabled, and `ics20_max_memo_size` and/or `ics20_max_receiver_size` enabled |
 
 Notes:
 - The two metrics `cleared_send_packet_count_total` and `cleared_acknowledgment_count_total` are only populated if `tx_confirmation = true`.

--- a/guide/src/documentation/telemetry/operators.md
+++ b/guide/src/documentation/telemetry/operators.md
@@ -142,7 +142,7 @@ If this metric is increasing, it signals that the packet queue is increasing and
 | `cleared_send_packet_count_total`    | Number of SendPacket events received during the initial and periodic clearing, per chain, counterparty chain, channel and port                                              | `u64` Counter       | Packet workers enabled, and periodic packet clearing or clear on start enabled |
 | `cleared_acknowledgment_count_total` | Number of WriteAcknowledgement events received during the initial and periodic clearing, per chain, counterparty chain, channel and port                                    | `u64` Counter       | Packet workers enabled, and periodic packet clearing or clear on start enabled |
 | `broadcast_errors_total`        | Number of errors observed by Hermes when broadcasting a Tx, per error type and account                                                                                                         | `u64` Counter       | Packet workers enabled |
-| `filtered_packets`        | Number of Packets filtered because the memo and/or the receiver were too big | `u64` Counter | Packet workers enabled, and `ics20_max_memo_size` and/or `ics20_max_receiver_size` enabled |
+| `filtered_packets`        | Number of ICS-20 packets filtered because the memo and/or the receiver fields were exceeding the configured limits | `u64` Counter | Packet workers enabled, and `ics20_max_memo_size` and/or `ics20_max_receiver_size` enabled |
 
 Notes:
 - The two metrics `cleared_send_packet_count_total` and `cleared_acknowledgment_count_total` are only populated if `tx_confirmation = true`.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3794

## Description

This PR adds a metric `filtered_packets` which counts the number of packets filtered because they had a memo and/or receiver field too big.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
