### PR TITLE
Proceed to next block after a few retries if Hermes can't parse current block during event sourcing

### DIFF
--- a/.changelog/unreleased/features/3894-continue-event-sourcing.md
+++ b/.changelog/unreleased/features/3894-continue-event-sourcing.md
@@ -1,2 +1,0 @@
-- Proceed to next block if it can't parse current block during event sourcing
-  ([\#3894](https://github.com/informalsystems/hermes/issues/3894))

--- a/.changelog/unreleased/features/3894-continue-event-sourcing.md
+++ b/.changelog/unreleased/features/3894-continue-event-sourcing.md
@@ -1,0 +1,2 @@
+- Proceed to next block if it can't parse current block during event sourcing
+  ([\#3894](https://github.com/informalsystems/hermes/issues/3894))

--- a/.changelog/unreleased/features/ibc-relayer/3894-continue-event-sourcing.md
+++ b/.changelog/unreleased/features/ibc-relayer/3894-continue-event-sourcing.md
@@ -1,0 +1,6 @@
+- Improve reliabily of event source in `pull` mode by proceeding to next block even if Hermes cannot parse the current block.
+  Add new configuration option to `event_source` setting: `max_retries` defines how many times Hermes should attempt to pull a block over RPC.
+  ```toml
+  event_source = { mode = 'pull', interval = '1s', max_retries = 4 }
+  ```
+  ([\#3894](https://github.com/informalsystems/hermes/issues/3894))

--- a/config.toml
+++ b/config.toml
@@ -189,11 +189,12 @@ grpc_addr = 'http://127.0.0.1:9090'
 
 # b) Pull: for polling for IBC events via the `/block_results` RPC endpoint.
 #
-#     `{ mode = 'pull', interval = '1s' }`
+#     `{ mode = 'pull', interval = '1s', max_retries = 4 }`
 #
 #    where
 #
 #    - `interval` is the interval at which to poll for blocks. Default: 1s
+#    - `max_retries` is the maximum number of retries to collect events for each block. Default: 4
 #
 #    This mode should only be used in situations where Hermes misses events that it should be
 #    receiving, such as when relaying for CosmWasm-enabled chains which emit IBC events without

--- a/crates/relayer-cli/src/commands/listen.rs
+++ b/crates/relayer-cli/src/commands/listen.rs
@@ -156,10 +156,14 @@ fn subscribe(
                     *batch_delay,
                     rt,
                 ),
-                EventSourceMode::Pull { interval } => EventSource::rpc(
+                EventSourceMode::Pull {
+                    interval,
+                    max_retries,
+                } => EventSource::rpc(
                     chain_config.id().clone(),
                     HttpClient::new(config.rpc_addr.clone())?,
                     *interval,
+                    *max_retries,
                     rt,
                 ),
             }?;

--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -335,10 +335,14 @@ impl CosmosSdkChain {
                 *batch_delay,
                 self.rt.clone(),
             ),
-            Mode::Pull { interval } => EventSource::rpc(
+            Mode::Pull {
+                interval,
+                max_retries,
+            } => EventSource::rpc(
                 self.config.id.clone(),
                 self.rpc_client.clone(),
                 *interval,
+                *max_retries,
                 self.rt.clone(),
             ),
         }

--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -178,6 +178,10 @@ pub mod default {
         Duration::from_secs(1)
     }
 
+    pub fn max_retries() -> u32 {
+        4
+    }
+
     pub fn batch_delay() -> Duration {
         Duration::from_millis(500)
     }
@@ -622,6 +626,11 @@ pub enum EventSourceMode {
         /// The polling interval
         #[serde(default = "default::poll_interval", with = "humantime_serde")]
         interval: Duration,
+
+        /// The maximum retries to collect the block results
+        /// before giving up and moving to the next block
+        #[serde(default = "default::max_retries")]
+        max_retries: u32,
     },
 }
 

--- a/crates/relayer/src/event/source.rs
+++ b/crates/relayer/src/event/source.rs
@@ -47,9 +47,11 @@ impl EventSource {
         chain_id: ChainId,
         rpc_client: HttpClient,
         poll_interval: Duration,
+        max_retries: u32,
         rt: Arc<TokioRuntime>,
     ) -> Result<(Self, TxEventSourceCmd)> {
-        let (source, tx) = rpc::EventSource::new(chain_id, rpc_client, poll_interval, rt)?;
+        let (source, tx) =
+            rpc::EventSource::new(chain_id, rpc_client, poll_interval, max_retries, rt)?;
         Ok((Self::Rpc(source), tx))
     }
 

--- a/crates/relayer/src/event/source/rpc.rs
+++ b/crates/relayer/src/event/source/rpc.rs
@@ -214,10 +214,11 @@ impl EventSource {
             loop {
                 match collect_events(&self.rpc_client, &self.chain_id, height).await {
                     Ok(batch) => {
+                        self.last_fetched_height = height;
+
                         if let Some(batch) = batch {
                             batches.push(batch);
                         }
-                        self.last_fetched_height = height;
                         break;
                     }
                     Err(e) if attempts < self.max_retries => {

--- a/crates/relayer/src/event/source/rpc.rs
+++ b/crates/relayer/src/event/source/rpc.rs
@@ -216,6 +216,8 @@ impl EventSource {
             self.last_fetched_height = height;
 
             loop {
+                attempts += 1;
+
                 match collect_events(&self.rpc_client, &self.chain_id, height).await {
                     Ok(batch) => {
                         if let Some(batch) = batch {
@@ -231,7 +233,6 @@ impl EventSource {
 
                             error!(%height, "failed to collect events: {e}, retrying in {delay:?}...");
                             sleep(delay).await;
-                            attempts += 1;
                         }
 
                         _ => {

--- a/crates/relayer/src/event/source/rpc.rs
+++ b/crates/relayer/src/event/source/rpc.rs
@@ -269,7 +269,7 @@ fn poll_backoff(poll_interval: Duration) -> impl Iterator<Item = Duration> {
 
 fn retries_backoff(collect_retries: u32) -> impl Iterator<Item = Duration> {
     ConstantGrowth::new(Duration::from_secs(1), Duration::from_millis(500))
-        .clamp(Duration::from_secs(1) * 4, collect_retries as usize)
+        .clamp(Duration::from_secs(4), collect_retries as usize)
 }
 
 fn dedupe(events: Vec<abci::Event>) -> Vec<abci::Event> {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3894 

## Description
* In the case of chains that are modified part of cosmos-sdk, Hermes may not be able to interpret a particular block, so in this case, instead of staying in that block, Hermes should move on to the next block.
* It may be a temporary network failure, so retry in `fetch_batches` loop as much as we set it in advance and then move on to the next block.

c.c. @romac 
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
