### PR TITLE
Use `packet_ack_hex` event attribute instead of deprecated `packet_ack` attribute to decode `WriteAck` event

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/3921-packet-ack-hex.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/3921-packet-ack-hex.md
@@ -1,0 +1,2 @@
+- Use `packet_ack_hex` event attribute instead of deprecated `packet_ack` attribute to decode `WriteAck` event
+  ([\#3921](https://github.com/informalsystems/hermes/issues/3921))

--- a/crates/relayer-types/src/core/ics04_channel/error.rs
+++ b/crates/relayer-types/src/core/ics04_channel/error.rs
@@ -199,6 +199,14 @@ define_error! {
                 format_args!("Invalid packet data, not a valid hex-encoded string: {}", e.data)
             },
 
+        InvalidPacketAck
+            {
+                ack: String,
+            }
+            | e | {
+                format_args!("Invalid packet ack, not a valid hex-encoded string: {}", e.ack)
+            },
+
         LowPacketHeight
             {
                 chain_height: Height,

--- a/crates/relayer-types/src/core/ics04_channel/events.rs
+++ b/crates/relayer-types/src/core/ics04_channel/events.rs
@@ -29,7 +29,7 @@ pub const PKT_DST_PORT_ATTRIBUTE_KEY: &str = "packet_dst_port";
 pub const PKT_DST_CHANNEL_ATTRIBUTE_KEY: &str = "packet_dst_channel";
 pub const PKT_TIMEOUT_HEIGHT_ATTRIBUTE_KEY: &str = "packet_timeout_height";
 pub const PKT_TIMEOUT_TIMESTAMP_ATTRIBUTE_KEY: &str = "packet_timeout_timestamp";
-pub const PKT_ACK_ATTRIBUTE_KEY: &str = "packet_ack";
+pub const PKT_ACK_ATTRIBUTE_KEY: &str = "packet_ack_hex";
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct Attributes {

--- a/crates/relayer-types/src/events.rs
+++ b/crates/relayer-types/src/events.rs
@@ -69,6 +69,10 @@ define_error! {
             { data: String }
             | e | { format_args!("error decoding hex-encoded packet data: {}", e.data) },
 
+        InvalidPacketAck
+            { ack: String }
+            | e | { format_args!("error decoding hex-encoded packet ack: {}", e.ack) },
+
         MissingActionString
             | _ | { "missing action string" },
 

--- a/crates/relayer/src/chain/cosmos/types/events/channel.rs
+++ b/crates/relayer/src/chain/cosmos/types/events/channel.rs
@@ -85,8 +85,11 @@ impl TryFrom<RawObject<'_>> for WriteAcknowledgement {
     type Error = EventError;
 
     fn try_from(obj: RawObject<'_>) -> Result<Self, Self::Error> {
-        let ack = extract_attribute(&obj, &format!("{}.{}", obj.action, PKT_ACK_ATTRIBUTE_KEY))?
-            .into_bytes();
+        let ack_str =
+            extract_attribute(&obj, &format!("{}.{}", obj.action, PKT_ACK_ATTRIBUTE_KEY))?;
+
+        let ack = hex::decode(ack_str.to_lowercase())
+            .map_err(|_| EventError::invalid_packet_ack(ack_str))?;
 
         let packet = Packet::try_from(obj)?;
 

--- a/crates/relayer/src/event.rs
+++ b/crates/relayer/src/event.rs
@@ -438,7 +438,8 @@ pub fn extract_packet_and_write_ack_from_tx(
                     .map_err(|_| ChannelError::invalid_packet_data(value.to_string()))?;
             }
             channel_events::PKT_ACK_ATTRIBUTE_KEY => {
-                write_ack = Vec::from(value.as_bytes());
+                write_ack = hex::decode(value.to_lowercase())
+                    .map_err(|_| ChannelError::invalid_packet_ack(value.to_string()))?;
             }
             _ => {}
         }


### PR DESCRIPTION
Closes: #3921

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
