### PR TITLE
Specify topology for n-ary chain tests

### DIFF
--- a/.changelog/unreleased/improvements/ibc-integration-test/4099-specify-topology-for-nary-tests.md
+++ b/.changelog/unreleased/improvements/ibc-integration-test/4099-specify-topology-for-nary-tests.md
@@ -1,0 +1,4 @@
+- Refactored the test-framework bootstrapping for n-ary chain tests
+  to utilize the specified topology.
+    * Currently, only linear and fully connected topologies are supported.
+  ([\#4038](https://github.com/informalsystems/hermes/issues/4038))

--- a/.changelog/unreleased/improvements/ibc-integration-test/4099-specify-topology-for-nary-tests.md
+++ b/.changelog/unreleased/improvements/ibc-integration-test/4099-specify-topology-for-nary-tests.md
@@ -1,4 +1,4 @@
 - Refactored the test-framework bootstrapping for n-ary chain tests
   to utilize the specified topology.
-    * Currently, only linear and fully connected topologies are supported.
+    * Currently, only linear, cyclic and fully connected topologies are supported.
   ([\#4038](https://github.com/informalsystems/hermes/issues/4038))

--- a/tools/integration-test/src/tests/forward/forward_hop_transfer.rs
+++ b/tools/integration-test/src/tests/forward/forward_hop_transfer.rs
@@ -53,7 +53,7 @@ impl NaryChannelTest<4> for IbcForwardHopTransferTest {
         chains: NaryConnectedChains<Handle, 4>,
         channels: NaryConnectedChannels<Handle, 4>,
     ) -> Result<(), Error> {
-        let connected_chains = chains.connected_chains_at::<0, 3>()?;
+        let connected_chains = chains.connected_chains_at::<0, 1>()?;
 
         let node_a = chains.full_node_at::<0>()?;
         let node_b = chains.full_node_at::<1>()?;
@@ -174,7 +174,7 @@ impl NaryChannelTest<4> for AtomicIbcForwardHopTransferTest {
         chains: NaryConnectedChains<Handle, 4>,
         channels: NaryConnectedChannels<Handle, 4>,
     ) -> Result<(), Error> {
-        let connected_chains = chains.connected_chains_at::<0, 3>()?;
+        let connected_chains = chains.connected_chains_at::<0, 1>()?;
 
         let node_a = chains.full_node_at::<0>()?;
         let node_b = chains.full_node_at::<1>()?;

--- a/tools/integration-test/src/tests/forward/forward_transfer.rs
+++ b/tools/integration-test/src/tests/forward/forward_transfer.rs
@@ -73,7 +73,7 @@ impl NaryChannelTest<3> for IbcForwardTransferTest {
         chains: NaryConnectedChains<Handle, 3>,
         channels: NaryConnectedChannels<Handle, 3>,
     ) -> Result<(), Error> {
-        let connected_chains = chains.connected_chains_at::<0, 2>()?;
+        let connected_chains = chains.connected_chains_at::<0, 1>()?;
 
         let node_a = chains.full_node_at::<0>()?;
         let node_b = chains.full_node_at::<1>()?;
@@ -176,7 +176,7 @@ impl NaryChannelTest<3> for MisspelledMemoFieldsIbcForwardTransferTest {
         chains: NaryConnectedChains<Handle, 3>,
         channels: NaryConnectedChannels<Handle, 3>,
     ) -> Result<(), Error> {
-        let connected_chains = chains.connected_chains_at::<0, 2>()?;
+        let connected_chains = chains.connected_chains_at::<0, 1>()?;
 
         let node_a = chains.full_node_at::<0>()?;
         let node_b = chains.full_node_at::<1>()?;
@@ -422,7 +422,7 @@ impl NaryChannelTest<3> for MisspelledMemoContentIbcForwardTransferTest {
         chains: NaryConnectedChains<Handle, 3>,
         channels: NaryConnectedChannels<Handle, 3>,
     ) -> Result<(), Error> {
-        let connected_chains = chains.connected_chains_at::<0, 2>()?;
+        let connected_chains = chains.connected_chains_at::<0, 1>()?;
 
         let node_a = chains.full_node_at::<0>()?;
         let node_b = chains.full_node_at::<1>()?;

--- a/tools/integration-test/src/tests/ternary_transfer.rs
+++ b/tools/integration-test/src/tests/ternary_transfer.rs
@@ -14,7 +14,7 @@ impl TestOverrides for TernaryIbcTransferTest {
     }
 
     fn topology(&self) -> Option<TopologyType> {
-        Some(TopologyType::Full)
+        Some(TopologyType::Cyclic)
     }
 }
 

--- a/tools/integration-test/src/tests/ternary_transfer.rs
+++ b/tools/integration-test/src/tests/ternary_transfer.rs
@@ -1,4 +1,5 @@
 use ibc_test_framework::prelude::*;
+use ibc_test_framework::types::topology::TopologyType;
 
 #[test]
 fn test_ternary_ibc_transfer() -> Result<(), Error> {
@@ -10,6 +11,10 @@ pub struct TernaryIbcTransferTest;
 impl TestOverrides for TernaryIbcTransferTest {
     fn modify_relayer_config(&self, config: &mut Config) {
         config.mode.clients.misbehaviour = false;
+    }
+
+    fn topology(&self) -> Option<TopologyType> {
+        Some(TopologyType::Full)
     }
 }
 

--- a/tools/test-framework/src/bootstrap/nary/chain.rs
+++ b/tools/test-framework/src/bootstrap/nary/chain.rs
@@ -22,10 +22,15 @@ use crate::types::topology::{bootstrap_topology, TopologyType};
 pub fn boostrap_chains_with_nodes<const SIZE: usize>(
     test_config: &TestConfig,
     full_nodes: [FullNode; SIZE],
+    topology_override: Option<TopologyType>,
     config_modifier: impl FnOnce(&mut Config),
 ) -> Result<(RelayerDriver, NaryConnectedChains<impl ChainHandle, SIZE>), Error> {
-    let (relayer, chains) =
-        boostrap_chains_with_any_nodes(test_config, full_nodes.into(), config_modifier)?;
+    let (relayer, chains) = boostrap_chains_with_any_nodes(
+        test_config,
+        full_nodes.into(),
+        topology_override,
+        config_modifier,
+    )?;
 
     Ok((relayer, chains.try_into()?))
 }
@@ -37,11 +42,16 @@ pub fn boostrap_chains_with_nodes<const SIZE: usize>(
 pub fn boostrap_chains_with_self_connected_node<const SIZE: usize>(
     test_config: &TestConfig,
     full_node: FullNode,
+    topology_override: Option<TopologyType>,
     config_modifier: impl FnOnce(&mut Config),
 ) -> Result<(RelayerDriver, NaryConnectedChains<impl ChainHandle, SIZE>), Error> {
     let full_nodes = vec![full_node; SIZE];
-    let (relayer, chains) =
-        boostrap_chains_with_any_nodes(test_config, full_nodes, config_modifier)?;
+    let (relayer, chains) = boostrap_chains_with_any_nodes(
+        test_config,
+        full_nodes,
+        topology_override,
+        config_modifier,
+    )?;
 
     Ok((relayer, chains.try_into()?))
 }
@@ -55,6 +65,7 @@ pub fn boostrap_chains_with_self_connected_node<const SIZE: usize>(
 pub fn boostrap_chains_with_any_nodes(
     test_config: &TestConfig,
     full_nodes: Vec<FullNode>,
+    topology_override: Option<TopologyType>,
     config_modifier: impl FnOnce(&mut Config),
 ) -> Result<(RelayerDriver, DynamicConnectedChains<impl ChainHandle>), Error> {
     let mut config = Config::default();
@@ -79,14 +90,18 @@ pub fn boostrap_chains_with_any_nodes(
     }
 
     // Retrieve the topology or fallback to the Linear topology
-    let topology_str = std::env::var("TOPOLOGY").unwrap_or_else(|_| "linear".to_owned());
-    let topology_type = match topology_str.parse() {
-        Ok(topology_type) => topology_type,
-        Err(_) => {
-            tracing::warn!(
-                "Failed to parse topology type `{topology_str}`. Will fallback to Linear topology"
-            );
-            TopologyType::Linear
+    let topology_type = if let Some(topology_type) = topology_override {
+        topology_type
+    } else {
+        let topology_str = std::env::var("TOPOLOGY").unwrap_or_else(|_| "linear".to_owned());
+        match topology_str.parse() {
+            Ok(topology_type) => topology_type,
+            Err(_) => {
+                tracing::warn!(
+                    "Failed to parse topology type `{topology_str}`. Will fallback to Linear topology"
+                );
+                TopologyType::Linear
+            }
         }
     };
     let topology = bootstrap_topology(topology_type);

--- a/tools/test-framework/src/bootstrap/nary/channel.rs
+++ b/tools/test-framework/src/bootstrap/nary/channel.rs
@@ -33,7 +33,7 @@ pub fn bootstrap_channels_with_connections_dynamic<Handle: ChainHandle>(
 ) -> Result<DynamicConnectedChannels<Handle>, Error> {
     let mut channels: TwoDimMap<ConnectedChannel<Handle, Handle>> = TwoDimMap::new();
 
-    for (src_chain, dst_chain, connection, _) in connections.connections().iter() {
+    for (src_chain, dst_chain, connection) in connections.connections().iter() {
         let channel = if let Some(counterparty_channel) = channels.get((dst_chain, src_chain)) {
             counterparty_channel.clone().flip()
         } else {

--- a/tools/test-framework/src/bootstrap/nary/channel.rs
+++ b/tools/test-framework/src/bootstrap/nary/channel.rs
@@ -7,7 +7,7 @@ use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer_types::core::ics04_channel::channel::Ordering;
 use ibc_relayer_types::core::ics24_host::identifier::PortId;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::bootstrap::binary::channel::{
     bootstrap_channel_with_connection, BootstrapChannelOptions,
@@ -32,11 +32,11 @@ pub fn bootstrap_channels_with_connections_dynamic<Handle: ChainHandle>(
     order: Ordering,
     bootstrap_with_random_ids: bool,
 ) -> Result<DynamicConnectedChannels<Handle>, Error> {
-    let mut channels: HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>> =
-        HashMap::new();
+    let mut channels: BTreeMap<usize, BTreeMap<usize, ConnectedChannel<Handle, Handle>>> =
+        BTreeMap::new();
 
-    for inner_connections in connections.connections().iter() {
-        let mut inner_channels: HashMap<usize, ConnectedChannel<Handle, Handle>> = HashMap::new();
+    for inner_connections in connections.connections().map.iter() {
+        let mut inner_channels: BTreeMap<usize, ConnectedChannel<Handle, Handle>> = BTreeMap::new();
 
         for connection in inner_connections.1.iter() {
             let channel = if let Some(counterparty_channels) = channels.get(connection.0) {
@@ -76,7 +76,7 @@ pub fn bootstrap_channels_with_connections_dynamic<Handle: ChainHandle>(
         channels.insert(*inner_connections.0, inner_channels);
     }
 
-    Ok(DynamicConnectedChannels::new(channels))
+    Ok(DynamicConnectedChannels::new(channels.into()))
 }
 
 /**

--- a/tools/test-framework/src/bootstrap/nary/channel.rs
+++ b/tools/test-framework/src/bootstrap/nary/channel.rs
@@ -3,9 +3,11 @@
 */
 
 use core::time::Duration;
+use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer_types::core::ics04_channel::channel::Ordering;
 use ibc_relayer_types::core::ics24_host::identifier::PortId;
+use std::collections::HashMap;
 
 use crate::bootstrap::binary::channel::{
     bootstrap_channel_with_connection, BootstrapChannelOptions,
@@ -17,60 +19,61 @@ use crate::types::nary::chains::{DynamicConnectedChains, NaryConnectedChains};
 use crate::types::nary::channel::{ConnectedChannels, DynamicConnectedChannels};
 use crate::types::nary::connection::{ConnectedConnections, DynamicConnectedConnections};
 use crate::types::tagged::*;
-use crate::util::array::{assert_same_dimension, into_nested_vec};
+use crate::util::array::into_nested_vec;
 
 /**
    Bootstrap a dynamic number of channels based on the number of
    connections in `DynamicConnectedConnections`.
+   See [`crate::types::topology`] for more information.
 */
 pub fn bootstrap_channels_with_connections_dynamic<Handle: ChainHandle>(
     connections: DynamicConnectedConnections<Handle>,
-    chains: &Vec<Handle>,
     ports: &Vec<Vec<PortId>>,
     order: Ordering,
     bootstrap_with_random_ids: bool,
 ) -> Result<DynamicConnectedChannels<Handle>, Error> {
-    let size = chains.len();
+    let mut channels: HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>> =
+        HashMap::new();
 
-    assert_same_dimension(size, connections.connections())?;
-    assert_same_dimension(size, ports)?;
+    for inner_connections in connections.connections().iter() {
+        let mut inner_channels: HashMap<usize, ConnectedChannel<Handle, Handle>> = HashMap::new();
 
-    let mut channels: Vec<Vec<ConnectedChannel<Handle, Handle>>> = Vec::new();
-
-    for (i, connections_b) in connections.connections().iter().enumerate() {
-        let mut channels_b: Vec<ConnectedChannel<Handle, Handle>> = Vec::new();
-
-        for (j, connection) in connections_b.iter().enumerate() {
-            if i <= j {
-                let chain_a = &chains[i];
-                let chain_b = &chains[j];
-
-                let port_a = &ports[i][j];
-                let port_b = &ports[j][i];
+        for connection in inner_connections.1.iter() {
+            let channel = if let Some(counterparty_channels) = channels.get(connection.0) {
+                let counterparty_channel = counterparty_channels
+                    .get(inner_connections.0)
+                    .ok_or_else(|| {
+                        Error::generic(eyre!(
+                            "No channel entry found from chain `{}` to `{}`",
+                            connection.0,
+                            inner_connections.0
+                        ))
+                    })?;
+                counterparty_channel.clone().flip()
+            } else {
+                // No channel is found, will create one
+                let chain_a = &connection.1.connection.a_chain();
+                let chain_b = &connection.1.connection.b_chain();
+                let port_a = ports[*inner_connections.0][*connection.0].clone();
+                let port_b = ports[*connection.0][*inner_connections.0].clone();
 
                 let bootstrap_options = BootstrapChannelOptions::default()
                     .order(order)
                     .bootstrap_with_random_ids(bootstrap_with_random_ids);
 
-                let channel = bootstrap_channel_with_connection(
+                bootstrap_channel_with_connection(
                     chain_a,
                     chain_b,
-                    connection.clone(),
-                    &DualTagged::new(port_a),
-                    &DualTagged::new(port_b),
+                    connection.1.clone(),
+                    &DualTagged::new(&port_a),
+                    &DualTagged::new(&port_b),
                     bootstrap_options,
-                )?;
+                )?
+            };
 
-                channels_b.push(channel);
-            } else {
-                let counter_channel = &channels[j][i];
-                let channel = counter_channel.clone().flip();
-
-                channels_b.push(channel);
-            }
+            inner_channels.insert(*connection.0, channel);
         }
-
-        channels.push(channels_b);
+        channels.insert(*inner_connections.0, inner_channels);
     }
 
     Ok(DynamicConnectedChannels::new(channels))
@@ -82,14 +85,12 @@ pub fn bootstrap_channels_with_connections_dynamic<Handle: ChainHandle>(
 */
 pub fn bootstrap_channels_with_connections<Handle: ChainHandle, const SIZE: usize>(
     connections: ConnectedConnections<Handle, SIZE>,
-    chains: [Handle; SIZE],
     ports: [[PortId; SIZE]; SIZE],
     order: Ordering,
     bootstrap_with_random_ids: bool,
 ) -> Result<ConnectedChannels<Handle, SIZE>, Error> {
     let channels = bootstrap_channels_with_connections_dynamic(
         connections.into(),
-        &chains.into(),
         &into_nested_vec(ports),
         order,
         bootstrap_with_random_ids,
@@ -118,7 +119,6 @@ pub fn bootstrap_channels_and_connections_dynamic<Handle: ChainHandle>(
 
     bootstrap_channels_with_connections_dynamic(
         connections,
-        chains.chain_handles(),
         ports,
         order,
         bootstrap_with_random_ids,

--- a/tools/test-framework/src/bootstrap/nary/connection.rs
+++ b/tools/test-framework/src/bootstrap/nary/connection.rs
@@ -27,7 +27,7 @@ pub fn bootstrap_connections_dynamic<Handle: ChainHandle>(
 ) -> Result<DynamicConnectedConnections<Handle>, Error> {
     let mut connections: TwoDimMap<ConnectedConnection<Handle, Handle>> = TwoDimMap::new();
 
-    for (src_chain, dst_chain, foreign_client, _) in foreign_clients.iter() {
+    for (src_chain, dst_chain, foreign_client) in foreign_clients.iter() {
         let connection = if let Some(counterparty_connection) =
             connections.get((dst_chain, src_chain))
         {

--- a/tools/test-framework/src/bootstrap/nary/connection.rs
+++ b/tools/test-framework/src/bootstrap/nary/connection.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::foreign_client::ForeignClient;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::bootstrap::binary::connection::{bootstrap_connection, BootstrapConnectionOptions};
 use crate::error::Error;
@@ -14,7 +14,7 @@ use crate::types::binary::connection::ConnectedConnection;
 use crate::types::binary::foreign_client::ForeignClientPair;
 use crate::types::nary::connection::{ConnectedConnections, DynamicConnectedConnections};
 use crate::types::nary::foreign_client::ForeignClientPairs;
-use crate::util::two_dim_hash_map::TwoDimHashMap;
+use crate::util::two_dim_hash_map::TwoDimMap;
 
 /**
    Bootstrap a dynamic number of connections based on the
@@ -22,16 +22,16 @@ use crate::util::two_dim_hash_map::TwoDimHashMap;
    See [`crate::types::topology`] for more information.
 */
 pub fn bootstrap_connections_dynamic<Handle: ChainHandle>(
-    foreign_clients: &TwoDimHashMap<ForeignClient<Handle, Handle>>,
+    foreign_clients: &TwoDimMap<ForeignClient<Handle, Handle>>,
     connection_delay: Duration,
     bootstrap_with_random_ids: bool,
 ) -> Result<DynamicConnectedConnections<Handle>, Error> {
-    let mut connections: HashMap<usize, HashMap<usize, ConnectedConnection<Handle, Handle>>> =
-        HashMap::new();
+    let mut connections: BTreeMap<usize, BTreeMap<usize, ConnectedConnection<Handle, Handle>>> =
+        BTreeMap::new();
 
     for foreign_client in foreign_clients.map.iter() {
-        let mut inner_connections: HashMap<usize, ConnectedConnection<Handle, Handle>> =
-            HashMap::new();
+        let mut inner_connections: BTreeMap<usize, ConnectedConnection<Handle, Handle>> =
+            BTreeMap::new();
 
         for client in foreign_client.1.iter() {
             let connection = if let Some(counterparty_connections) = connections.get(client.0) {
@@ -71,7 +71,7 @@ pub fn bootstrap_connections_dynamic<Handle: ChainHandle>(
         connections.insert(*foreign_client.0, inner_connections);
     }
 
-    Ok(DynamicConnectedConnections::new(connections))
+    Ok(DynamicConnectedConnections::new(connections.into()))
 }
 
 pub fn bootstrap_connections<Handle: ChainHandle, const SIZE: usize>(

--- a/tools/test-framework/src/framework/binary/chain.rs
+++ b/tools/test-framework/src/framework/binary/chain.rs
@@ -22,6 +22,7 @@ use crate::types::binary::chains::{ConnectedChains, DropChainHandle};
 use crate::types::config::TestConfig;
 use crate::types::env::write_env;
 use crate::types::single::node::FullNode;
+use crate::types::topology::TopologyType;
 use crate::util::suspend::hang_on_error;
 
 /**
@@ -111,6 +112,10 @@ pub trait BinaryChainTest {
 pub trait RelayerConfigOverride {
     /// Modify the relayer config
     fn modify_relayer_config(&self, config: &mut Config);
+}
+
+pub trait TopologyOverride {
+    fn topology(&self) -> Option<TopologyType>;
 }
 
 /// An internal trait that can be implemented by test cases to override the

--- a/tools/test-framework/src/framework/nary/channel.rs
+++ b/tools/test-framework/src/framework/nary/channel.rs
@@ -175,7 +175,6 @@ where
 
         let channels = bootstrap_channels_with_connections(
             connections,
-            chains.chain_handles().clone(),
             port_ids,
             order,
             config.bootstrap_with_random_ids,

--- a/tools/test-framework/src/framework/nary/channel.rs
+++ b/tools/test-framework/src/framework/nary/channel.rs
@@ -11,7 +11,7 @@ use tracing::info;
 use crate::bootstrap::nary::channel::bootstrap_channels_with_connections;
 use crate::error::Error;
 use crate::framework::base::{HasOverrides, TestConfigOverride};
-use crate::framework::binary::chain::RelayerConfigOverride;
+use crate::framework::binary::chain::{RelayerConfigOverride, TopologyOverride};
 use crate::framework::binary::channel::{BinaryChannelTest, ChannelOrderOverride};
 use crate::framework::binary::connection::ConnectionDelayOverride;
 use crate::framework::binary::node::{NodeConfigOverride, NodeGenesisOverride};
@@ -38,7 +38,8 @@ where
         + SupervisorOverride
         + ConnectionDelayOverride
         + PortsOverride<SIZE>
-        + ChannelOrderOverride,
+        + ChannelOrderOverride
+        + TopologyOverride,
 {
     run_nary_node_test(&RunNaryChainTest::new(&RunNaryConnectionTest::new(
         &RunNaryChannelTest::new(&RunWithSupervisor::new(test)),
@@ -56,7 +57,8 @@ where
         + SupervisorOverride
         + ConnectionDelayOverride
         + PortsOverride<2>
-        + ChannelOrderOverride,
+        + ChannelOrderOverride
+        + TopologyOverride,
 {
     run_nary_channel_test(&RunBinaryAsNaryChannelTest::new(test))
 }

--- a/tools/test-framework/src/framework/nary/connection.rs
+++ b/tools/test-framework/src/framework/nary/connection.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use crate::bootstrap::nary::connection::bootstrap_connections;
 use crate::error::Error;
 use crate::framework::base::{HasOverrides, TestConfigOverride};
-use crate::framework::binary::chain::RelayerConfigOverride;
+use crate::framework::binary::chain::{RelayerConfigOverride, TopologyOverride};
 use crate::framework::binary::connection::{BinaryConnectionTest, ConnectionDelayOverride};
 use crate::framework::binary::node::{NodeConfigOverride, NodeGenesisOverride};
 use crate::framework::nary::chain::{NaryChainTest, RunNaryChainTest};
@@ -34,7 +34,8 @@ where
         + NodeGenesisOverride
         + RelayerConfigOverride
         + SupervisorOverride
-        + ConnectionDelayOverride,
+        + ConnectionDelayOverride
+        + TopologyOverride,
 {
     run_nary_node_test(&RunNaryChainTest::new(&RunNaryConnectionTest::new(
         &RunWithSupervisor::new(test),

--- a/tools/test-framework/src/framework/overrides.rs
+++ b/tools/test-framework/src/framework/overrides.rs
@@ -22,6 +22,9 @@ use crate::framework::binary::node::{NodeConfigOverride, NodeGenesisOverride};
 use crate::framework::nary::channel::PortsOverride as NaryPortsOverride;
 use crate::framework::supervisor::SupervisorOverride;
 use crate::types::config::TestConfig;
+use crate::types::topology::TopologyType;
+
+use super::binary::chain::TopologyOverride;
 
 /**
    This trait should be implemented for all test cases to allow overriding
@@ -145,6 +148,10 @@ pub trait TestOverrides {
     fn channel_version(&self) -> Version {
         Version::ics20()
     }
+
+    fn topology(&self) -> Option<TopologyType> {
+        None
+    }
 }
 
 impl<Test: TestOverrides> HasOverrides for Test {
@@ -229,5 +236,11 @@ impl<Test: TestOverrides> NaryPortsOverride<2> for Test {
         let port_b = self.channel_port_b();
 
         [[port_a.clone(), port_b.clone()], [port_b, port_a]]
+    }
+}
+
+impl<Test: TestOverrides> TopologyOverride for Test {
+    fn topology(&self) -> Option<TopologyType> {
+        TestOverrides::topology(self)
     }
 }

--- a/tools/test-framework/src/types/mod.rs
+++ b/tools/test-framework/src/types/mod.rs
@@ -16,4 +16,5 @@ pub mod nary;
 pub mod process;
 pub mod single;
 pub mod tagged;
+pub mod topology;
 pub mod wallet;

--- a/tools/test-framework/src/types/nary/chains.rs
+++ b/tools/test-framework/src/types/nary/chains.rs
@@ -20,7 +20,8 @@ use crate::util::two_dim_hash_map::TwoDimMap;
    A fixed-size N-ary connected chains as specified by `SIZE`.
 
    Contains `SIZE` number of [`ChainHandle`]s, `SIZE` number of
-   [`FullNode`]s, and `SIZE`x`SIZE` numbers of [`ForeignClient`] pairs.
+   [`FullNode`]s, and a numbers of [`ForeignClient`] pairs
+   depending on `SIZE` and the topology.
 
    A `ConnectedChains` can be constructed by first constructing
    a [`DynamicConnectedChains`], and then calling

--- a/tools/test-framework/src/types/nary/chains.rs
+++ b/tools/test-framework/src/types/nary/chains.rs
@@ -14,7 +14,7 @@ use crate::types::nary::foreign_client::*;
 use crate::types::single::node::FullNode;
 use crate::types::tagged::*;
 use crate::util::array::try_into_array;
-use crate::util::two_dim_hash_map::TwoDimHashMap;
+use crate::util::two_dim_hash_map::TwoDimMap;
 
 /**
    A fixed-size N-ary connected chains as specified by `SIZE`.
@@ -45,7 +45,7 @@ pub struct NaryConnectedChains<Handle: ChainHandle, const SIZE: usize> {
 pub struct DynamicConnectedChains<Handle: ChainHandle> {
     chain_handles: Vec<Handle>,
     full_nodes: Vec<FullNode>,
-    pub foreign_clients: TwoDimHashMap<ForeignClient<Handle, Handle>>,
+    pub foreign_clients: TwoDimMap<ForeignClient<Handle, Handle>>,
 }
 
 /**
@@ -183,7 +183,7 @@ impl<Handle: ChainHandle> DynamicConnectedChains<Handle> {
     pub fn new(
         chain_handles: Vec<Handle>,
         full_nodes: Vec<FullNode>,
-        foreign_clients: TwoDimHashMap<ForeignClient<Handle, Handle>>,
+        foreign_clients: TwoDimMap<ForeignClient<Handle, Handle>>,
     ) -> Self {
         Self {
             chain_handles,
@@ -200,7 +200,7 @@ impl<Handle: ChainHandle> DynamicConnectedChains<Handle> {
         &self.full_nodes
     }
 
-    pub fn foreign_clients(&self) -> &TwoDimHashMap<ForeignClient<Handle, Handle>> {
+    pub fn foreign_clients(&self) -> &TwoDimMap<ForeignClient<Handle, Handle>> {
         &self.foreign_clients
     }
 }

--- a/tools/test-framework/src/types/nary/chains.rs
+++ b/tools/test-framework/src/types/nary/chains.rs
@@ -2,6 +2,8 @@
    Constructs for N-ary connected chains.
 */
 
+use std::collections::HashMap;
+
 use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::foreign_client::ForeignClient;
@@ -44,7 +46,7 @@ pub struct NaryConnectedChains<Handle: ChainHandle, const SIZE: usize> {
 pub struct DynamicConnectedChains<Handle: ChainHandle> {
     chain_handles: Vec<Handle>,
     full_nodes: Vec<FullNode>,
-    pub foreign_clients: Vec<Vec<ForeignClient<Handle, Handle>>>,
+    pub foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>,
 }
 
 /**
@@ -182,7 +184,7 @@ impl<Handle: ChainHandle> DynamicConnectedChains<Handle> {
     pub fn new(
         chain_handles: Vec<Handle>,
         full_nodes: Vec<FullNode>,
-        foreign_clients: Vec<Vec<ForeignClient<Handle, Handle>>>,
+        foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>,
     ) -> Self {
         Self {
             chain_handles,
@@ -199,7 +201,9 @@ impl<Handle: ChainHandle> DynamicConnectedChains<Handle> {
         &self.full_nodes
     }
 
-    pub fn foreign_clients(&self) -> &Vec<Vec<ForeignClient<Handle, Handle>>> {
+    pub fn foreign_clients(
+        &self,
+    ) -> &HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>> {
         &self.foreign_clients
     }
 }

--- a/tools/test-framework/src/types/nary/chains.rs
+++ b/tools/test-framework/src/types/nary/chains.rs
@@ -2,8 +2,6 @@
    Constructs for N-ary connected chains.
 */
 
-use std::collections::HashMap;
-
 use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::foreign_client::ForeignClient;
@@ -16,6 +14,7 @@ use crate::types::nary::foreign_client::*;
 use crate::types::single::node::FullNode;
 use crate::types::tagged::*;
 use crate::util::array::try_into_array;
+use crate::util::two_dim_hash_map::TwoDimHashMap;
 
 /**
    A fixed-size N-ary connected chains as specified by `SIZE`.
@@ -46,7 +45,7 @@ pub struct NaryConnectedChains<Handle: ChainHandle, const SIZE: usize> {
 pub struct DynamicConnectedChains<Handle: ChainHandle> {
     chain_handles: Vec<Handle>,
     full_nodes: Vec<FullNode>,
-    pub foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>,
+    pub foreign_clients: TwoDimHashMap<ForeignClient<Handle, Handle>>,
 }
 
 /**
@@ -184,7 +183,7 @@ impl<Handle: ChainHandle> DynamicConnectedChains<Handle> {
     pub fn new(
         chain_handles: Vec<Handle>,
         full_nodes: Vec<FullNode>,
-        foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>,
+        foreign_clients: TwoDimHashMap<ForeignClient<Handle, Handle>>,
     ) -> Self {
         Self {
             chain_handles,
@@ -201,9 +200,7 @@ impl<Handle: ChainHandle> DynamicConnectedChains<Handle> {
         &self.full_nodes
     }
 
-    pub fn foreign_clients(
-        &self,
-    ) -> &HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>> {
+    pub fn foreign_clients(&self) -> &TwoDimHashMap<ForeignClient<Handle, Handle>> {
         &self.foreign_clients
     }
 }

--- a/tools/test-framework/src/types/nary/channel.rs
+++ b/tools/test-framework/src/types/nary/channel.rs
@@ -14,9 +14,10 @@ use crate::types::tagged::*;
 use crate::util::two_dim_hash_map::TwoDimMap;
 
 /**
-   A fixed-size N-ary connected channels as specified by `SIZE`.
+   A two dimensional BTreeMap of connected channels as specified by `SIZE`
+   and topology.
 
-   Contains `SIZE`x`SIZE` number of binary [`ConnectedChannel`]s.
+   The number of binary [`ConnectedChannel`]s depends on the topology.
 */
 #[derive(Debug, Clone)]
 pub struct ConnectedChannels<Handle: ChainHandle, const SIZE: usize> {
@@ -24,9 +25,10 @@ pub struct ConnectedChannels<Handle: ChainHandle, const SIZE: usize> {
 }
 
 /**
-   A dynamic-sized N-ary connected channels, consist of a nested
-   vector of binary [`ConnectedChannel`]s which must be of the
-   same length.
+   A two dimensional BTreeMap of connected channels as specified by `SIZE`
+   and topology.
+
+   The number of binary [`ConnectedChannel`]s depends on the topology.
 */
 #[derive(Debug, Clone)]
 pub struct DynamicConnectedChannels<Handle: ChainHandle> {

--- a/tools/test-framework/src/types/nary/channel.rs
+++ b/tools/test-framework/src/types/nary/channel.rs
@@ -2,6 +2,8 @@
    Constructs for N-ary connected channels.
 */
 
+use std::collections::HashMap;
+
 use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::channel::Channel;
@@ -12,7 +14,6 @@ use crate::error::Error;
 use crate::types::binary::channel::ConnectedChannel;
 use crate::types::env::{EnvWriter, ExportEnv};
 use crate::types::tagged::*;
-use crate::util::array::try_into_nested_array;
 
 /**
    A fixed-size N-ary connected channels as specified by `SIZE`.
@@ -21,7 +22,7 @@ use crate::util::array::try_into_nested_array;
 */
 #[derive(Debug, Clone)]
 pub struct ConnectedChannels<Handle: ChainHandle, const SIZE: usize> {
-    channels: [[ConnectedChannel<Handle, Handle>; SIZE]; SIZE],
+    pub channels: HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>>,
 }
 
 /**
@@ -31,7 +32,7 @@ pub struct ConnectedChannels<Handle: ChainHandle, const SIZE: usize> {
 */
 #[derive(Debug, Clone)]
 pub struct DynamicConnectedChannels<Handle: ChainHandle> {
-    channels: Vec<Vec<ConnectedChannel<Handle, Handle>>>,
+    channels: HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>>,
 }
 
 /**
@@ -70,32 +71,33 @@ impl<Handle: ChainHandle, const SIZE: usize> ConnectedChannels<Handle, SIZE> {
     pub fn channel_at<const CHAIN_A: usize, const CHAIN_B: usize>(
         &self,
     ) -> Result<NthConnectedChannel<CHAIN_A, CHAIN_B, Handle>, Error> {
-        if CHAIN_A >= SIZE || CHAIN_B >= SIZE {
-            Err(Error::generic(eyre!(
-                "cannot get channel beyond position {}/{}",
-                CHAIN_A,
-                CHAIN_B
-            )))
-        } else {
-            let raw_channel = self.channels[CHAIN_A][CHAIN_B].clone();
+        let inner_channels = self.channels.get(&CHAIN_A).ok_or_else(|| {
+            Error::generic(eyre!("No channel entries found for chain `{CHAIN_A}`"))
+        })?;
+        let raw_channel = inner_channels
+            .get(&CHAIN_B)
+            .ok_or_else(|| {
+                Error::generic(eyre!(
+                    "No channel entry found for chain `{CHAIN_A}` to `{CHAIN_B}`"
+                ))
+            })?
+            .clone();
+        let channel = raw_channel.map_chain(MonoTagged::new, MonoTagged::new);
 
-            let channel = raw_channel.map_chain(MonoTagged::new, MonoTagged::new);
-
-            Ok(channel)
-        }
+        Ok(channel)
     }
 
-    pub fn channels(&self) -> &[[ConnectedChannel<Handle, Handle>; SIZE]; SIZE] {
+    pub fn channels(&self) -> &HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>> {
         &self.channels
     }
 }
 
 impl<Handle: ChainHandle> DynamicConnectedChannels<Handle> {
-    pub fn new(channels: Vec<Vec<ConnectedChannel<Handle, Handle>>>) -> Self {
+    pub fn new(channels: HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>>) -> Self {
         Self { channels }
     }
 
-    pub fn channels(&self) -> &Vec<Vec<ConnectedChannel<Handle, Handle>>> {
+    pub fn channels(&self) -> &HashMap<usize, HashMap<usize, ConnectedChannel<Handle, Handle>>> {
         &self.channels
     }
 }
@@ -107,7 +109,7 @@ impl<Handle: ChainHandle, const SIZE: usize> TryFrom<DynamicConnectedChannels<Ha
 
     fn try_from(channels: DynamicConnectedChannels<Handle>) -> Result<Self, Error> {
         Ok(ConnectedChannels {
-            channels: try_into_nested_array(channels.channels)?,
+            channels: channels.channels,
         })
     }
 }
@@ -120,36 +122,21 @@ impl<Handle: ChainHandle> From<ConnectedChannels<Handle, 2>> for NthConnectedCha
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ConnectedChannels<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for (i, inner_channels) in self.channels.iter().enumerate() {
-            for (j, channel_i_to_j) in inner_channels.iter().enumerate() {
+        for inner_channels in self.channels.iter() {
+            for channel in inner_channels.1.iter() {
                 writer.write_env(
-                    &format!("CONNECTION_ID_{j}_to_{i}"),
-                    &format!("{}", channel_i_to_j.connection.connection_id_a),
+                    &format!("CONNECTION_ID_{}_to_{}", inner_channels.0, channel.0),
+                    &format!("{}", channel.1.connection.connection_id_a),
                 );
 
                 writer.write_env(
-                    &format!("CONNECTION_ID_{i}_to_{j}"),
-                    &format!("{}", channel_i_to_j.connection.connection_id_b),
+                    &format!("CHANNEL_ID_{}_to_{}", inner_channels.0, channel.0),
+                    &format!("{}", channel.1.channel_id_a),
                 );
 
                 writer.write_env(
-                    &format!("CHANNEL_ID_{j}_to_{i}"),
-                    &format!("{}", channel_i_to_j.channel_id_a),
-                );
-
-                writer.write_env(
-                    &format!("PORT_{j}_to_{i}"),
-                    &format!("{}", channel_i_to_j.port_a),
-                );
-
-                writer.write_env(
-                    &format!("CHANNEL_ID_{i}_to_{j}"),
-                    &format!("{}", channel_i_to_j.channel_id_b),
-                );
-
-                writer.write_env(
-                    &format!("PORT_{i}_to_{j}"),
-                    &format!("{}", channel_i_to_j.port_b),
+                    &format!("PORT_{}_to_{}", inner_channels.0, channel.0),
+                    &format!("{}", channel.1.port_a),
                 );
             }
         }

--- a/tools/test-framework/src/types/nary/channel.rs
+++ b/tools/test-framework/src/types/nary/channel.rs
@@ -118,7 +118,7 @@ impl<Handle: ChainHandle> From<ConnectedChannels<Handle, 2>> for NthConnectedCha
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ConnectedChannels<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for (src_chain, dst_chain, channel, _) in self.channels.iter() {
+        for (src_chain, dst_chain, channel) in self.channels.iter() {
             writer.write_env(
                 &format!("CONNECTION_ID_{}_to_{}", src_chain, dst_chain),
                 &format!("{}", channel.connection.connection_id_a),

--- a/tools/test-framework/src/types/nary/channel.rs
+++ b/tools/test-framework/src/types/nary/channel.rs
@@ -118,23 +118,21 @@ impl<Handle: ChainHandle> From<ConnectedChannels<Handle, 2>> for NthConnectedCha
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ConnectedChannels<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for inner_channels in self.channels.map.iter() {
-            for channel in inner_channels.1.iter() {
-                writer.write_env(
-                    &format!("CONNECTION_ID_{}_to_{}", inner_channels.0, channel.0),
-                    &format!("{}", channel.1.connection.connection_id_a),
-                );
+        for (src_chain, dst_chain, channel, _) in self.channels.iter() {
+            writer.write_env(
+                &format!("CONNECTION_ID_{}_to_{}", src_chain, dst_chain),
+                &format!("{}", channel.connection.connection_id_a),
+            );
 
-                writer.write_env(
-                    &format!("CHANNEL_ID_{}_to_{}", inner_channels.0, channel.0),
-                    &format!("{}", channel.1.channel_id_a),
-                );
+            writer.write_env(
+                &format!("CHANNEL_ID_{}_to_{}", src_chain, dst_chain),
+                &format!("{}", channel.channel_id_a),
+            );
 
-                writer.write_env(
-                    &format!("PORT_{}_to_{}", inner_channels.0, channel.0),
-                    &format!("{}", channel.1.port_a),
-                );
-            }
+            writer.write_env(
+                &format!("PORT_{}_to_{}", src_chain, dst_chain),
+                &format!("{}", channel.port_a),
+            );
         }
     }
 }

--- a/tools/test-framework/src/types/nary/connection.rs
+++ b/tools/test-framework/src/types/nary/connection.rs
@@ -13,9 +13,10 @@ use crate::types::tagged::*;
 use crate::util::two_dim_hash_map::TwoDimMap;
 
 /**
-   A fixed-size N-ary connected connections as specified by `SIZE`.
+   A two dimensional BTreeMap of connected connections as specified by `SIZE`
+   and topology.
 
-   Contains `SIZE`x`SIZE` number of binary [`ConnectedConnection`]s.
+   The number of binary [`ConnectedConnection`]s depends on the topology.
 */
 #[derive(Debug, Clone)]
 pub struct ConnectedConnections<Handle: ChainHandle, const SIZE: usize> {
@@ -23,9 +24,10 @@ pub struct ConnectedConnections<Handle: ChainHandle, const SIZE: usize> {
 }
 
 /**
-   A dynamic-sized N-ary connected connections, made of a
-   nested vector of binary [`ConnectedConnection`] which must be
-   in the same dimension.
+   A two dimensional BTreeMap of connected connections as specified by `SIZE`
+   and topology.
+
+   The number of binary [`ConnectedConnection`]s depends on the topology.
 */
 #[derive(Debug, Clone)]
 pub struct DynamicConnectedConnections<Handle: ChainHandle> {

--- a/tools/test-framework/src/types/nary/connection.rs
+++ b/tools/test-framework/src/types/nary/connection.rs
@@ -2,6 +2,8 @@
    Constructs for N-ary connected connections.
 */
 
+use std::collections::HashMap;
+
 use eyre::eyre;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer_types::core::ics24_host::identifier::ConnectionId;
@@ -11,7 +13,6 @@ use crate::error::Error;
 use crate::types::binary::connection::ConnectedConnection;
 use crate::types::env::{EnvWriter, ExportEnv};
 use crate::types::tagged::*;
-use crate::util::array::{into_nested_vec, try_into_nested_array};
 
 /**
    A fixed-size N-ary connected connections as specified by `SIZE`.
@@ -20,7 +21,7 @@ use crate::util::array::{into_nested_vec, try_into_nested_array};
 */
 #[derive(Debug, Clone)]
 pub struct ConnectedConnections<Handle: ChainHandle, const SIZE: usize> {
-    connections: [[ConnectedConnection<Handle, Handle>; SIZE]; SIZE],
+    connections: HashMap<usize, HashMap<usize, ConnectedConnection<Handle, Handle>>>,
 }
 
 /**
@@ -30,7 +31,7 @@ pub struct ConnectedConnections<Handle: ChainHandle, const SIZE: usize> {
 */
 #[derive(Debug, Clone)]
 pub struct DynamicConnectedConnections<Handle: ChainHandle> {
-    connections: Vec<Vec<ConnectedConnection<Handle, Handle>>>,
+    connections: HashMap<usize, HashMap<usize, ConnectedConnection<Handle, Handle>>>,
 }
 
 /**
@@ -55,32 +56,39 @@ impl<Handle: ChainHandle, const SIZE: usize> ConnectedConnections<Handle, SIZE> 
     pub fn connection_at<const CHAIN_A: usize, const CHAIN_B: usize>(
         &self,
     ) -> Result<NthConnectedConnection<CHAIN_A, CHAIN_B, Handle>, Error> {
-        if CHAIN_A >= SIZE || CHAIN_B >= SIZE {
-            Err(Error::generic(eyre!(
-                "cannot get connection beyond position {}/{}",
-                CHAIN_A,
-                CHAIN_B
-            )))
-        } else {
-            let raw_connection = self.connections[CHAIN_A][CHAIN_B].clone();
+        let inner_connections = self.connections.get(&CHAIN_A).ok_or_else(|| {
+            Error::generic(eyre!("No connection entries found for chain `{CHAIN_A}`"))
+        })?;
+        let raw_connection = inner_connections
+            .get(&CHAIN_B)
+            .ok_or_else(|| {
+                Error::generic(eyre!(
+                    "No connection entry found for chain `{CHAIN_A}` to `{CHAIN_B}`"
+                ))
+            })?
+            .clone();
+        let connection = raw_connection.map_chain(MonoTagged::new, MonoTagged::new);
 
-            let channel = raw_connection.map_chain(MonoTagged::new, MonoTagged::new);
-
-            Ok(channel)
-        }
+        Ok(connection)
     }
 
-    pub fn connections(&self) -> &[[ConnectedConnection<Handle, Handle>; SIZE]; SIZE] {
+    pub fn connections(
+        &self,
+    ) -> &HashMap<usize, HashMap<usize, ConnectedConnection<Handle, Handle>>> {
         &self.connections
     }
 }
 
 impl<Handle: ChainHandle> DynamicConnectedConnections<Handle> {
-    pub fn new(connections: Vec<Vec<ConnectedConnection<Handle, Handle>>>) -> Self {
+    pub fn new(
+        connections: HashMap<usize, HashMap<usize, ConnectedConnection<Handle, Handle>>>,
+    ) -> Self {
         Self { connections }
     }
 
-    pub fn connections(&self) -> &Vec<Vec<ConnectedConnection<Handle, Handle>>> {
+    pub fn connections(
+        &self,
+    ) -> &HashMap<usize, HashMap<usize, ConnectedConnection<Handle, Handle>>> {
         &self.connections
     }
 }
@@ -90,7 +98,7 @@ impl<Handle: ChainHandle, const SIZE: usize> From<ConnectedConnections<Handle, S
 {
     fn from(connections: ConnectedConnections<Handle, SIZE>) -> Self {
         DynamicConnectedConnections {
-            connections: into_nested_vec(connections.connections),
+            connections: connections.connections,
         }
     }
 }
@@ -102,7 +110,7 @@ impl<Handle: ChainHandle, const SIZE: usize> TryFrom<DynamicConnectedConnections
 
     fn try_from(connections: DynamicConnectedConnections<Handle>) -> Result<Self, Error> {
         Ok(ConnectedConnections {
-            connections: try_into_nested_array(connections.connections)?,
+            connections: connections.connections,
         })
     }
 }
@@ -117,16 +125,11 @@ impl<Handle: ChainHandle> From<ConnectedConnections<Handle, 2>>
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ConnectedConnections<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for (i, inner_connections) in self.connections.iter().enumerate() {
-            for (j, connection_i_to_j) in inner_connections.iter().enumerate() {
+        for inner_connections in self.connections.iter() {
+            for connection in inner_connections.1.iter() {
                 writer.write_env(
-                    &format!("CONNECTION_ID_{j}_to_{i}"),
-                    &format!("{}", connection_i_to_j.connection_id_a),
-                );
-
-                writer.write_env(
-                    &format!("CONNECTION_ID_{i}_to_{j}"),
-                    &format!("{}", connection_i_to_j.connection_id_b),
+                    &format!("CONNECTION_ID_{}_to_{}", inner_connections.0, connection.0),
+                    &format!("{}", connection.1.connection_id_a),
                 );
             }
         }

--- a/tools/test-framework/src/types/nary/connection.rs
+++ b/tools/test-framework/src/types/nary/connection.rs
@@ -115,7 +115,7 @@ impl<Handle: ChainHandle> From<ConnectedConnections<Handle, 2>>
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ConnectedConnections<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for (src_chain, dst_chain, connection, _) in self.connections.iter() {
+        for (src_chain, dst_chain, connection) in self.connections.iter() {
             writer.write_env(
                 &format!("CONNECTION_ID_{}_to_{}", src_chain, dst_chain),
                 &format!("{}", connection.connection_id_a),

--- a/tools/test-framework/src/types/nary/connection.rs
+++ b/tools/test-framework/src/types/nary/connection.rs
@@ -115,13 +115,11 @@ impl<Handle: ChainHandle> From<ConnectedConnections<Handle, 2>>
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ConnectedConnections<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for inner_connections in self.connections.map.iter() {
-            for connection in inner_connections.1.iter() {
-                writer.write_env(
-                    &format!("CONNECTION_ID_{}_to_{}", inner_connections.0, connection.0),
-                    &format!("{}", connection.1.connection_id_a),
-                );
-            }
+        for (src_chain, dst_chain, connection, _) in self.connections.iter() {
+            writer.write_env(
+                &format!("CONNECTION_ID_{}_to_{}", src_chain, dst_chain),
+                &format!("{}", connection.connection_id_a),
+            );
         }
     }
 }

--- a/tools/test-framework/src/types/nary/foreign_client.rs
+++ b/tools/test-framework/src/types/nary/foreign_client.rs
@@ -71,7 +71,7 @@ impl<Handle: ChainHandle, const SIZE: usize> TryFrom<TwoDimMap<ForeignClient<Han
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ForeignClientPairs<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for (src_chain, dst_chain, client, _) in self.foreign_clients.iter() {
+        for (src_chain, dst_chain, client) in self.foreign_clients.iter() {
             writer.write_env(
                 &format!("CLIENT_ID_{}_to_{}", src_chain, dst_chain),
                 &format!("{}", client.id()),

--- a/tools/test-framework/src/types/nary/foreign_client.rs
+++ b/tools/test-framework/src/types/nary/foreign_client.rs
@@ -71,13 +71,11 @@ impl<Handle: ChainHandle, const SIZE: usize> TryFrom<TwoDimMap<ForeignClient<Han
 
 impl<Handle: ChainHandle, const SIZE: usize> ExportEnv for ForeignClientPairs<Handle, SIZE> {
     fn export_env(&self, writer: &mut impl EnvWriter) {
-        for inner_clients in self.foreign_clients.map.iter() {
-            for client in inner_clients.1.iter() {
-                writer.write_env(
-                    &format!("CLIENT_ID_{}_to_{}", inner_clients.0, client.0),
-                    &format!("{}", client.1.id()),
-                );
-            }
+        for (src_chain, dst_chain, client, _) in self.foreign_clients.iter() {
+            writer.write_env(
+                &format!("CLIENT_ID_{}_to_{}", src_chain, dst_chain),
+                &format!("{}", client.id()),
+            );
         }
     }
 }

--- a/tools/test-framework/src/types/nary/foreign_client.rs
+++ b/tools/test-framework/src/types/nary/foreign_client.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::types::binary::foreign_client::ForeignClientPair;
 use crate::types::env::{EnvWriter, ExportEnv};
 use crate::types::tagged::*;
-use crate::util::two_dim_hash_map::TwoDimHashMap;
+use crate::util::two_dim_hash_map::TwoDimMap;
 
 /**
    A [`ForeignClient`] that is tagged by a `Handle: ChainHandle` and
@@ -21,7 +21,7 @@ pub type NthForeignClientPair<Handle, const DST: usize, const SRC: usize> =
 
 #[derive(Clone)]
 pub struct ForeignClientPairs<Handle: ChainHandle, const SIZE: usize> {
-    foreign_clients: TwoDimHashMap<ForeignClient<Handle, Handle>>,
+    foreign_clients: TwoDimMap<ForeignClient<Handle, Handle>>,
 }
 
 impl<Handle: ChainHandle, const SIZE: usize> ForeignClientPairs<Handle, SIZE> {
@@ -53,17 +53,17 @@ impl<Handle: ChainHandle, const SIZE: usize> ForeignClientPairs<Handle, SIZE> {
         Ok(ForeignClientPair::new(client_a_to_b, client_b_to_a))
     }
 
-    pub fn into_nested_vec(self) -> TwoDimHashMap<ForeignClient<Handle, Handle>> {
+    pub fn into_nested_vec(self) -> TwoDimMap<ForeignClient<Handle, Handle>> {
         self.foreign_clients
     }
 }
 
-impl<Handle: ChainHandle, const SIZE: usize> TryFrom<TwoDimHashMap<ForeignClient<Handle, Handle>>>
+impl<Handle: ChainHandle, const SIZE: usize> TryFrom<TwoDimMap<ForeignClient<Handle, Handle>>>
     for ForeignClientPairs<Handle, SIZE>
 {
     type Error = Error;
 
-    fn try_from(clients: TwoDimHashMap<ForeignClient<Handle, Handle>>) -> Result<Self, Error> {
+    fn try_from(clients: TwoDimMap<ForeignClient<Handle, Handle>>) -> Result<Self, Error> {
         let foreign_clients = clients;
         Ok(Self { foreign_clients })
     }

--- a/tools/test-framework/src/types/topology.rs
+++ b/tools/test-framework/src/types/topology.rs
@@ -35,7 +35,7 @@
 
    Example: Cyclic Topology
 
-   The cylic topology is similar to the linear topology with the addition of the first and
+   The cyclic topology is similar to the linear topology with the addition of the first and
    last chain being connected as well.
    For chains A, B, C and D, the clients are created as follows:
 

--- a/tools/test-framework/src/types/topology.rs
+++ b/tools/test-framework/src/types/topology.rs
@@ -51,7 +51,7 @@ pub enum TopologyType {
     Full,
 }
 
-impl FromStr for TopologyTypes {
+impl FromStr for TopologyType {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -73,7 +73,7 @@ pub trait Topology<Handle: ChainHandle> {
 pub struct FullyConnectedTopology;
 
 impl<Handle: ChainHandle> Topology<Handle> for FullyConnectedTopology {
-    fn get_topology(
+    fn create_topology(
         &self,
         chain_handles: &Vec<Handle>,
     ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error> {
@@ -99,7 +99,7 @@ impl<Handle: ChainHandle> Topology<Handle> for FullyConnectedTopology {
 pub struct LinearTopology;
 
 impl<Handle: ChainHandle> Topology<Handle> for LinearTopology {
-    fn get_topology(
+    fn create_topology(
         &self,
         chain_handles: &Vec<Handle>,
     ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error> {
@@ -132,14 +132,11 @@ impl<Handle: ChainHandle> Topology<Handle> for LinearTopology {
     }
 }
 
-pub fn bootstrap_topology<Handle: ChainHandle>(topology: TopologyType) -> Box<dyn Topology<Handle>> {
-    if let Ok(topology_type) = value.parse() {
-        match topology_type {
-            TopologyTypes::Full => Box::new(FullyConnectedTopology),
-            TopologyTypes::Linear => Box::new(LinearTopology),
-        }
-    } else {
-        tracing::warn!("Failed to parse topology type `{value}`. Will fallback to Linear topology");
-        Box::new(LinearTopology)
+pub fn bootstrap_topology<Handle: ChainHandle>(
+    topology: TopologyType,
+) -> Box<dyn Topology<Handle>> {
+    match topology {
+        TopologyType::Full => Box::new(FullyConnectedTopology),
+        TopologyType::Linear => Box::new(LinearTopology),
     }
 }

--- a/tools/test-framework/src/types/topology.rs
+++ b/tools/test-framework/src/types/topology.rs
@@ -1,0 +1,145 @@
+/*!
+   The Topology defines how chains are interconnected when more than two are used in tests.
+   This setup is managed by the [`crate::bootstrap::nary::chain::boostrap_chains_with_any_nodes`]
+   function.
+
+   Connections are established by examining the existing clients, and channels are created based
+   on these connections. Therefore, to define the topology of the chains, it is sufficient to
+   create the appropriate set of clients.
+
+   Example: Linear Topology
+
+   For a linear topology between chains A, B, and C, the clients are created as follows:
+   * Chain A: a client referencing chain B
+   * Chain B: a client referencing chain B and a client referencing chain C
+   * Chain C: a client referencing chain B
+
+   This setup ensures that:
+
+   * Chain A is connected to Chain B.
+   * Chain B is connected to both Chain A and Chain C.
+   * Chain C is connected to Chain B.
+
+   Example: Fully Connected Topology
+
+   In a fully connected topology, every chain has clients referencing all other chains.
+   For chains A, B, and C, the clients are created as follows:
+
+   * Chain A: Clients referencing chains B and C
+   * Chain B: Clients referencing chains A and C
+   * Chain C: Clients referencing chains A and B
+
+   This setup ensures that every chain is directly connected to every other chain, forming
+   a complete graph.
+
+   By defining the appropriate set of clients, you can establish the desired topology for
+   your tests, whether it be linear, fully connected, or any other configuration.
+*/
+
+use eyre::eyre;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use ibc_relayer::chain::handle::ChainHandle;
+use ibc_relayer::foreign_client::ForeignClient;
+
+use crate::bootstrap::binary::chain::bootstrap_foreign_client;
+use crate::error::Error;
+
+pub enum TopologyTypes {
+    Linear,
+    Full,
+}
+
+impl FromStr for TopologyTypes {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "linear" => Ok(Self::Linear),
+            "full" => Ok(Self::Full),
+            _ => Err(Error::generic(eyre!("The topology `{s}` does not exist"))),
+        }
+    }
+}
+
+pub trait Topology<Handle: ChainHandle> {
+    fn get_topology(
+        &self,
+        chain_handles: &Vec<Handle>,
+    ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error>;
+}
+
+pub struct FullyConnectedTopology;
+
+impl<Handle: ChainHandle> Topology<Handle> for FullyConnectedTopology {
+    fn get_topology(
+        &self,
+        chain_handles: &Vec<Handle>,
+    ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error> {
+        let mut foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<_, _>>> =
+            HashMap::new();
+
+        for (i, handle_a) in chain_handles.iter().enumerate() {
+            let mut foreign_clients_b = HashMap::new();
+
+            for (j, handle_b) in chain_handles.iter().enumerate() {
+                let foreign_client =
+                    bootstrap_foreign_client(handle_a, handle_b, Default::default())?;
+
+                foreign_clients_b.insert(j, foreign_client);
+            }
+
+            foreign_clients.insert(i, foreign_clients_b);
+        }
+        Ok(foreign_clients)
+    }
+}
+
+pub struct LinearTopology;
+
+impl<Handle: ChainHandle> Topology<Handle> for LinearTopology {
+    fn get_topology(
+        &self,
+        chain_handles: &Vec<Handle>,
+    ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error> {
+        let mut foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<_, _>>> =
+            HashMap::new();
+
+        let last_index = chain_handles.len() - 1;
+        for (i, _) in chain_handles.iter().enumerate() {
+            let mut clients = HashMap::new();
+            if i < last_index {
+                let client = bootstrap_foreign_client(
+                    &chain_handles[i],
+                    &chain_handles[i + 1],
+                    Default::default(),
+                )?;
+                clients.insert(i + 1, client);
+            }
+            if i > 0 {
+                let client = bootstrap_foreign_client(
+                    &chain_handles[i],
+                    &chain_handles[i - 1],
+                    Default::default(),
+                )?;
+                clients.insert(i - 1, client);
+            }
+
+            foreign_clients.insert(i, clients);
+        }
+        Ok(foreign_clients)
+    }
+}
+
+pub fn get_topology<Handle: ChainHandle>(value: &str) -> Box<dyn Topology<Handle>> {
+    if let Ok(topology_type) = value.parse() {
+        match topology_type {
+            TopologyTypes::Full => Box::new(FullyConnectedTopology),
+            TopologyTypes::Linear => Box::new(LinearTopology),
+        }
+    } else {
+        tracing::warn!("Failed to parse topology type `{value}`. Will fallback to Linear topology");
+        Box::new(LinearTopology)
+    }
+}

--- a/tools/test-framework/src/types/topology.rs
+++ b/tools/test-framework/src/types/topology.rs
@@ -45,6 +45,7 @@ use ibc_relayer::foreign_client::ForeignClient;
 
 use crate::bootstrap::binary::chain::bootstrap_foreign_client;
 use crate::error::Error;
+use crate::util::two_dim_hash_map::TwoDimHashMap;
 
 pub enum TopologyType {
     Linear,
@@ -67,7 +68,7 @@ pub trait Topology<Handle: ChainHandle> {
     fn create_topology(
         &self,
         chain_handles: &Vec<Handle>,
-    ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error>;
+    ) -> Result<TwoDimHashMap<ForeignClient<Handle, Handle>>, Error>;
 }
 
 pub struct FullyConnectedTopology;
@@ -76,7 +77,7 @@ impl<Handle: ChainHandle> Topology<Handle> for FullyConnectedTopology {
     fn create_topology(
         &self,
         chain_handles: &Vec<Handle>,
-    ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error> {
+    ) -> Result<TwoDimHashMap<ForeignClient<Handle, Handle>>, Error> {
         let mut foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<_, _>>> =
             HashMap::new();
 
@@ -92,7 +93,7 @@ impl<Handle: ChainHandle> Topology<Handle> for FullyConnectedTopology {
 
             foreign_clients.insert(i, foreign_clients_b);
         }
-        Ok(foreign_clients)
+        Ok(foreign_clients.into())
     }
 }
 
@@ -102,7 +103,7 @@ impl<Handle: ChainHandle> Topology<Handle> for LinearTopology {
     fn create_topology(
         &self,
         chain_handles: &Vec<Handle>,
-    ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error> {
+    ) -> Result<TwoDimHashMap<ForeignClient<Handle, Handle>>, Error> {
         let mut foreign_clients: HashMap<usize, HashMap<usize, ForeignClient<_, _>>> =
             HashMap::new();
 
@@ -128,7 +129,7 @@ impl<Handle: ChainHandle> Topology<Handle> for LinearTopology {
 
             foreign_clients.insert(i, clients);
         }
-        Ok(foreign_clients)
+        Ok(foreign_clients.into())
     }
 }
 

--- a/tools/test-framework/src/types/topology.rs
+++ b/tools/test-framework/src/types/topology.rs
@@ -46,7 +46,7 @@ use ibc_relayer::foreign_client::ForeignClient;
 use crate::bootstrap::binary::chain::bootstrap_foreign_client;
 use crate::error::Error;
 
-pub enum TopologyTypes {
+pub enum TopologyType {
     Linear,
     Full,
 }
@@ -64,7 +64,7 @@ impl FromStr for TopologyTypes {
 }
 
 pub trait Topology<Handle: ChainHandle> {
-    fn get_topology(
+    fn create_topology(
         &self,
         chain_handles: &Vec<Handle>,
     ) -> Result<HashMap<usize, HashMap<usize, ForeignClient<Handle, Handle>>>, Error>;
@@ -132,7 +132,7 @@ impl<Handle: ChainHandle> Topology<Handle> for LinearTopology {
     }
 }
 
-pub fn get_topology<Handle: ChainHandle>(value: &str) -> Box<dyn Topology<Handle>> {
+pub fn bootstrap_topology<Handle: ChainHandle>(topology: TopologyType) -> Box<dyn Topology<Handle>> {
     if let Ok(topology_type) = value.parse() {
         match topology_type {
             TopologyTypes::Full => Box::new(FullyConnectedTopology),

--- a/tools/test-framework/src/util/array.rs
+++ b/tools/test-framework/src/util/array.rs
@@ -16,71 +16,9 @@ pub fn try_into_array<T, const SIZE: usize>(list: Vec<T>) -> Result<[T; SIZE], E
 }
 
 /**
-   Converts a dynamic-sized nested vector `Vec<Vec<T>>` into a fixed-sized
-   nested array `[[T; SIZE]; SIZE]`. Fails if the nested vector is not of
-   `SIZE`x`SIZE` length.
-*/
-pub fn try_into_nested_array<T, const SIZE: usize>(
-    list: Vec<Vec<T>>,
-) -> Result<[[T; SIZE]; SIZE], Error> {
-    let list_a = list
-        .into_iter()
-        .map(try_into_array)
-        .collect::<Result<Vec<_>, _>>()?;
-
-    try_into_array(list_a)
-}
-
-/**
    Converts a fixed-sized nested array `[[T; SIZE]; SIZE]` into a nested
    vector `Vec<Vec<T>>`.
 */
 pub fn into_nested_vec<T, const SIZE: usize>(array: [[T; SIZE]; SIZE]) -> Vec<Vec<T>> {
     array.map(|array_b| array_b.into()).into()
-}
-
-/**
-   Map the elements in the fixed-sized array `[[T; SIZE]; SIZE]`.
-*/
-pub fn map_nested_array<T, R, const SIZE: usize>(
-    array: [[T; SIZE]; SIZE],
-    mapper: impl Fn(T) -> Result<R, Error>,
-) -> Result<[[R; SIZE]; SIZE], Error> {
-    let mapped = into_nested_vec(array)
-        .into_iter()
-        .map(|inner| {
-            inner
-                .into_iter()
-                .map(&mapper)
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    try_into_nested_array(mapped)
-}
-
-/**
-   Asserts that a nested vector `Vec<Vec<T>>` has the same dimension
-   in its inner vectors.
-*/
-pub fn assert_same_dimension<T>(size: usize, list: &Vec<Vec<T>>) -> Result<(), Error> {
-    if list.len() != size {
-        return Err(Error::generic(eyre!(
-            "expect nested vector to have the dimension {} x {}",
-            size,
-            size
-        )));
-    }
-
-    for list_b in list.iter() {
-        if list_b.len() != size {
-            return Err(Error::generic(eyre!(
-                "expect nested vector to have the dimension {} x {}",
-                size,
-                size
-            )));
-        }
-    }
-
-    Ok(())
 }

--- a/tools/test-framework/src/util/mod.rs
+++ b/tools/test-framework/src/util/mod.rs
@@ -10,3 +10,4 @@ pub mod proposal_status;
 pub mod random;
 pub mod retry;
 pub mod suspend;
+pub mod two_dim_hash_map;

--- a/tools/test-framework/src/util/two_dim_hash_map.rs
+++ b/tools/test-framework/src/util/two_dim_hash_map.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct TwoDimHashMap<T> {
+    pub map: HashMap<usize, HashMap<usize, T>>,
+}
+
+impl<T> TwoDimHashMap<T> {
+    pub fn get(&self, coords: (usize, usize)) -> Option<&T> {
+        self.map
+            .get(&coords.0)
+            .and_then(|inner| inner.get(&coords.1))
+    }
+}
+
+impl<T> From<HashMap<usize, HashMap<usize, T>>> for TwoDimHashMap<T> {
+    fn from(value: HashMap<usize, HashMap<usize, T>>) -> Self {
+        TwoDimHashMap { map: value }
+    }
+}

--- a/tools/test-framework/src/util/two_dim_hash_map.rs
+++ b/tools/test-framework/src/util/two_dim_hash_map.rs
@@ -48,18 +48,13 @@ pub struct Iter<'a, T> {
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
-    type Item = (usize, usize, &'a T, bool);
+    type Item = (usize, usize, &'a T);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(inner_iter) = &mut self.inner_iter {
                 if let Some((inner_key, inner_value)) = inner_iter.next() {
-                    return Some((
-                        self.outer_key,
-                        *inner_key,
-                        inner_value,
-                        inner_iter.len() == 0,
-                    ));
+                    return Some((self.outer_key, *inner_key, inner_value));
                 }
             }
 
@@ -106,12 +101,12 @@ mod tests {
         let two_dim_hash_map = TwoDimMap::from(outer_hashmap);
         let mut two_dim_hash_map_iter = two_dim_hash_map.iter();
 
-        assert_eq!(two_dim_hash_map_iter.next(), Some((0, 1, &"a", true)));
+        assert_eq!(two_dim_hash_map_iter.next(), Some((0, 1, &"a")));
 
-        assert_eq!(two_dim_hash_map_iter.next(), Some((1, 0, &"b", false)));
-        assert_eq!(two_dim_hash_map_iter.next(), Some((1, 2, &"c", true)));
+        assert_eq!(two_dim_hash_map_iter.next(), Some((1, 0, &"b")));
+        assert_eq!(two_dim_hash_map_iter.next(), Some((1, 2, &"c")));
 
-        assert_eq!(two_dim_hash_map_iter.next(), Some((2, 1, &"d", true)));
+        assert_eq!(two_dim_hash_map_iter.next(), Some((2, 1, &"d")));
 
         assert_eq!(two_dim_hash_map_iter.next(), None);
     }

--- a/tools/test-framework/src/util/two_dim_hash_map.rs
+++ b/tools/test-framework/src/util/two_dim_hash_map.rs
@@ -1,20 +1,118 @@
-use std::collections::HashMap;
+use std::collections::{btree_map, BTreeMap};
 
-#[derive(Clone)]
-pub struct TwoDimHashMap<T> {
-    pub map: HashMap<usize, HashMap<usize, T>>,
+#[derive(Clone, Debug)]
+pub struct TwoDimMap<T> {
+    pub map: BTreeMap<usize, BTreeMap<usize, T>>,
 }
 
-impl<T> TwoDimHashMap<T> {
-    pub fn get(&self, coords: (usize, usize)) -> Option<&T> {
-        self.map
-            .get(&coords.0)
-            .and_then(|inner| inner.get(&coords.1))
+impl<T> Default for TwoDimMap<T> {
+    fn default() -> Self {
+        TwoDimMap {
+            map: BTreeMap::new(),
+        }
     }
 }
 
-impl<T> From<HashMap<usize, HashMap<usize, T>>> for TwoDimHashMap<T> {
-    fn from(value: HashMap<usize, HashMap<usize, T>>) -> Self {
-        TwoDimHashMap { map: value }
+impl<T> TwoDimMap<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn get(&self, (x, y): (usize, usize)) -> Option<&T> {
+        self.map.get(&x).and_then(|inner| inner.get(&y))
+    }
+
+    pub fn insert(&mut self, (x, y): (usize, usize), value: T) -> Option<T> {
+        if let Some(existing_values) = self.map.get_mut(&x) {
+            existing_values.insert(y, value)
+        } else {
+            let mut new_values = BTreeMap::new();
+            new_values.insert(y, value);
+            self.map.insert(x, new_values);
+            None
+        }
+    }
+
+    pub fn iter(&self) -> Iter<T> {
+        Iter {
+            outer_iter: self.map.iter(),
+            inner_iter: None,
+            outer_key: 0,
+        }
+    }
+}
+
+pub struct Iter<'a, T> {
+    outer_iter: btree_map::Iter<'a, usize, BTreeMap<usize, T>>,
+    inner_iter: Option<btree_map::Iter<'a, usize, T>>,
+    outer_key: usize,
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = (usize, usize, &'a T, bool);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(inner_iter) = &mut self.inner_iter {
+                if let Some((inner_key, inner_value)) = inner_iter.next() {
+                    return Some((
+                        self.outer_key,
+                        *inner_key,
+                        inner_value,
+                        inner_iter.len() == 0,
+                    ));
+                }
+            }
+
+            if let Some((outer_key, inner_map)) = self.outer_iter.next() {
+                self.outer_key = *outer_key;
+                self.inner_iter = Some(inner_map.iter());
+            } else {
+                return None;
+            }
+        }
+    }
+}
+
+impl<T> From<BTreeMap<usize, BTreeMap<usize, T>>> for TwoDimMap<T> {
+    fn from(map: BTreeMap<usize, BTreeMap<usize, T>>) -> Self {
+        Self { map }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn test_two_dim_hash_map_iterator() {
+        let mut outer_hashmap = BTreeMap::new();
+        let mut inner_hashmap1 = BTreeMap::new();
+        let mut inner_hashmap2 = BTreeMap::new();
+        let mut inner_hashmap3 = BTreeMap::new();
+
+        inner_hashmap1.insert(1, "a");
+
+        inner_hashmap2.insert(2, "c");
+        inner_hashmap2.insert(0, "b");
+
+        inner_hashmap3.insert(1, "d");
+
+        outer_hashmap.insert(0, inner_hashmap1);
+        outer_hashmap.insert(1, inner_hashmap2);
+        outer_hashmap.insert(2, inner_hashmap3);
+
+        let two_dim_hash_map = TwoDimMap::from(outer_hashmap);
+        let mut two_dim_hash_map_iter = two_dim_hash_map.iter();
+
+        assert_eq!(two_dim_hash_map_iter.next(), Some((0, 1, &"a", true)));
+
+        assert_eq!(two_dim_hash_map_iter.next(), Some((1, 0, &"b", false)));
+        assert_eq!(two_dim_hash_map_iter.next(), Some((1, 2, &"c", true)));
+
+        assert_eq!(two_dim_hash_map_iter.next(), Some((2, 1, &"d", true)));
+
+        assert_eq!(two_dim_hash_map_iter.next(), None);
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4038 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR refactors the bootstrapping of n-ary chain tests in order to use the specified topology. Only linear and fully connected are currently supported, and if the topology is not specified the linear one is used.

This also facilitates the implementation of new topologies if required.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
