### PR TITLE
Update release-template to consistently notify comms team

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -20,4 +20,4 @@ v                     without deliberation
 - [ ] Create a new release in the changelog, using [`unclog`](https://github.com/informalsystems/unclog)
   - If doing a release candidate (`rc`) version, then skip the `unclog release` step
 - [ ] Reassign unfinished issues of previous milestone to the next milestone
-- [ ] Notify the comms team about the pending new release and [prepare a message](https://www.notion.so/informalsystems/Communications-pipeline-b8c0eeb71dc24203a048fa6ccf189e1a?pvs=4) to announce it
+- [ ] Notify the comms team about the pending new release by tagging [@isa-belch](https://github.com/isa-belch) as a reviewer here


### PR DESCRIPTION
Trying to find a way for the marketing/comms team to get early notification, consistently, that a new release will happen.

@romac or Luca (not tagging b/c of holidays) if you prefer other approaches then happy to go with something else.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
