### PR TITLE
Add configuration to skip packet sequences when clearing

### DIFF
--- a/.changelog/unreleased/features/ibc-relayer/3754-filter-packet-clearing.md
+++ b/.changelog/unreleased/features/ibc-relayer/3754-filter-packet-clearing.md
@@ -1,0 +1,5 @@
+- Add a per-chain configuration `excluded_sequences` allowing
+  users to specify a list of packet sequences which will not be
+  cleared.
+  This configuration has no impact on standard packet relaying.
+  ([\#3754](https://github.com/informalsystems/hermes/issues/3754))

--- a/config.toml
+++ b/config.toml
@@ -433,8 +433,15 @@ memo_prefix = ''
 # This will override the global clear interval for this chain only, allowing different intervals for each chain.
 # clear_interval = 50
 
-# Specify packet sequences which should not be cleared.
-# Sequences should be set as a list of numbers: [2, 3, 5].
+# Specify packet sequences which should not be cleared, per channel.
+#
+# For each channel, specify a list of sequences which should not be cleared, eg.
+#
+#   excluded_sequences = [
+#     ['channel-0', [1, 2, 3]],
+#     ['channel-1', [4, 5, 6]]
+#  ]
+#
 # Default: No filter
 # excluded_sequences = []
 

--- a/config.toml
+++ b/config.toml
@@ -433,6 +433,11 @@ memo_prefix = ''
 # This will override the global clear interval for this chain only, allowing different intervals for each chain.
 # clear_interval = 50
 
+# Specify packet sequences which should not be cleared.
+# Sequences should be set as a list of numbers: [2, 3, 5].
+# Default: No filter
+# excluded_sequences = []
+
 [[chains]]
 id = 'ibc-1'
 rpc_addr = 'http://127.0.0.1:26557'

--- a/crates/relayer-cli/src/chain_registry.rs
+++ b/crates/relayer-cli/src/chain_registry.rs
@@ -1,12 +1,12 @@
 //! Contains functions to generate a relayer config for a given chain
 
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::marker::Send;
-
 use futures::future::join_all;
 use http::Uri;
 use ibc_relayer::config::dynamic_gas::DynamicGasPrice;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::marker::Send;
 use tokio::task::{JoinError, JoinHandle};
 use tracing::{error, trace};
 
@@ -172,7 +172,7 @@ where
         extension_options: Vec::new(),
         compat_mode: None,
         clear_interval: None,
-        excluded_sequences: Vec::new(),
+        excluded_sequences: BTreeMap::new(),
     }))
 }
 

--- a/crates/relayer-cli/src/chain_registry.rs
+++ b/crates/relayer-cli/src/chain_registry.rs
@@ -172,6 +172,7 @@ where
         extension_options: Vec::new(),
         compat_mode: None,
         clear_interval: None,
+        excluded_sequences: Vec::new(),
     }))
 }
 

--- a/crates/relayer-cli/src/commands/clear.rs
+++ b/crates/relayer-cli/src/commands/clear.rs
@@ -5,6 +5,7 @@ use abscissa_core::config::Override;
 use abscissa_core::{Command, FrameworkErrorKind, Runnable};
 
 use ibc_relayer::chain::handle::{BaseChainHandle, ChainHandle};
+use ibc_relayer::chain::requests::{IncludeProof, QueryChannelRequest, QueryHeight};
 use ibc_relayer::config::Config;
 use ibc_relayer::link::error::LinkError;
 use ibc_relayer::link::{Link, LinkParameters};
@@ -146,33 +147,79 @@ impl Runnable for ClearPacketsCmd {
             }
         }
 
+        let (channel, _) = match chains.src.query_channel(
+            QueryChannelRequest {
+                port_id: self.port_id.clone(),
+                channel_id: self.channel_id.clone(),
+                height: QueryHeight::Latest,
+            },
+            IncludeProof::No,
+        ) {
+            Ok(channel) => channel,
+            Err(e) => Output::error(e).exit(),
+        };
+
         let exclude_src_sequences = config
             .find_chain(&chains.src.id())
-            .map(|chain| chain.excluded_sequences())
+            .map(|chain_config| {
+                chain_config
+                    .excluded_sequences()
+                    .iter()
+                    .find(|e| e.0 == &self.channel_id)
+                    .map(|filter| filter.1.clone())
+                    .unwrap_or_default()
+            })
             .unwrap_or_default();
 
         let exclude_dst_sequences = config
             .find_chain(&chains.dst.id())
-            .map(|chain| chain.excluded_sequences())
+            .map(|chain_config| {
+                chain_config
+                    .excluded_sequences()
+                    .iter()
+                    .find(|e| {
+                        if let Some(counterparty_channel_id) = channel.counterparty().channel_id() {
+                            e.0 == counterparty_channel_id
+                        } else {
+                            false
+                        }
+                    })
+                    .map(|filter| filter.1.clone())
+                    .unwrap_or_default()
+            })
             .unwrap_or_default();
 
         // Construct links in both directions.
