### PR TITLE
Publish release automatically when pushing version tag

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,13 +1,13 @@
-name: Publish
+name: Publish (dry-run)
 
 on:
   push:
-    tags:
-      - v[0-9]+.*
+    branches:
+      - 'release/*'
 
 jobs:
   publish_dry_run:
-    name: Publish to crates.io
+    name: Publish (dry-run)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,6 +17,5 @@ jobs:
           override: true
       - uses: katyo/publish-crates@v2
         with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
+          dry-run: true
 


### PR DESCRIPTION
Will be useful for releases going forward. I did 1.8.0 manually so we'll see how it goes for v1.8.1.

Releases will be published by GitHub user `ibcbot`, just like the ibc-rs crates.

- [x] Add `ibcbot` as owner of the crates to publish
- [x] Add crates.io token as an action secret for use in the workflow