### PR TITLE
Improve channel and port filter policy parsing

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/4045-trim-whitespaces-channel-port-filter.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/4045-trim-whitespaces-channel-port-filter.md
@@ -1,0 +1,5 @@
+- Updated the channel and port filter parsing to ignore whitespaces.
+  This will prevent unintended channel scanning due to accidental
+  whitespaces when exact matches are specified in the `packet_filter`
+  configuration.
+  ([\#4045](https://github.com/informalsystems/hermes/issues/4045))

--- a/crates/relayer/src/config/filter.rs
+++ b/crates/relayer/src/config/filter.rs
@@ -384,11 +384,12 @@ pub(crate) mod port {
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            if v.contains('*') {
-                let wildcard = v.parse().map_err(E::custom)?;
+            let trimmed_v = v.trim();
+            if trimmed_v.contains('*') {
+                let wildcard = trimmed_v.parse().map_err(E::custom)?;
                 Ok(PortFilterMatch::Wildcard(wildcard))
             } else {
-                let port_id = PortId::from_str(v.trim()).map_err(E::custom)?;
+                let port_id = PortId::from_str(trimmed_v).map_err(E::custom)?;
                 Ok(PortFilterMatch::Exact(port_id))
             }
         }
@@ -412,11 +413,12 @@ pub(crate) mod channel {
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            if v.contains('*') {
-                let wildcard = v.parse().map_err(E::custom)?;
+            let trimmed_v = v.trim();
+            if trimmed_v.contains('*') {
+                let wildcard = trimmed_v.parse().map_err(E::custom)?;
                 Ok(ChannelFilterMatch::Wildcard(wildcard))
             } else {
-                let channel_id = ChannelId::from_str(v.trim()).map_err(E::custom)?;
+                let channel_id = ChannelId::from_str(trimmed_v.trim()).map_err(E::custom)?;
                 Ok(ChannelFilterMatch::Exact(channel_id))
             }
         }

--- a/crates/relayer/src/config/filter.rs
+++ b/crates/relayer/src/config/filter.rs
@@ -384,11 +384,12 @@ pub(crate) mod port {
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            if let Ok(port_id) = PortId::from_str(v) {
-                Ok(PortFilterMatch::Exact(port_id))
-            } else {
+            if v.contains('*') {
                 let wildcard = v.parse().map_err(E::custom)?;
                 Ok(PortFilterMatch::Wildcard(wildcard))
+            } else {
+                let port_id = PortId::from_str(v.trim()).map_err(E::custom)?;
+                Ok(PortFilterMatch::Exact(port_id))
             }
         }
 
@@ -411,11 +412,12 @@ pub(crate) mod channel {
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            if let Ok(channel_id) = ChannelId::from_str(v) {
-                Ok(ChannelFilterMatch::Exact(channel_id))
-            } else {
+            if v.contains('*') {
                 let wildcard = v.parse().map_err(E::custom)?;
                 Ok(ChannelFilterMatch::Wildcard(wildcard))
+            } else {
+                let channel_id = ChannelId::from_str(v.trim()).map_err(E::custom)?;
+                Ok(ChannelFilterMatch::Exact(channel_id))
             }
         }
 
@@ -601,5 +603,22 @@ mod tests {
     fn to_string_wildcards() {
         let wildcard = "ica*".parse::<Wildcard>().unwrap();
         assert_eq!(wildcard.to_string(), "ica*".to_string());
+    }
+
+    #[test]
+    fn test_exact_matches() {
+        let allow_policy = r#"
+            policy = "allow"
+            list = [
+                [ "transfer", "channel-88", ], # Standard exact match
+                [ "transfer", "channel-476 ", ], # Whitespace abstraction
+            ]
+            "#;
+
+        let pf: ChannelPolicy =
+            toml::from_str(allow_policy).expect("could not parse filter policy");
+
+        let assert_allow = matches!(pf, ChannelPolicy::Allow(filters) if filters.is_exact());
+        assert!(assert_allow);
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4045

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR adds whitespace trimming before parsing values in the `list` of `packet_filter` configuration.

This will avoid triggering channel scanning if there is an unintended whitespace, e.g.:

```toml
    policy = "allow"
    list = [
        [ "transfer", "channel-1 ", ],
    ]
```

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] ~Updated code comments and documentation (e.g., `docs/`).~
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