-        let opts = LinkParameters {
+        let fwd_opts = LinkParameters {
             src_port_id: self.port_id.clone(),
             src_channel_id: self.channel_id.clone(),
             max_memo_size: config.mode.packets.ics20_max_memo_size,
             max_receiver_size: config.mode.packets.ics20_max_receiver_size,
             exclude_src_sequences,
-            exclude_dst_sequences,
         };
 
-        let fwd_link = match Link::new_from_opts(chains.src.clone(), chains.dst, opts, false, false)
-        {
+        // Construct links in both directions.
+        let reverse_opts = LinkParameters {
+            src_port_id: self.port_id.clone(),
+            src_channel_id: self.channel_id.clone(),
+            max_memo_size: config.mode.packets.ics20_max_memo_size,
+            max_receiver_size: config.mode.packets.ics20_max_receiver_size,
+            exclude_src_sequences: exclude_dst_sequences,
+        };
+
+        let fwd_link = match Link::new_from_opts(
+            chains.src.clone(),
+            chains.dst.clone(),
+            fwd_opts,
+            false,
+            false,
+        ) {
             Ok(link) => link,
             Err(e) => Output::error(e).exit(),
         };
 
-        let rev_link = match fwd_link.reverse(false, false) {
+        let rev_link = match Link::new_from_opts(chains.dst, chains.src, reverse_opts, false, false)
+        {
             Ok(link) => link,
             Err(e) => Output::error(e).exit(),
         };

--- a/crates/relayer-cli/src/commands/clear.rs
+++ b/crates/relayer-cli/src/commands/clear.rs
@@ -156,8 +156,33 @@ impl Runnable for ClearPacketsCmd {
             max_receiver_size: config.mode.packets.ics20_max_receiver_size,
         };
 
-        let fwd_link = match Link::new_from_opts(chains.src.clone(), chains.dst, opts, false, false)
+        let excluded_src_sequences = match config
+            .chains
+            .iter()
+            .find(|chain| *chain.id() == chains.src.id())
         {
+            Some(chain_config) => chain_config.excluded_sequences(),
+            None => vec![],
+        };
+
+        let excluded_dst_sequences = match config
+            .chains
+            .iter()
+            .find(|chain| *chain.id() == chains.dst.id())
+        {
+            Some(chain_config) => chain_config.excluded_sequences(),
+            None => vec![],
+        };
+
+        let fwd_link = match Link::new_from_opts(
+            chains.src.clone(),
+            chains.dst,
+            opts,
+            false,
+            false,
+            excluded_src_sequences,
+            excluded_dst_sequences,
+        ) {
             Ok(link) => link,
             Err(e) => Output::error(e).exit(),
         };

--- a/crates/relayer-cli/src/commands/tx/packet.rs
+++ b/crates/relayer-cli/src/commands/tx/packet.rs
@@ -91,7 +91,6 @@ impl Runnable for TxPacketRecvCmd {
 
             // Packets are only excluded when clearing
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
         };
 
         let link = match Link::new_from_opts(chains.src, chains.dst, opts, false, false) {
@@ -193,7 +192,6 @@ impl Runnable for TxPacketAckCmd {
 
             // Packets are only excluded when clearing
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
         };
 
         let link = match Link::new_from_opts(chains.src, chains.dst, opts, false, false) {

--- a/crates/relayer-cli/src/commands/tx/packet.rs
+++ b/crates/relayer-cli/src/commands/tx/packet.rs
@@ -88,13 +88,16 @@ impl Runnable for TxPacketRecvCmd {
             src_channel_id: self.src_channel_id.clone(),
             max_memo_size: config.mode.packets.ics20_max_memo_size,
             max_receiver_size: config.mode.packets.ics20_max_receiver_size,
+
+            // Packets are only excluded when clearing
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
-        // Packets are only excluded when clearing
-        let link =
-            match Link::new_from_opts(chains.src, chains.dst, opts, false, false, vec![], vec![]) {
-                Ok(link) => link,
-                Err(e) => Output::error(e).exit(),
-            };
+
+        let link = match Link::new_from_opts(chains.src, chains.dst, opts, false, false) {
+            Ok(link) => link,
+            Err(e) => Output::error(e).exit(),
+        };
 
         let packet_data_query_height = self
             .packet_data_query_height
@@ -187,13 +190,16 @@ impl Runnable for TxPacketAckCmd {
             src_channel_id: self.src_channel_id.clone(),
             max_memo_size: config.mode.packets.ics20_max_memo_size,
             max_receiver_size: config.mode.packets.ics20_max_receiver_size,
+
+            // Packets are only excluded when clearing
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
-        // Packets are only excluded when clearing
-        let link =
-            match Link::new_from_opts(chains.src, chains.dst, opts, false, false, vec![], vec![]) {
-                Ok(link) => link,
-                Err(e) => Output::error(e).exit(),
-            };
+
+        let link = match Link::new_from_opts(chains.src, chains.dst, opts, false, false) {
+            Ok(link) => link,
+            Err(e) => Output::error(e).exit(),
+        };
 
         let packet_data_query_height = self
             .packet_data_query_height

--- a/crates/relayer-cli/src/commands/tx/packet.rs
+++ b/crates/relayer-cli/src/commands/tx/packet.rs
@@ -89,10 +89,12 @@ impl Runnable for TxPacketRecvCmd {
             max_memo_size: config.mode.packets.ics20_max_memo_size,
             max_receiver_size: config.mode.packets.ics20_max_receiver_size,
         };
-        let link = match Link::new_from_opts(chains.src, chains.dst, opts, false, false) {
-            Ok(link) => link,
-            Err(e) => Output::error(e).exit(),
-        };
+        // Packets are only excluded when clearing
+        let link =
+            match Link::new_from_opts(chains.src, chains.dst, opts, false, false, vec![], vec![]) {
+                Ok(link) => link,
+                Err(e) => Output::error(e).exit(),
+            };
 
         let packet_data_query_height = self
             .packet_data_query_height
@@ -186,10 +188,12 @@ impl Runnable for TxPacketAckCmd {
             max_memo_size: config.mode.packets.ics20_max_memo_size,
             max_receiver_size: config.mode.packets.ics20_max_receiver_size,
         };
-        let link = match Link::new_from_opts(chains.src, chains.dst, opts, false, false) {
-            Ok(link) => link,
-            Err(e) => Output::error(e).exit(),
-        };
+        // Packets are only excluded when clearing
+        let link =
+            match Link::new_from_opts(chains.src, chains.dst, opts, false, false, vec![], vec![]) {
+                Ok(link) => link,
+                Err(e) => Output::error(e).exit(),
+            };
 
         let packet_data_query_height = self
             .packet_data_query_height

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -2432,12 +2432,11 @@ fn do_health_check(chain: &CosmosSdkChain) -> Result<(), Error> {
     let rpc_address = chain.config.rpc_addr.to_string();
 
     if !chain.config.excluded_sequences.is_empty() {
-        for filter in chain.config.excluded_sequences.iter() {
-            if !filter.1.is_empty() {
+        for (channel_id, seqs) in chain.config.excluded_sequences.iter() {
+            if !seqs.is_empty() {
                 warn!(
-                    "chain '{chain_id}' will not clear packets on channel '{}' with sequences: {}. \
-                    Ignore this warning if this configuration is correct.",
-                    filter.0, PrettySlice(filter.1)
+                    "chain '{chain_id}' will not clear packets on channel '{channel_id}' with sequences: {}. \
+                    Ignore this warning if this configuration is correct.", PrettySlice(seqs)
                 );
             }
         }

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -2432,11 +2432,15 @@ fn do_health_check(chain: &CosmosSdkChain) -> Result<(), Error> {
     let rpc_address = chain.config.rpc_addr.to_string();
 
     if !chain.config.excluded_sequences.is_empty() {
-        warn!(
-            "chain '{chain_id}' will not clear packets with sequences: {}. \
-            Ignore this warning if this configuration is correct.",
-            PrettySlice(&chain.config.excluded_sequences)
-        );
+        for filter in chain.config.excluded_sequences.iter() {
+            if !filter.1.is_empty() {
+                warn!(
+                    "chain '{chain_id}' will not clear packets on channel '{}' with sequences: {}. \
+                    Ignore this warning if this configuration is correct.",
+                    filter.0, PrettySlice(filter.1)
+                );
+            }
+        }
     }
 
     chain.block_on(chain.rpc_client.health()).map_err(|e| {

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -63,6 +63,7 @@ use tendermint_rpc::endpoint::status;
 use tendermint_rpc::{Client, HttpClient, Order};
 
 use crate::account::Balance;
+use crate::chain::client::ClientSettings;
 use crate::chain::cosmos::batch::{
     send_batched_messages_and_wait_check_tx, send_batched_messages_and_wait_commit,
     sequential_send_batched_messages_and_wait_commit,
@@ -91,6 +92,7 @@ use crate::chain::handle::Subscription;
 use crate::chain::requests::*;
 use crate::chain::tracking::TrackedMsgs;
 use crate::client_state::{AnyClientState, IdentifiedAnyClientState};
+use crate::config::Error as ConfigError;
 use crate::config::{parse_gas_prices, ChainConfig, GasPrice};
 use crate::consensus_state::AnyConsensusState;
 use crate::denom::DenomTrace;
@@ -102,10 +104,10 @@ use crate::light_client::tendermint::LightClient as TmLightClient;
 use crate::light_client::{LightClient, Verified};
 use crate::misbehaviour::MisbehaviourEvidence;
 use crate::util::compat_mode::compat_mode_from_version;
+use crate::util::pretty::PrettySlice;
 use crate::util::pretty::{
     PrettyIdentifiedChannel, PrettyIdentifiedClientState, PrettyIdentifiedConnection,
 };
-use crate::{chain::client::ClientSettings, config::Error as ConfigError};
 
 use self::gas::dynamic_gas_price;
 use self::types::app_state::GenesisAppState;
@@ -671,8 +673,7 @@ impl CosmosSdkChain {
 
         let mut client = self
             .block_on(ServiceClient::connect(grpc_addr.clone()))
-            .map_err(Error::grpc_transport)
-            .unwrap();
+            .map_err(Error::grpc_transport)?;
 
         let request = tonic::Request::new(GetSyncingRequest {});
 
@@ -2429,6 +2430,14 @@ fn do_health_check(chain: &CosmosSdkChain) -> Result<(), Error> {
     let chain_id = chain.id();
     let grpc_address = chain.grpc_addr.to_string();
     let rpc_address = chain.config.rpc_addr.to_string();
+
+    if !chain.config.excluded_sequences.is_empty() {
+        warn!(
+            "chain '{chain_id}' will not clear packets with sequences: {}. \
+            Ignore this warning if this configuration is correct.",
+            PrettySlice(&chain.config.excluded_sequences)
+        );
+    }
 
     chain.block_on(chain.rpc_client.health()).map_err(|e| {
         Error::health_check_json_rpc(

--- a/crates/relayer/src/chain/cosmos/config.rs
+++ b/crates/relayer/src/chain/cosmos/config.rs
@@ -2,6 +2,7 @@ use core::time::Duration;
 use std::path::PathBuf;
 
 use byte_unit::Byte;
+use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use serde_derive::{Deserialize, Serialize};
 use tendermint_rpc::Url;
 
@@ -143,6 +144,8 @@ pub struct CosmosSdkConfig {
     pub extension_options: Vec<ExtensionOption>,
     pub compat_mode: Option<CompatMode>,
     pub clear_interval: Option<u64>,
+    #[serde(default)]
+    pub excluded_sequences: Vec<Sequence>,
 }
 
 impl CosmosSdkConfig {

--- a/crates/relayer/src/chain/cosmos/config.rs
+++ b/crates/relayer/src/chain/cosmos/config.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use byte_unit::Byte;
@@ -7,7 +8,7 @@ use serde_derive::{Deserialize, Serialize};
 use tendermint_rpc::Url;
 
 use ibc_relayer_types::core::ics23_commitment::specs::ProofSpecs;
-use ibc_relayer_types::core::ics24_host::identifier::ChainId;
+use ibc_relayer_types::core::ics24_host::identifier::{ChainId, ChannelId};
 
 use crate::chain::cosmos::config::error::Error as ConfigError;
 use crate::config::compat_mode::CompatMode;
@@ -145,7 +146,7 @@ pub struct CosmosSdkConfig {
     pub compat_mode: Option<CompatMode>,
     pub clear_interval: Option<u64>,
     #[serde(default)]
-    pub excluded_sequences: Vec<Sequence>,
+    pub excluded_sequences: BTreeMap<ChannelId, Vec<Sequence>>,
 }
 
 impl CosmosSdkConfig {

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -14,6 +14,7 @@ use core::cmp::Ordering;
 use core::fmt::{Display, Error as FmtError, Formatter};
 use core::str::FromStr;
 use core::time::Duration;
+use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use std::{fs, fs::File, io::Write, ops::Range, path::Path};
 
 use byte_unit::Byte;
@@ -701,6 +702,12 @@ impl ChainConfig {
     pub fn set_query_packets_chunk_size(&mut self, query_packets_chunk_size: usize) {
         match self {
             Self::CosmosSdk(config) => config.query_packets_chunk_size = query_packets_chunk_size,
+        }
+    }
+
+    pub fn excluded_sequences(&self) -> Vec<Sequence> {
+        match self {
+            Self::CosmosSdk(config) => config.excluded_sequences.clone(),
         }
     }
 }

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -15,6 +15,7 @@ use core::fmt::{Display, Error as FmtError, Formatter};
 use core::str::FromStr;
 use core::time::Duration;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
+use std::borrow::Cow;
 use std::{fs, fs::File, io::Write, ops::Range, path::Path};
 
 use byte_unit::Byte;
@@ -705,9 +706,13 @@ impl ChainConfig {
         }
     }
 
-    pub fn excluded_sequences(&self) -> BTreeMap<ChannelId, Vec<Sequence>> {
+    pub fn excluded_sequences(&self, channel_id: &ChannelId) -> Cow<'_, [Sequence]> {
         match self {
-            Self::CosmosSdk(config) => config.excluded_sequences.clone(),
+            Self::CosmosSdk(config) => config
+                .excluded_sequences
+                .get(channel_id)
+                .map(|seqs| Cow::Borrowed(seqs.as_slice()))
+                .unwrap_or_else(|| Cow::Owned(Vec::new())),
         }
     }
 }

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -705,7 +705,7 @@ impl ChainConfig {
         }
     }
 
-    pub fn excluded_sequences(&self) -> Vec<Sequence> {
+    pub fn excluded_sequences(&self) -> BTreeMap<ChannelId, Vec<Sequence>> {
         match self {
             Self::CosmosSdk(config) => config.excluded_sequences.clone(),
         }

--- a/crates/relayer/src/link.rs
+++ b/crates/relayer/src/link.rs
@@ -40,7 +40,6 @@ pub struct LinkParameters {
     pub max_memo_size: Ics20FieldSizeLimit,
     pub max_receiver_size: Ics20FieldSizeLimit,
     pub exclude_src_sequences: Vec<Sequence>,
-    pub exclude_dst_sequences: Vec<Sequence>,
 }
 
 pub struct Link<ChainA: ChainHandle, ChainB: ChainHandle> {
@@ -179,35 +178,5 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
         }
 
         Link::new(channel, with_tx_confirmation, opts)
-    }
-
-    /// Constructs a link around the channel that is reverse to the channel
-    /// in this link.
-    pub fn reverse(
-        &self,
-        with_tx_confirmation: bool,
-        auto_register_counterparty_payee: bool,
-    ) -> Result<Link<ChainB, ChainA>, LinkError> {
-        let opts = LinkParameters {
-            src_port_id: self.a_to_b.dst_port_id().clone(),
-            src_channel_id: self.a_to_b.dst_channel_id().clone(),
-            max_memo_size: self.a_to_b.max_memo_size,
-            max_receiver_size: self.a_to_b.max_receiver_size,
-            exclude_src_sequences: self.a_to_b.exclude_dst_sequences.clone(),
-            exclude_dst_sequences: self.a_to_b.exclude_src_sequences.clone(),
-        };
-
-        let chain_b = self.a_to_b.dst_chain().clone();
-        let chain_a = self.a_to_b.src_chain().clone();
-
-        // Some of the checks and initializations may be redundant;
-        // going slowly, but reliably.
-        Link::new_from_opts(
-            chain_b,
-            chain_a,
-            opts,
-            with_tx_confirmation,
-            auto_register_counterparty_payee,
-        )
     }
 }

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -125,8 +125,6 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
         channel: Channel<ChainA, ChainB>,
         with_tx_confirmation: bool,
         link_parameters: LinkParameters,
-        exclude_src_sequences: Vec<Sequence>,
-        exclude_dst_sequences: Vec<Sequence>,
     ) -> Result<Self, LinkError> {
         let src_chain = channel.src_chain().clone();
         let dst_chain = channel.dst_chain().clone();
@@ -168,8 +166,9 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
 
             max_memo_size: link_parameters.max_memo_size,
             max_receiver_size: link_parameters.max_receiver_size,
-            exclude_src_sequences,
-            exclude_dst_sequences,
+
+            exclude_src_sequences: link_parameters.exclude_src_sequences,
+            exclude_dst_sequences: link_parameters.exclude_dst_sequences,
         })
     }
 

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -117,7 +117,6 @@ pub struct RelayPath<ChainA: ChainHandle, ChainB: ChainHandle> {
     pub max_memo_size: Ics20FieldSizeLimit,
     pub max_receiver_size: Ics20FieldSizeLimit,
     pub exclude_src_sequences: Vec<Sequence>,
-    pub exclude_dst_sequences: Vec<Sequence>,
 }
 
 impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
@@ -168,7 +167,6 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             max_receiver_size: link_parameters.max_receiver_size,
 
             exclude_src_sequences: link_parameters.exclude_src_sequences,
-            exclude_dst_sequences: link_parameters.exclude_dst_sequences,
         })
     }
 

--- a/crates/relayer/src/worker.rs
+++ b/crates/relayer/src/worker.rs
@@ -112,15 +112,9 @@ pub fn spawn_worker_tasks<ChainA: ChainHandle, ChainB: ChainHandle>(
         Object::Packet(path) => {
             let exclude_src_sequences = config
                 .find_chain(&chains.a.id())
-                .map(|chain_config| {
-                    chain_config
-                        .excluded_sequences()
-                        .iter()
-                        .find(|e| e.0 == &path.src_channel_id)
-                        .map(|filter| filter.1.clone())
-                        .unwrap_or_default()
-                })
-                .unwrap_or_default();
+                .map(|chain_config| chain_config.excluded_sequences(&path.src_channel_id))
+                .unwrap_or_default()
+                .to_vec();
 
             let packets_config = config.mode.packets;
             let link_res = Link::new_from_opts(

--- a/crates/relayer/src/worker.rs
+++ b/crates/relayer/src/worker.rs
@@ -110,6 +110,24 @@ pub fn spawn_worker_tasks<ChainA: ChainHandle, ChainB: ChainHandle>(
             (Some(cmd_tx), None)
         }
         Object::Packet(path) => {
+            let excluded_src_sequences = match config
+                .chains
+                .iter()
+                .find(|chain| *chain.id() == chains.a.id())
+            {
+                Some(chain_config) => chain_config.excluded_sequences(),
+                None => vec![],
+            };
+
+            let excluded_dst_sequences = match config
+                .chains
+                .iter()
+                .find(|chain| *chain.id() == chains.b.id())
+            {
+                Some(chain_config) => chain_config.excluded_sequences(),
+                None => vec![],
+            };
+
             let packets_config = config.mode.packets;
             let link_res = Link::new_from_opts(
                 chains.a.clone(),
@@ -122,6 +140,8 @@ pub fn spawn_worker_tasks<ChainA: ChainHandle, ChainB: ChainHandle>(
                 },
                 packets_config.tx_confirmation,
                 packets_config.auto_register_counterparty_payee,
+                excluded_src_sequences,
+                excluded_dst_sequences,
             );
 
             match link_res {

--- a/guide/src/documentation/configuration/packet-clearing.md
+++ b/guide/src/documentation/configuration/packet-clearing.md
@@ -2,7 +2,7 @@
 
 Hermes can be configured in order to clear packets which haven't been relayed. This can happen if there wasn't a relayer instance running when the packet event was submitted or if there was an issue relaying the packet.
 
-There are three different configurations to determine when Hermes will clear packets.
+There are four different configurations to determine when Hermes will clear packets.
 
 ## Global configurations
 
@@ -32,7 +32,7 @@ This configuration defines how often Hermes will verify if there are pending pac
 
 ## Chain specific configuration
 
-The third configuration is specific for each chain.
+The third and fourth configurations are specific for each chain.
 
 ### 3. `clear_interval`
 
@@ -43,3 +43,13 @@ clear_interval = 50
 ```
 
 An additional `clear_interval` can be specified for each chain, this value is also in number of blocks. This configuration will override the clear interval value for the specific chain and can be used if chains need to have different clear values. This configuration is optional, if it is not set the global value will be used.
+
+### 4. `excluded_sequences`
+
+```toml
+[[chains]]
+...
+excluded_sequences = [2, 4]
+```
+
+It is possible to specify which packet sequences should be ignored when clearing packets. This can be used when there are stuck packets which need to be handled in a specific way, but it is still required to clear the other stuck packets. This configuration will only filter packet when clearing, standard relaying will not filter the sequences configured in `excluded_sequences`.

--- a/guide/src/documentation/configuration/packet-clearing.md
+++ b/guide/src/documentation/configuration/packet-clearing.md
@@ -49,7 +49,10 @@ An additional `clear_interval` can be specified for each chain, this value is al
 ```toml
 [[chains]]
 ...
-excluded_sequences = [2, 4]
+excluded_sequences = [
+    ['channel-0', [1, 2, 3]],
+    ['channel-1', [4, 5, 6]]
+]
 ```
 
-It is possible to specify which packet sequences should be ignored when clearing packets. This can be used when there are stuck packets which need to be handled in a specific way, but it is still required to clear the other stuck packets. This configuration will only filter packet when clearing, standard relaying will not filter the sequences configured in `excluded_sequences`.
+It is possible to specify which packet sequences should be ignored when clearing packets for specific channels. This can be used when there are stuck packets which need to be handled in a specific way, but it is still required to clear the other stuck packets. This configuration will only filter packet when clearing, standard relaying will not filter the sequences configured in `excluded_sequences`.

--- a/tools/integration-test/src/tests/clear_packet.rs
+++ b/tools/integration-test/src/tests/clear_packet.rs
@@ -488,7 +488,14 @@ impl BinaryChannelTest for ClearPacketSequencesTest {
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
+        };
+
+        let rev_opts = LinkParameters {
+            src_port_id: channel.port_b.clone().into_value(),
+            src_channel_id: channel.channel_id_b.clone().into_value(),
+            max_memo_size: packet_config.ics20_max_memo_size,
+            max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
         };
 
         // Clear all even packets
@@ -534,8 +541,15 @@ impl BinaryChannelTest for ClearPacketSequencesTest {
 
         info!("Clearing all unreceived ack packets ({})", to_clear.len());
 
-        let rev_link = link.reverse(false, false).unwrap();
-        rev_link.relay_ack_packet_messages(to_clear).unwrap();
+        let rev_link = Link::new_from_opts(
+            chains.handle_b().clone(),
+            chains.handle_a().clone(),
+            rev_opts,
+            false,
+            false,
+        )?;
+
+        rev_link.relay_ack_packet_messages(to_clear)?;
 
         let pending_packets_a =
             pending_packet_summary(chains.handle_a(), chains.handle_b(), channel_end_a.value())?;

--- a/tools/integration-test/src/tests/clear_packet.rs
+++ b/tools/integration-test/src/tests/clear_packet.rs
@@ -487,6 +487,8 @@ impl BinaryChannelTest for ClearPacketSequencesTest {
             src_channel_id: channel.channel_id_a.clone().into_value(),
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
 
         // Clear all even packets
@@ -505,8 +507,6 @@ impl BinaryChannelTest for ClearPacketSequencesTest {
             opts,
             false,
             false,
-            vec![],
-            vec![],
         )?;
 
         info!("Clearing all even packets ({})", to_clear.len());

--- a/tools/integration-test/src/tests/clear_packet.rs
+++ b/tools/integration-test/src/tests/clear_packet.rs
@@ -505,6 +505,8 @@ impl BinaryChannelTest for ClearPacketSequencesTest {
             opts,
             false,
             false,
+            vec![],
+            vec![],
         )?;
 
         info!("Clearing all even packets ({})", to_clear.len());

--- a/tools/integration-test/src/tests/execute_schedule.rs
+++ b/tools/integration-test/src/tests/execute_schedule.rs
@@ -57,6 +57,8 @@ impl BinaryChannelTest for ExecuteScheduleTest {
             chain_a_link_opts,
             true,
             false,
+            vec![],
+            vec![],
         )?;
 
         let mut relay_path_a_to_b = chain_a_link.a_to_b;

--- a/tools/integration-test/src/tests/execute_schedule.rs
+++ b/tools/integration-test/src/tests/execute_schedule.rs
@@ -49,6 +49,8 @@ impl BinaryChannelTest for ExecuteScheduleTest {
             src_channel_id: channel.channel_id_a.clone().into_value(),
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
 
         let chain_a_link = Link::new_from_opts(
@@ -57,8 +59,6 @@ impl BinaryChannelTest for ExecuteScheduleTest {
             chain_a_link_opts,
             true,
             false,
-            vec![],
-            vec![],
         )?;
 
         let mut relay_path_a_to_b = chain_a_link.a_to_b;

--- a/tools/integration-test/src/tests/execute_schedule.rs
+++ b/tools/integration-test/src/tests/execute_schedule.rs
@@ -50,7 +50,6 @@ impl BinaryChannelTest for ExecuteScheduleTest {
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
         };
 
         let chain_a_link = Link::new_from_opts(

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -22,6 +22,7 @@ pub mod ics20_filter;
 pub mod memo;
 pub mod python;
 pub mod query_packet;
+#[cfg(not(feature = "celestia"))]
 pub mod sequence_filter;
 pub mod supervisor;
 pub mod tendermint;

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -22,6 +22,7 @@ pub mod ics20_filter;
 pub mod memo;
 pub mod python;
 pub mod query_packet;
+pub mod sequence_filter;
 pub mod supervisor;
 pub mod tendermint;
 #[cfg(not(feature = "celestia"))]

--- a/tools/integration-test/src/tests/ordered_channel_clear.rs
+++ b/tools/integration-test/src/tests/ordered_channel_clear.rs
@@ -121,6 +121,8 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             src_channel_id: channel.channel_id_a.clone().into_value(),
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
 
         let chain_a_link = Link::new_from_opts(
@@ -129,8 +131,6 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             chain_a_link_opts,
             true,
             true,
-            vec![],
-            vec![],
         )?;
 
         let chain_b_link_opts = LinkParameters {
@@ -138,6 +138,8 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             src_channel_id: channel.channel_id_b.clone().into_value(),
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
 
         let chain_b_link = Link::new_from_opts(
@@ -146,8 +148,6 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             chain_b_link_opts,
             true,
             true,
-            vec![],
-            vec![],
         )?;
 
         // Send the transfer (recv) packets from A to B over the channel.
@@ -276,6 +276,8 @@ impl BinaryChannelTest for OrderedChannelClearEqualCLITest {
             src_channel_id: channel.channel_id_a.into_value(),
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
 
         let chain_a_link = Link::new_from_opts(
@@ -284,8 +286,6 @@ impl BinaryChannelTest for OrderedChannelClearEqualCLITest {
             chain_a_link_opts,
             true,
             true,
-            vec![],
-            vec![],
         )?;
 
         let events_returned: Vec<IbcEvent> = chain_a_link

--- a/tools/integration-test/src/tests/ordered_channel_clear.rs
+++ b/tools/integration-test/src/tests/ordered_channel_clear.rs
@@ -129,6 +129,8 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             chain_a_link_opts,
             true,
             true,
+            vec![],
+            vec![],
         )?;
 
         let chain_b_link_opts = LinkParameters {
@@ -144,6 +146,8 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             chain_b_link_opts,
             true,
             true,
+            vec![],
+            vec![],
         )?;
 
         // Send the transfer (recv) packets from A to B over the channel.
@@ -280,6 +284,8 @@ impl BinaryChannelTest for OrderedChannelClearEqualCLITest {
             chain_a_link_opts,
             true,
             true,
+            vec![],
+            vec![],
         )?;
 
         let events_returned: Vec<IbcEvent> = chain_a_link

--- a/tools/integration-test/src/tests/ordered_channel_clear.rs
+++ b/tools/integration-test/src/tests/ordered_channel_clear.rs
@@ -122,7 +122,6 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
         };
 
         let chain_a_link = Link::new_from_opts(
@@ -139,7 +138,6 @@ impl BinaryChannelTest for OrderedChannelClearTest {
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
         };
 
         let chain_b_link = Link::new_from_opts(
@@ -277,7 +275,6 @@ impl BinaryChannelTest for OrderedChannelClearEqualCLITest {
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
         };
 
         let chain_a_link = Link::new_from_opts(

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -62,15 +62,16 @@ impl BinaryChannelTest for QueryPacketPendingTest {
             src_channel_id: channel.channel_id_a.clone().into_value(),
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
+            exclude_dst_sequences: vec![],
         };
+
         let link = Link::new_from_opts(
             chains.handle_a().clone(),
             chains.handle_b().clone(),
             opts,
             false,
             false,
-            vec![],
-            vec![],
         )?;
 
         let channel_end = query_identified_channel_end(

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -63,7 +63,14 @@ impl BinaryChannelTest for QueryPacketPendingTest {
             max_memo_size: packet_config.ics20_max_memo_size,
             max_receiver_size: packet_config.ics20_max_receiver_size,
             exclude_src_sequences: vec![],
-            exclude_dst_sequences: vec![],
+        };
+
+        let rev_opts = LinkParameters {
+            src_port_id: channel.port_b.clone().into_value(),
+            src_channel_id: channel.channel_id_b.clone().into_value(),
+            max_memo_size: packet_config.ics20_max_memo_size,
+            max_receiver_size: packet_config.ics20_max_receiver_size,
+            exclude_src_sequences: vec![],
         };
 
         let link = Link::new_from_opts(
@@ -96,8 +103,16 @@ impl BinaryChannelTest for QueryPacketPendingTest {
         assert_eq!(summary.unreceived_acks, [1.into()]);
 
         // Acknowledge the packet on the source chain
-        let link = link.reverse(false, false)?;
-        link.relay_ack_packet_messages(vec![])?;
+
+        let rev_link = Link::new_from_opts(
+            chains.handle_b().clone(),
+            chains.handle_a().clone(),
+            rev_opts,
+            false,
+            false,
+        )?;
+
+        rev_link.relay_ack_packet_messages(vec![])?;
 
         let summary =
             pending_packet_summary(chains.handle_a(), chains.handle_b(), channel_end.value())?;

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -69,6 +69,8 @@ impl BinaryChannelTest for QueryPacketPendingTest {
             opts,
             false,
             false,
+            vec![],
+            vec![],
         )?;
 
         let channel_end = query_identified_channel_end(

--- a/tools/integration-test/src/tests/sequence_filter.rs
+++ b/tools/integration-test/src/tests/sequence_filter.rs
@@ -1,0 +1,442 @@
+//! This tests different scenarios for the packet sequence filter.
+//! The purpose of this filter is to only filter out packets when clearing,
+//! standard relaying should not be affected by this configuration.
+//!
+//! `FilterClearOnStartTest` tests that the packets sequences configured in
+//! `excluded_sequences` are not relayed when clearing packet on start.
+//!
+//! `FilterClearIntervalTest` tests that the packet sequences configured in
+//! `excluded_sequences` are not relayed when the clear interval is triggered.
+//!
+//! `ClearNoFilterTest` tests that packets are correctly cleared if there is no
+//! packet sequence configured in `excluded_sequences`.
+//!
+//! `StandardRelayingNoFilterTest` tests that even if a packet sequence is
+//! configured in the `excluded_sequences` it will be relayed by the running
+//! instance.
+
+use ibc_relayer::config::ChainConfig;
+use ibc_test_framework::prelude::*;
+
+#[test]
+fn test_filter_clear_on_start() -> Result<(), Error> {
+    run_binary_channel_test(&FilterClearOnStartTest)
+}
+
+#[test]
+fn test_filter_clear_interval() -> Result<(), Error> {
+    run_binary_channel_test(&FilterClearIntervalTest)
+}
+
+#[test]
+fn test_clear_no_filter() -> Result<(), Error> {
+    run_binary_channel_test(&ClearNoFilterTest)
+}
+
+#[test]
+fn test_no_filter_standard_relaying() -> Result<(), Error> {
+    run_binary_channel_test(&StandardRelayingNoFilterTest)
+}
+
+pub struct FilterClearOnStartTest;
+
+impl TestOverrides for FilterClearOnStartTest {
+    fn modify_relayer_config(&self, config: &mut Config) {
+        let chain_a = &mut config.chains[0];
+        match chain_a {
+            ChainConfig::CosmosSdk(chain_config) => {
+                chain_config.excluded_sequences = vec![2.into()];
+            }
+        }
+        config.mode.packets.clear_on_start = true;
+        config.mode.packets.clear_interval = 0;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChannelTest for FilterClearOnStartTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channels: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        run_sequence_filter_test(relayer, chains, channels)
+    }
+}
+
+pub struct FilterClearIntervalTest;
+
+impl TestOverrides for FilterClearIntervalTest {
+    fn modify_relayer_config(&self, config: &mut Config) {
+        let chain_a = &mut config.chains[0];
+        match chain_a {
+            ChainConfig::CosmosSdk(chain_config) => {
+                chain_config.excluded_sequences = vec![2.into()];
+            }
+        }
+        config.mode.packets.clear_on_start = false;
+        config.mode.packets.clear_interval = 10;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChannelTest for FilterClearIntervalTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channels: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        run_sequence_filter_test(relayer, chains, channels)
+    }
+}
+
+pub struct ClearNoFilterTest;
+
+impl TestOverrides for ClearNoFilterTest {
+    fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.packets.clear_on_start = true;
+        config.mode.packets.clear_interval = 0;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+}
+
+impl BinaryChannelTest for ClearNoFilterTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channels: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let denom_a = chains.node_a.denom();
+        let denom_a_to_b = derive_ibc_denom(
+            &channels.port_b.as_ref(),
+            &channels.channel_id_b.as_ref(),
+            &denom_a,
+        )?;
+        let denom_b = chains.node_b.denom();
+        let denom_b_to_a = derive_ibc_denom(
+            &channels.port_a.as_ref(),
+            &channels.channel_id_a.as_ref(),
+            &denom_b,
+        )?;
+
+        let wallet_a = chains.node_a.wallets().user1().cloned();
+        let wallet_b = chains.node_b.wallets().user1().cloned();
+
+        let a_to_b_amount = 12345u64;
+        let b_to_a_amount = 54321u64;
+
+        let balance_a = chains
+            .node_a
+            .chain_driver()
+            .query_balance(&wallet_a.address(), &denom_a)?;
+
+        let balance_b = chains
+            .node_b
+            .chain_driver()
+            .query_balance(&wallet_b.address(), &denom_b)?;
+
+        // Create a pending transfer from A to B with sequence 1
+        chains.node_a.chain_driver().ibc_transfer_token(
+            &channels.port_a.as_ref(),
+            &channels.channel_id_a.as_ref(),
+            &wallet_a.as_ref(),
+            &wallet_b.address(),
+            &denom_a.with_amount(a_to_b_amount).as_ref(),
+        )?;
+
+        // Create a pending transfer from A to B with sequence 2
+        chains.node_a.chain_driver().ibc_transfer_token(
+            &channels.port_a.as_ref(),
+            &channels.channel_id_a.as_ref(),
+            &wallet_a.as_ref(),
+            &wallet_b.address(),
+            &denom_a.with_amount(a_to_b_amount).as_ref(),
+        )?;
+
+        // Create a pending transfer from B to A with sequence 1
+        chains.node_b.chain_driver().ibc_transfer_token(
+            &channels.port_b.as_ref(),
+            &channels.channel_id_b.as_ref(),
+            &wallet_b.as_ref(),
+            &wallet_a.address(),
+            &denom_b.with_amount(b_to_a_amount).as_ref(),
+        )?;
+
+        // Create a pending transfer from B to A with sequence 2
+        chains.node_b.chain_driver().ibc_transfer_token(
+            &channels.port_b.as_ref(),
+            &channels.channel_id_b.as_ref(),
+            &wallet_b.as_ref(),
+            &wallet_a.address(),
+            &denom_b.with_amount(b_to_a_amount).as_ref(),
+        )?;
+
+        relayer.with_supervisor(|| {
+            info!("Assert that the send from A escrowed tokens for both transfers");
+
+            chains.node_a.chain_driver().assert_eventual_wallet_amount(
+                &wallet_a.address(),
+                &(balance_a - 2 * a_to_b_amount).as_ref(),
+            )?;
+
+            info!("Assert that only the first transfer A to B was cleared");
+
+            chains.node_b.chain_driver().assert_eventual_wallet_amount(
+                &wallet_b.address(),
+                &denom_a_to_b.with_amount(2 * a_to_b_amount).as_ref(),
+            )?;
+            info!("Assert that the sender from B escrowed tokens for both transfers");
+
+            chains.node_b.chain_driver().assert_eventual_wallet_amount(
+                &wallet_b.address(),
+                &(balance_b - 2 * b_to_a_amount).as_ref(),
+            )?;
+
+            info!("Assert that both transfers from B to A were cleared");
+
+            chains.node_a.chain_driver().assert_eventual_wallet_amount(
+                &wallet_a.address(),
+                &denom_b_to_a.with_amount(2 * b_to_a_amount).as_ref(),
+            )?;
+            Ok(())
+        })
+    }
+}
+
+pub struct StandardRelayingNoFilterTest;
+
+impl TestOverrides for StandardRelayingNoFilterTest {
+    fn modify_relayer_config(&self, config: &mut Config) {
+        let chain_a = &mut config.chains[0];
+        match chain_a {
+            ChainConfig::CosmosSdk(chain_config) => {
+                chain_config.excluded_sequences = vec![2.into()];
+            }
+        }
+        config.mode.packets.clear_on_start = true;
+        config.mode.packets.clear_interval = 0;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        true
+    }
+}
+
+impl BinaryChannelTest for StandardRelayingNoFilterTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        _relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channels: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let denom_a = chains.node_a.denom();
+        let denom_a_to_b = derive_ibc_denom(
+            &channels.port_b.as_ref(),
+            &channels.channel_id_b.as_ref(),
+            &denom_a,
+        )?;
+        let denom_b = chains.node_b.denom();
+        let denom_b_to_a = derive_ibc_denom(
+            &channels.port_a.as_ref(),
+            &channels.channel_id_a.as_ref(),
+            &denom_b,
+        )?;
+
+        let wallet_a = chains.node_a.wallets().user1().cloned();
+        let wallet_b = chains.node_b.wallets().user1().cloned();
+
+        let a_to_b_amount = 12345u64;
+        let b_to_a_amount = 54321u64;
+
+        let balance_a = chains
+            .node_a
+            .chain_driver()
+            .query_balance(&wallet_a.address(), &denom_a)?;
+
+        let balance_b = chains
+            .node_b
+            .chain_driver()
+            .query_balance(&wallet_b.address(), &denom_b)?;
+
+        // Create a pending transfer from A to B with sequence 1
+        chains.node_a.chain_driver().ibc_transfer_token(
+            &channels.port_a.as_ref(),
+            &channels.channel_id_a.as_ref(),
+            &wallet_a.as_ref(),
+            &wallet_b.address(),
+            &denom_a.with_amount(a_to_b_amount).as_ref(),
+        )?;
+
+        // Create a pending transfer from A to B with sequence 2
+        chains.node_a.chain_driver().ibc_transfer_token(
+            &channels.port_a.as_ref(),
+            &channels.channel_id_a.as_ref(),
+            &wallet_a.as_ref(),
+            &wallet_b.address(),
+            &denom_a.with_amount(a_to_b_amount).as_ref(),
+        )?;
+
+        // Create a pending transfer from B to A with sequence 1
+        chains.node_b.chain_driver().ibc_transfer_token(
+            &channels.port_b.as_ref(),
+            &channels.channel_id_b.as_ref(),
+            &wallet_b.as_ref(),
+            &wallet_a.address(),
+            &denom_b.with_amount(b_to_a_amount).as_ref(),
+        )?;
+
+        // Create a pending transfer from B to A with sequence 2
+        chains.node_b.chain_driver().ibc_transfer_token(
+            &channels.port_b.as_ref(),
+            &channels.channel_id_b.as_ref(),
+            &wallet_b.as_ref(),
+            &wallet_a.address(),
+            &denom_b.with_amount(b_to_a_amount).as_ref(),
+        )?;
+
+        info!("Assert that the send from A escrowed tokens for both transfers");
+
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a.address(),
+            &(balance_a - 2 * a_to_b_amount).as_ref(),
+        )?;
+
+        info!("Assert that only the first transfer A to B was cleared");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b.address(),
+            &denom_a_to_b.with_amount(2 * a_to_b_amount).as_ref(),
+        )?;
+        info!("Assert that the sender from B escrowed tokens for both transfers");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b.address(),
+            &(balance_b - 2 * b_to_a_amount).as_ref(),
+        )?;
+
+        info!("Assert that both transfers from B to A were cleared");
+
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a.address(),
+            &denom_b_to_a.with_amount(2 * b_to_a_amount).as_ref(),
+        )?;
+        Ok(())
+    }
+}
+
+fn run_sequence_filter_test<ChainA: ChainHandle, ChainB: ChainHandle>(
+    relayer: RelayerDriver,
+    chains: ConnectedChains<ChainA, ChainB>,
+    channels: ConnectedChannel<ChainA, ChainB>,
+) -> Result<(), Error> {
+    let denom_a = chains.node_a.denom();
+    let denom_a_to_b = derive_ibc_denom(
+        &channels.port_b.as_ref(),
+        &channels.channel_id_b.as_ref(),
+        &denom_a,
+    )?;
+    let denom_b = chains.node_b.denom();
+    let denom_b_to_a = derive_ibc_denom(
+        &channels.port_a.as_ref(),
+        &channels.channel_id_a.as_ref(),
+        &denom_b,
+    )?;
+
+    let wallet_a = chains.node_a.wallets().user1().cloned();
+    let wallet_b = chains.node_b.wallets().user1().cloned();
+
+    let a_to_b_amount = 12345u64;
+    let b_to_a_amount = 54321u64;
+
+    let balance_a = chains
+        .node_a
+        .chain_driver()
+        .query_balance(&wallet_a.address(), &denom_a)?;
+
+    let balance_b = chains
+        .node_b
+        .chain_driver()
+        .query_balance(&wallet_b.address(), &denom_b)?;
+
+    // Create a pending transfer from A to B with sequence 1
+    chains.node_a.chain_driver().ibc_transfer_token(
+        &channels.port_a.as_ref(),
+        &channels.channel_id_a.as_ref(),
+        &wallet_a.as_ref(),
+        &wallet_b.address(),
+        &denom_a.with_amount(a_to_b_amount).as_ref(),
+    )?;
+
+    // Create a pending transfer from A to B with sequence 2
+    chains.node_a.chain_driver().ibc_transfer_token(
+        &channels.port_a.as_ref(),
+        &channels.channel_id_a.as_ref(),
+        &wallet_a.as_ref(),
+        &wallet_b.address(),
+        &denom_a.with_amount(a_to_b_amount).as_ref(),
+    )?;
+
+    // Create a pending transfer from B to A with sequence 1
+    chains.node_b.chain_driver().ibc_transfer_token(
+        &channels.port_b.as_ref(),
+        &channels.channel_id_b.as_ref(),
+        &wallet_b.as_ref(),
+        &wallet_a.address(),
+        &denom_b.with_amount(b_to_a_amount).as_ref(),
+    )?;
+
+    // Create a pending transfer from B to A with sequence 2
+    chains.node_b.chain_driver().ibc_transfer_token(
+        &channels.port_b.as_ref(),
+        &channels.channel_id_b.as_ref(),
+        &wallet_b.as_ref(),
+        &wallet_a.address(),
+        &denom_b.with_amount(b_to_a_amount).as_ref(),
+    )?;
+
+    relayer.with_supervisor(|| {
+        info!("Assert that the send from A escrowed tokens for both transfers");
+
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a.address(),
+            &(balance_a - 2 * a_to_b_amount).as_ref(),
+        )?;
+
+        info!("Assert that only the first transfer A to B was cleared");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b.address(),
+            &denom_a_to_b.with_amount(a_to_b_amount).as_ref(),
+        )?;
+        info!("Assert that the sender from B escrowed tokens for both transfers");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b.address(),
+            &(balance_b - 2 * b_to_a_amount).as_ref(),
+        )?;
+
+        info!("Assert that both transfers from B to A were cleared");
+
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a.address(),
+            &denom_b_to_a.with_amount(2 * b_to_a_amount).as_ref(),
+        )?;
+        Ok(())
+    })
+}

--- a/tools/integration-test/src/tests/sequence_filter.rs
+++ b/tools/integration-test/src/tests/sequence_filter.rs
@@ -15,8 +15,13 @@
 //! configured in the `excluded_sequences` it will be relayed by the running
 //! instance.
 
+use std::collections::BTreeMap;
+
 use ibc_relayer::config::ChainConfig;
-use ibc_test_framework::prelude::*;
+use ibc_test_framework::{
+    prelude::*,
+    relayer::channel::{assert_eventually_channel_established, init_channel},
+};
 
 #[test]
 fn test_filter_clear_on_start() -> Result<(), Error> {
@@ -42,14 +47,20 @@ pub struct FilterClearOnStartTest;
 
 impl TestOverrides for FilterClearOnStartTest {
     fn modify_relayer_config(&self, config: &mut Config) {
+        let mut excluded_sequences = BTreeMap::new();
+        excluded_sequences.insert(ChannelId::new(2), vec![2.into()]);
         let chain_a = &mut config.chains[0];
         match chain_a {
             ChainConfig::CosmosSdk(chain_config) => {
-                chain_config.excluded_sequences = vec![2.into()];
+                chain_config.excluded_sequences = excluded_sequences;
             }
         }
+        config.mode.channels.enabled = true;
+
         config.mode.packets.clear_on_start = true;
         config.mode.packets.clear_interval = 0;
+
+        config.mode.clients.misbehaviour = false;
     }
 
     fn should_spawn_supervisor(&self) -> bool {
@@ -73,14 +84,20 @@ pub struct FilterClearIntervalTest;
 
 impl TestOverrides for FilterClearIntervalTest {
     fn modify_relayer_config(&self, config: &mut Config) {
+        let mut excluded_sequences = BTreeMap::new();
+        excluded_sequences.insert(ChannelId::new(2), vec![2.into()]);
         let chain_a = &mut config.chains[0];
         match chain_a {
             ChainConfig::CosmosSdk(chain_config) => {
-                chain_config.excluded_sequences = vec![2.into()];
+                chain_config.excluded_sequences = excluded_sequences;
             }
         }
+        config.mode.channels.enabled = true;
+
         config.mode.packets.clear_on_start = false;
         config.mode.packets.clear_interval = 10;
+
+        config.mode.clients.misbehaviour = false;
     }
 
     fn should_spawn_supervisor(&self) -> bool {
@@ -104,8 +121,12 @@ pub struct ClearNoFilterTest;
 
 impl TestOverrides for ClearNoFilterTest {
     fn modify_relayer_config(&self, config: &mut Config) {
+        config.mode.channels.enabled = true;
+
         config.mode.packets.clear_on_start = true;
         config.mode.packets.clear_interval = 0;
+
+        config.mode.clients.misbehaviour = false;
     }
 
     fn should_spawn_supervisor(&self) -> bool {
@@ -222,10 +243,12 @@ pub struct StandardRelayingNoFilterTest;
 
 impl TestOverrides for StandardRelayingNoFilterTest {
     fn modify_relayer_config(&self, config: &mut Config) {
+        let mut excluded_sequences = BTreeMap::new();
+        excluded_sequences.insert(ChannelId::new(2), vec![2.into()]);
         let chain_a = &mut config.chains[0];
         match chain_a {
             ChainConfig::CosmosSdk(chain_config) => {
-                chain_config.excluded_sequences = vec![2.into()];
+                chain_config.excluded_sequences = excluded_sequences;
             }
         }
         config.mode.packets.clear_on_start = true;
@@ -345,68 +368,131 @@ fn run_sequence_filter_test<ChainA: ChainHandle, ChainB: ChainHandle>(
     chains: ConnectedChains<ChainA, ChainB>,
     channels: ConnectedChannel<ChainA, ChainB>,
 ) -> Result<(), Error> {
+    let (channel_id_a_2, channel_id_b_2, channel_b_2) = relayer.with_supervisor(|| {
+        // During test bootstrap channel padding initialises a channel with ID 0.
+        // Before creating the new channel with sequence filter, complete the handshake of
+        // the pad channel in order to insure that the retrieved channel IDs `channel_id_a_2` and
+        // `channel_id_b_2` are `channel-2`
+        let pad_channel_id = DualTagged::new(ChannelId::new(0));
+        let _ = assert_eventually_channel_established(
+            chains.handle_b(),
+            chains.handle_a(),
+            &pad_channel_id.as_ref(),
+            &channels.port_b.as_ref(),
+        )?;
+        let (channel_id_b_2, channel_b_2) = init_channel(
+            chains.handle_a(),
+            chains.handle_b(),
+            &chains.client_id_a(),
+            &chains.client_id_b(),
+            &channels.connection.connection_id_a.as_ref(),
+            &channels.connection.connection_id_b.as_ref(),
+            &channels.port_a.as_ref(),
+            &channels.port_b.as_ref(),
+        )?;
+
+        let channel_id_a_2 = assert_eventually_channel_established(
+            chains.handle_b(),
+            chains.handle_a(),
+            &channel_id_b_2.as_ref(),
+            &channels.port_b.as_ref(),
+        )?;
+        Ok((channel_id_a_2, channel_id_b_2, channel_b_2))
+    })?;
+
     let denom_a = chains.node_a.denom();
-    let denom_a_to_b = derive_ibc_denom(
+    let denom_a_to_b_1 = derive_ibc_denom(
         &channels.port_b.as_ref(),
         &channels.channel_id_b.as_ref(),
         &denom_a,
     )?;
+    let denom_a_to_b_2 = derive_ibc_denom(
+        &channels.port_b.as_ref(),
+        &channel_id_b_2.as_ref(),
+        &denom_a,
+    )?;
     let denom_b = chains.node_b.denom();
-    let denom_b_to_a = derive_ibc_denom(
+    let denom_b_to_a_1 = derive_ibc_denom(
         &channels.port_a.as_ref(),
         &channels.channel_id_a.as_ref(),
         &denom_b,
     )?;
+    let denom_b_to_a_2 = derive_ibc_denom(
+        &channels.port_a.as_ref(),
+        &channel_id_a_2.as_ref(),
+        &denom_b,
+    )?;
 
-    let wallet_a = chains.node_a.wallets().user1().cloned();
-    let wallet_b = chains.node_b.wallets().user1().cloned();
+    let wallet_a_1 = chains.node_a.wallets().user1().cloned();
+    let wallet_a_2 = chains.node_a.wallets().user2().cloned();
+    let wallet_b_1 = chains.node_b.wallets().user1().cloned();
+    let wallet_b_2 = chains.node_b.wallets().user2().cloned();
 
     let a_to_b_amount = 12345u64;
     let b_to_a_amount = 54321u64;
 
-    let balance_a = chains
+    let balance_a_1 = chains
         .node_a
         .chain_driver()
-        .query_balance(&wallet_a.address(), &denom_a)?;
+        .query_balance(&wallet_a_1.address(), &denom_a)?;
 
-    let balance_b = chains
+    let balance_b_1 = chains
         .node_b
         .chain_driver()
-        .query_balance(&wallet_b.address(), &denom_b)?;
+        .query_balance(&wallet_b_1.address(), &denom_b)?;
 
-    // Create a pending transfer from A to B with sequence 1
-    chains.node_a.chain_driver().ibc_transfer_token(
+    let balance_a_2 = chains
+        .node_a
+        .chain_driver()
+        .query_balance(&wallet_a_2.address(), &denom_a)?;
+
+    let balance_b_2 = chains
+        .node_b
+        .chain_driver()
+        .query_balance(&wallet_b_2.address(), &denom_b)?;
+
+    // Double transfer from A to B on channel with filter
+    double_transfer(
+        chains.node_a.chain_driver(),
         &channels.port_a.as_ref(),
         &channels.channel_id_a.as_ref(),
-        &wallet_a.as_ref(),
-        &wallet_b.address(),
+        &wallet_a_1.as_ref(),
+        &wallet_b_1.address(),
         &denom_a.with_amount(a_to_b_amount).as_ref(),
     )?;
 
-    // Create a pending transfer from A to B with sequence 2
-    chains.node_a.chain_driver().ibc_transfer_token(
-        &channels.port_a.as_ref(),
-        &channels.channel_id_a.as_ref(),
-        &wallet_a.as_ref(),
-        &wallet_b.address(),
+    let port_b_2: DualTagged<ChainB, ChainA, &PortId> =
+        DualTagged::new(channel_b_2.a_side.port_id());
+    let port_a_2: DualTagged<ChainA, ChainB, PortId> =
+        DualTagged::new(channel_b_2.clone().flipped().a_side.port_id().clone());
+
+    // Double transfer from A to B on channel without filter
+    double_transfer(
+        chains.node_a.chain_driver(),
+        &port_a_2.as_ref(),
+        &channel_id_a_2.as_ref(),
+        &wallet_a_2.as_ref(),
+        &wallet_b_2.address(),
         &denom_a.with_amount(a_to_b_amount).as_ref(),
     )?;
 
-    // Create a pending transfer from B to A with sequence 1
-    chains.node_b.chain_driver().ibc_transfer_token(
+    // Double transfer from B to A on channel with filter
+    double_transfer(
+        chains.node_b.chain_driver(),
         &channels.port_b.as_ref(),
         &channels.channel_id_b.as_ref(),
-        &wallet_b.as_ref(),
-        &wallet_a.address(),
+        &wallet_b_1.as_ref(),
+        &wallet_a_1.address(),
         &denom_b.with_amount(b_to_a_amount).as_ref(),
     )?;
 
-    // Create a pending transfer from B to A with sequence 2
-    chains.node_b.chain_driver().ibc_transfer_token(
-        &channels.port_b.as_ref(),
-        &channels.channel_id_b.as_ref(),
-        &wallet_b.as_ref(),
-        &wallet_a.address(),
+    // Double transfer from B to A on channel without filter
+    double_transfer(
+        chains.node_b.chain_driver(),
+        &port_b_2,
+        &channel_id_b_2.as_ref(),
+        &wallet_b_2.as_ref(),
+        &wallet_a_2.address(),
         &denom_b.with_amount(b_to_a_amount).as_ref(),
     )?;
 
@@ -414,29 +500,70 @@ fn run_sequence_filter_test<ChainA: ChainHandle, ChainB: ChainHandle>(
         info!("Assert that the send from A escrowed tokens for both transfers");
 
         chains.node_a.chain_driver().assert_eventual_wallet_amount(
-            &wallet_a.address(),
-            &(balance_a - 2 * a_to_b_amount).as_ref(),
+            &wallet_a_1.address(),
+            &(balance_a_1 - 2 * a_to_b_amount).as_ref(),
         )?;
-
-        info!("Assert that only the first transfer A to B was cleared");
-
-        chains.node_b.chain_driver().assert_eventual_wallet_amount(
-            &wallet_b.address(),
-            &denom_a_to_b.with_amount(a_to_b_amount).as_ref(),
-        )?;
-        info!("Assert that the sender from B escrowed tokens for both transfers");
-
-        chains.node_b.chain_driver().assert_eventual_wallet_amount(
-            &wallet_b.address(),
-            &(balance_b - 2 * b_to_a_amount).as_ref(),
-        )?;
-
-        info!("Assert that both transfers from B to A were cleared");
 
         chains.node_a.chain_driver().assert_eventual_wallet_amount(
-            &wallet_a.address(),
-            &denom_b_to_a.with_amount(2 * b_to_a_amount).as_ref(),
+            &wallet_a_2.address(),
+            &(balance_a_2 - 2 * a_to_b_amount).as_ref(),
         )?;
+
+        info!("Assert that only the first transfer A to B was cleared on channel with filter");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b_2.address(),
+            &denom_a_to_b_2.with_amount(a_to_b_amount).as_ref(),
+        )?;
+
+        info!("Assert that both transfer A to B were cleared on channel without filter");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b_1.address(),
+            &denom_a_to_b_1.with_amount(2 * a_to_b_amount).as_ref(),
+        )?;
+
+        info!("Assert that the sender from B escrowed tokens for both transfers on both channels");
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b_1.address(),
+            &(balance_b_1 - 2 * b_to_a_amount).as_ref(),
+        )?;
+
+        chains.node_b.chain_driver().assert_eventual_wallet_amount(
+            &wallet_b_2.address(),
+            &(balance_b_2 - 2 * b_to_a_amount).as_ref(),
+        )?;
+
+        info!("Assert that both transfers from B to A were cleared on both channels");
+
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a_1.address(),
+            &denom_b_to_a_1.with_amount(2 * b_to_a_amount).as_ref(),
+        )?;
+
+        chains.node_a.chain_driver().assert_eventual_wallet_amount(
+            &wallet_a_2.address(),
+            &denom_b_to_a_2.with_amount(2 * b_to_a_amount).as_ref(),
+        )?;
+
         Ok(())
     })
+}
+
+fn double_transfer<Chain: ChainHandle, Counterparty: ChainHandle>(
+    chain_driver: MonoTagged<Chain, &ChainDriver>,
+    port_id: &TaggedPortIdRef<Chain, Counterparty>,
+    channel_id: &TaggedChannelIdRef<Chain, Counterparty>,
+    sender: &MonoTagged<Chain, &Wallet>,
+    recipient: &MonoTagged<Counterparty, &WalletAddress>,
+    token: &TaggedTokenRef<Chain>,
+) -> Result<(), Error> {
+    // Create a pending transfer from B to A with sequence 1
+    chain_driver.ibc_transfer_token(port_id, channel_id, sender, recipient, token)?;
+
+    // Create a pending transfer from B to A with sequence 2
+    chain_driver.ibc_transfer_token(port_id, channel_id, sender, recipient, token)?;
+
+    Ok(())
 }

--- a/tools/test-framework/src/types/single/node.rs
+++ b/tools/test-framework/src/types/single/node.rs
@@ -196,6 +196,7 @@ impl FullNode {
             sequential_batch_tx: false,
             compat_mode,
             clear_interval: None,
+            excluded_sequences: Vec::new(),
         }))
     }
 

--- a/tools/test-framework/src/types/single/node.rs
+++ b/tools/test-framework/src/types/single/node.rs
@@ -13,6 +13,7 @@ use ibc_relayer::config::dynamic_gas::DynamicGasPrice;
 use ibc_relayer::config::gas_multiplier::GasMultiplier;
 use ibc_relayer::keyring::Store;
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
+use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 use tendermint_rpc::Url;
 use tendermint_rpc::WebSocketClientUrl;
@@ -196,7 +197,7 @@ impl FullNode {
             sequential_batch_tx: false,
             compat_mode,
             clear_interval: None,
-            excluded_sequences: Vec::new(),
+            excluded_sequences: BTreeMap::new(),
         }))
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3754

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR adds a per-chain configuration `excluded_sequences` that can be used to specify which packet sequences should not be cleared when clearing is triggered.

This filter is only applied to pending packets cleared, standard relaying is not affected by the filter.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
