### PR TITLE
Fix `clear packets` CLI bug where `counterparty_channel_id` cannot be found

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer-cli/3889-clear-packet-cli-fix.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer-cli/3889-clear-packet-cli-fix.md
@@ -1,0 +1,3 @@
+- Correctly use the counterparty channel and port IDs when clearing the packets
+  from the destination chain to the source chain in the `packet clear` command
+  ([\#3889](https://github.com/informalsystems/hermes/issues/3889))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3889

## Description

This PR fixes the bug with the `clear packets` CLI by using the correct counterparty channel and port IDs.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
