### PR TITLE
Fix bug where only first CCQ event was extracted

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/3954-interchainquery-missed-events.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/3954-interchainquery-missed-events.md
@@ -1,0 +1,3 @@
+- Correctly extract all `interchainquery` events if
+  there are more than one emitted at the same time
+  ([\#3954](https://github.com/informalsystems/hermes/issues/3954))

--- a/.changelog/unreleased/bug-fixes/ibc-relayer/3954-interchainquery-missed-events.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/3954-interchainquery-missed-events.md
@@ -1,3 +1,2 @@
-- Correctly extract all `interchainquery` events if
-  there are more than one emitted at the same time
+- Fix a bug where Hermes would only ever extract the first emitted ICS 031 CrossChain Query event, which would cause it to miss the other CCQ events.
   ([\#3954](https://github.com/informalsystems/hermes/issues/3954))

--- a/ci/misbehaviour/create_fork.sh
+++ b/ci/misbehaviour/create_fork.sh
@@ -50,7 +50,7 @@ sconfig data/ibc-1-f/config/config.toml "rpc.laddr=tcp://0.0.0.0:26457"
 sconfig data/ibc-1-f/config/config.toml "p2p.laddr=tcp://0.0.0.0:26456"
 
 info "Starting ibc-1..."
-gaiad --home ./data/ibc-1 start --pruning=nothing --grpc.address=0.0.0.0:9091 --log_level error > data/ibc-1.log 2>&1 &
+gaiad --home ./data/ibc-1 start --pruning=nothing --rpc.laddr="tcp://0.0.0.0:26557" --grpc.address=0.0.0.0:9091 --log_level error > data/ibc-1.log 2>&1 &
 
 info "Starting ibc-1 fork..."
-gaiad --home ./data/ibc-1-f start --pruning=nothing --grpc.address=0.0.0.0:9092 --log_level error > data/ibc-1-f.log 2>&1 &
+gaiad --home ./data/ibc-1-f start --pruning=nothing --rpc.laddr="tcp://0.0.0.0:26457" --grpc.address=0.0.0.0:9092 --log_level error > data/ibc-1-f.log 2>&1 &

--- a/crates/relayer/src/chain/cosmos/types/events/channel.rs
+++ b/crates/relayer/src/chain/cosmos/types/events/channel.rs
@@ -1,5 +1,6 @@
 use alloc::collections::btree_map::BTreeMap as HashMap;
 
+use ibc_relayer_types::applications::ics31_icq::events::CrossChainQueryPacket;
 use ibc_relayer_types::core::ics02_client::height::HeightErrorDetail;
 use ibc_relayer_types::core::ics04_channel::error::Error;
 use ibc_relayer_types::core::ics04_channel::events::{
@@ -12,6 +13,7 @@ use ibc_relayer_types::core::ics04_channel::events::{
 use ibc_relayer_types::core::ics04_channel::events::{ReceivePacket, TimeoutOnClosePacket};
 use ibc_relayer_types::core::ics04_channel::packet::Packet;
 use ibc_relayer_types::core::ics04_channel::timeout::TimeoutHeight;
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 use ibc_relayer_types::events::Error as EventError;
 use ibc_relayer_types::Height;
 
@@ -172,6 +174,28 @@ impl TryFrom<RawObject<'_>> for Packet {
             )?
             .parse()
             .map_err(EventError::timestamp)?,
+        })
+    }
+}
+
+impl TryFrom<RawObject<'_>> for CrossChainQueryPacket {
+    type Error = EventError;
+
+    fn try_from(obj: RawObject<'_>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            module: extract_attribute(&obj, &format!("{}.module", obj.action))?,
+            action: extract_attribute(&obj, &format!("{}.action", obj.action))?,
+            query_id: extract_attribute(&obj, &format!("{}.query_id", obj.action))?,
+            chain_id: extract_attribute(&obj, &format!("{}.chain_id", obj.action))
+                .map(|s| ChainId::from_string(&s))?,
+            connection_id: extract_attribute(&obj, &format!("{}.connection_id", obj.action))?
+                .parse()
+                .map_err(EventError::parse)?,
+            query_type: extract_attribute(&obj, &format!("{}.type", obj.action))?,
+            request: extract_attribute(&obj, &format!("{}.request", obj.action))?,
+            height: extract_attribute(&obj, &format!("{}.height", obj.action))?
+                .parse()
+                .map_err(|_| EventError::height())?,
         })
     }
 }

