### PR TITLE
Reduce ICS29 tests run time

### DIFF
--- a/.changelog/unreleased/improvements/ibc-integration-test/4053-reduce-ics29-tests-run-time.md
+++ b/.changelog/unreleased/improvements/ibc-integration-test/4053-reduce-ics29-tests-run-time.md
@@ -1,0 +1,4 @@
+- Reduce run time for ICS29 tests by immediately verifying if either
+  the legacy fees, `recv_fee + ack_fee + timeout_fee` or current
+  fees, `max(recv_fee + ack_fee, timeout_fee)` have been escrowed.
+  ([\#4053](https://github.com/informalsystems/hermes/issues/4053))

--- a/tools/integration-test/src/tests/fee/filter_fees.rs
+++ b/tools/integration-test/src/tests/fee/filter_fees.rs
@@ -75,7 +75,6 @@ impl BinaryChannelTest for FilterIncentivizedFeesRelayerTest {
             let ack_fee = random_u128_range(200, 300);
             let timeout_fee = random_u128_range(100, 200);
 
-            // Before ibc-go v8.1.0 the amount escrowed for ICS29 fees is the sum of recv, ack and timeout fees
             let balance_a2 = balance_a1.clone() - send_amount;
 
             chain_driver_a.ibc_token_transfer_with_fee(
@@ -223,7 +222,6 @@ impl BinaryChannelTest for FilterByChannelIncentivizedFeesRelayerTest {
         let ack_fee = random_u128_range(200, 300);
         let timeout_fee = random_u128_range(100, 200);
 
-        // Before ibc-go v8.1.0 the amount escrowed for ICS29 fees is the sum of recv, ack and timeout fees
         let balance_a2 = balance_a1.clone() - send_amount;
 
         let denom_b = derive_ibc_denom(

--- a/tools/test-framework/src/chain/tagged.rs
+++ b/tools/test-framework/src/chain/tagged.rs
@@ -72,6 +72,23 @@ pub trait TaggedChainDriverExt<Chain> {
     ) -> Result<(), Error>;
 
     /**
+       Tagged version of [`ChainDriver::assert_eventual_escrowed_amount_ics29`].
+
+       Assert that a wallet should eventually have escrowed the amount for ICS29
+       fees of a given denomination.
+       Legacy ICS29 will escrow recv_fee + ack_fee + timeout_fee while more recent
+       versions will escrow max(recv_fee + ack_fee, timeout_fee).
+    */
+    fn assert_eventual_escrowed_amount_ics29(
+        &self,
+        user: &MonoTagged<Chain, &WalletAddress>,
+        token: &TaggedTokenRef<Chain>,
+        recv_fee: u128,
+        ack_fee: u128,
+        timeout_fee: u128,
+    ) -> Result<(), Error>;
+
+    /**
         Tagged version of [`query_recipient_transactions`].
 
         Query for the transactions related to a wallet on `Chain`
@@ -149,6 +166,23 @@ impl<'a, Chain: Send> TaggedChainDriverExt<Chain> for MonoTagged<Chain, &'a Chai
     ) -> Result<(), Error> {
         self.value()
             .assert_eventual_wallet_amount(user.value(), token.value())
+    }
+
+    fn assert_eventual_escrowed_amount_ics29(
+        &self,
+        user: &MonoTagged<Chain, &WalletAddress>,
+        token: &TaggedTokenRef<Chain>,
+        recv_fee: u128,
+        ack_fee: u128,
+        timeout_fee: u128,
+    ) -> Result<(), Error> {
+        self.value().assert_eventual_escrowed_amount_ics29(
+            user.value(),
+            token.value(),
+            recv_fee,
+            ack_fee,
+            timeout_fee,
+        )
     }
 
     fn query_recipient_transactions(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4053 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR reduces the run time of three ICS29 tests by verifying if the escrowed amount is either the legacy amount, `recv_fee + ack_fee + timeout_fee` or the current `max(recv_fee + ack_fee, timeout_fee)`.

This avoids the necessity to have the first assertion fail and then run the second one for tests running with a chain with ibc-go v8+.

### Impact

* `tests::fee::filter_fees::test_filter_by_channel_incentivized_fees_relayer`
  * ibc-go v7: No significant difference
  * ibc-go v8: Went from around 200 seconds to 110 seconds
* `tests::fee::filter_fees::test_filter_incentivized_fees_relayer`
  * ibc-go v7: No significant difference
  * ibc-go v8: Went from around 330 seconds to 115 seconds
* tests::fee::pay_fee_async::test_pay_packet_fee_async`
  * ibc-go v7: No significant difference
  * ibc-go v8: Went from around 320 seconds to 120 seconds

The total time to run the 10 ICS29 tests with chains having ibc-go v8+ has been reduced by approximately 8 minutes.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