--- a/crates/relayer/src/error.rs
+++ b/crates/relayer/src/error.rs
@@ -520,6 +520,10 @@ define_error! {
             { address: String }
             |e| { format!("Query/Account RPC returned an empty account for address: {}", e.address) },
 
+        EmptyProposal
+            { proposal_id: String }
+            |e| { format!("Query/Proposal RPC returned an empty proposal for proposal id: {}", e.proposal_id) },
+
         NoHistoricalEntries
             { chain_id: ChainId }
             |e| {

--- a/crates/relayer/src/event/source/rpc/extract.rs
+++ b/crates/relayer/src/event/source/rpc/extract.rs
@@ -1,6 +1,6 @@
-use ibc_relayer_types::applications::ics29_fee::events::DistributionType;
 use tendermint::abci;
 
+use ibc_relayer_types::applications::ics29_fee::events::DistributionType;
 use ibc_relayer_types::core::ics02_client::height::Height;
 use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 use ibc_relayer_types::events::IbcEvent;

--- a/crates/relayer/src/event/source/websocket/extract.rs
+++ b/crates/relayer/src/event/source/websocket/extract.rs
@@ -1,6 +1,7 @@
 use alloc::collections::BTreeMap as HashMap;
 use ibc_relayer_types::applications::ics29_fee::events::DistributionType;
 
+use ibc_relayer_types::applications::ics31_icq;
 use tendermint_rpc::{event::Event as RpcEvent, event::EventData as RpcEventData};
 
 use ibc_relayer_types::applications::ics31_icq::events::CrossChainQueryPacket;
@@ -328,14 +329,17 @@ fn extract_block_events(
         extract_events(height, block_events, "channel_close_confirm", "channel_id"),
         height,
     );
-    // extract cross chain query event from block_events
-    if let Ok(ccqs) = CrossChainQueryPacket::extract_query_event(block_events) {
-        let mut ccqs_with_height = ccqs
-            .iter()
-            .map(|ccq| IbcEventWithHeight::new(ccq.clone(), height))
-            .collect::<Vec<IbcEventWithHeight>>();
-        events.append(&mut ccqs_with_height);
-    }
+
+    append_events::<CrossChainQueryPacket>(
+        &mut events,
+        extract_events(
+            height,
+            block_events,
+            ics31_icq::events::EVENT_TYPE_PREFIX,
+            "query_id",
+        ),
+        height,
+    );
 
     events
 }

--- a/crates/relayer/src/event/source/websocket/extract.rs
+++ b/crates/relayer/src/event/source/websocket/extract.rs
@@ -329,8 +329,12 @@ fn extract_block_events(
         height,
     );
     // extract cross chain query event from block_events
-    if let Ok(ccq) = CrossChainQueryPacket::extract_query_event(block_events) {
-        events.push(IbcEventWithHeight::new(ccq, height));
+    if let Ok(ccqs) = CrossChainQueryPacket::extract_query_event(block_events) {
+        let mut ccqs_with_height = ccqs
+            .iter()
+            .map(|ccq| IbcEventWithHeight::new(ccq.clone(), height))
+            .collect::<Vec<IbcEventWithHeight>>();
+        events.append(&mut ccqs_with_height);
     }
 
     events

--- a/tools/integration-test/src/tests/client_upgrade.rs
+++ b/tools/integration-test/src/tests/client_upgrade.rs
@@ -32,6 +32,7 @@ const MAX_DEPOSIT_PERIOD: &str = "10s";
 const VOTING_PERIOD: u64 = 10;
 const DELTA_HEIGHT: u64 = 15;
 const WAIT_CHAIN_UPGRADE: Duration = Duration::from_secs(4);
+const WAIT_CHAIN_HEIGHT: Duration = Duration::from_secs(3);
 const MIN_DEPOSIT: u64 = 10000000u64;
 
 #[test]
@@ -134,15 +135,28 @@ impl BinaryChainTest for ClientUpgradeTest {
             "1",
         )?;
 
-        // Wait for the chain to upgrade
-        std::thread::sleep(WAIT_CHAIN_UPGRADE);
+        let halt_height = (client_upgrade_height - 1).unwrap();
+
+        // Wait for the chain to get to the halt height
+        loop {
+            let latest_height = chains.handle_a().query_latest_height()?;
+            info!("latest height: {latest_height}");
+
+            if latest_height >= halt_height {
+                break;
+            }
+            std::thread::sleep(WAIT_CHAIN_HEIGHT);
+        }
+        // Wait for an additional height which is required to fetch
+        // the header
+        std::thread::sleep(WAIT_CHAIN_HEIGHT);
 
         // Trigger the client upgrade
         // The error is ignored as the client state will be asserted afterwards.
         let _ = foreign_clients.client_a_to_b.upgrade(client_upgrade_height);
 
         // Wait to seconds before querying the client state
-        std::thread::sleep(Duration::from_secs(2));
+        std::thread::sleep(WAIT_CHAIN_UPGRADE);
 
         let (state, _) = chains.handle_b().query_client_state(
             QueryClientStateRequest {

--- a/tools/test-framework/src/chain/chain_type.rs
+++ b/tools/test-framework/src/chain/chain_type.rs
@@ -12,6 +12,7 @@ const PROVENANCE_HD_PATH: &str = "m/44'/505'/0'/0/0";
 #[derive(Clone, Debug)]
 pub enum ChainType {
     Cosmos,
+    Osmosis,
     Evmos,
     Provenance,
     Injective,
@@ -20,7 +21,7 @@ pub enum ChainType {
 impl ChainType {
     pub fn hd_path(&self) -> &str {
         match self {
-            Self::Cosmos => COSMOS_HD_PATH,
+            Self::Cosmos | Self::Osmosis => COSMOS_HD_PATH,
             Self::Evmos | Self::Injective => EVMOS_HD_PATH,
             Self::Provenance => PROVENANCE_HD_PATH,
         }
@@ -28,7 +29,7 @@ impl ChainType {
 
     pub fn chain_id(&self, prefix: &str, use_random_id: bool) -> ChainId {
         match self {
-            Self::Cosmos => {
+            Self::Cosmos | Self::Osmosis => {
                 if use_random_id {
                     ChainId::from_string(&format!("ibc-{}-{:x}", prefix, random_u32()))
                 } else {
@@ -47,6 +48,9 @@ impl ChainType {
         let json_rpc_port = random_unused_tcp_port();
         match self {
             Self::Cosmos | Self::Injective | Self::Provenance => {}
+            Self::Osmosis => {
+                res.push("--reject-config-defaults".to_owned());
+            }
             Self::Evmos => {
                 res.push("--json-rpc.address".to_owned());
                 res.push(format!("localhost:{json_rpc_port}"));
@@ -59,7 +63,7 @@ impl ChainType {
     pub fn extra_add_genesis_account_args(&self, chain_id: &ChainId) -> Vec<String> {
         let mut res = vec![];
         match self {
-            Self::Cosmos | Self::Evmos | Self::Provenance => {}
+            Self::Cosmos | Self::Osmosis | Self::Evmos | Self::Provenance => {}
             Self::Injective => {
                 res.push("--chain-id".to_owned());
                 res.push(format!("{chain_id}"));
@@ -70,7 +74,7 @@ impl ChainType {
 
     pub fn address_type(&self) -> AddressType {
         match self {
-            Self::Cosmos | Self::Provenance => AddressType::default(),
+            Self::Cosmos | Self::Osmosis | Self::Provenance => AddressType::default(),
             Self::Evmos => AddressType::Ethermint {
                 pk_type: "/ethermint.crypto.v1.ethsecp256k1.PubKey".to_string(),
             },
@@ -89,6 +93,7 @@ impl FromStr for ChainType {
             name if name.contains("evmosd") => Ok(ChainType::Evmos),
             name if name.contains("injectived") => Ok(ChainType::Injective),
             name if name.contains("provenanced") => Ok(ChainType::Provenance),
+            name if name.contains("osmosisd") => Ok(ChainType::Osmosis),
             _ => Ok(ChainType::Cosmos),
         }
     }

--- a/tools/test-framework/src/chain/cli/host_zone.rs
+++ b/tools/test-framework/src/chain/cli/host_zone.rs
@@ -31,7 +31,7 @@ pub fn register_host_zone(
             bech32_prefix,
             ibc_denom,
             channel_id,
-            "5",
+            "10",
             "false",
             "--from",
             sender,

--- a/tools/test-framework/src/chain/ext/crosschainquery.rs
+++ b/tools/test-framework/src/chain/ext/crosschainquery.rs
@@ -72,14 +72,13 @@ impl<'a, Chain: Send> CrossChainQueryMethodsExt<Chain> for MonoTagged<Chain, &'a
                 )?;
 
                 // Verify that the there are no more pending Cross Chain Queries.
-                if json::from_str::<json::Value>(&output)
+                if !json::from_str::<json::Value>(&output)
                     .map_err(handle_generic_error)?
                     .get("pending_queries")
                     .ok_or_else(|| eyre!("no pending cross chain queries"))?
                     .as_array()
                     .ok_or_else(|| eyre!("pending cross chain queries is not an array"))?
-                    .first()
-                    .is_some()
+                    .is_empty()
                 {
                     return Err(Error::generic(eyre!(
                         "Pending query has not been processed"

--- a/tools/test-framework/src/chain/ext/proposal.rs
+++ b/tools/test-framework/src/chain/ext/proposal.rs
@@ -70,10 +70,10 @@ pub async fn query_upgrade_proposal_height(
         .map(|r| r.into_inner())
         .map_err(|e| RelayerError::grpc_status(e, "query_upgrade_proposal_height".to_owned()))?;
 
-    // Querying for a balance might fail, i.e. if the account doesn't actually exist
+    // Querying for proposal might not exist if the proposal id is incorrect
     let proposal = response
         .proposal
-        .ok_or_else(|| RelayerError::empty_query_account(proposal_id.to_string()))?;
+        .ok_or_else(|| RelayerError::empty_proposal(proposal_id.to_string()))?;
 
     let proposal_content = proposal
         .content


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3954

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR fixes the bug where Hermes would only extract the first `interchainquery` if there are more than one in the RPC event.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
