### PR TITLE
Test ICS29 fees with additional chains

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -79,7 +79,7 @@ jobs:
             command: junod
             account_prefix: juno
             native_token: stake
-            features: juno,forward-packet,ica,ics29-fee
+            features: juno,forward-packet,ica
           - package: provenance
             command: provenanced
             account_prefix: pb

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -79,7 +79,7 @@ jobs:
             command: junod
             account_prefix: juno
             native_token: stake
-            features: juno,forward-packet,ica
+            features: juno,forward-packet,ica,ics29-fee
           - package: provenance
             command: provenanced
             account_prefix: pb
@@ -89,12 +89,12 @@ jobs:
             command: migalood
             account_prefix: migaloo
             native_token: stake
-            features: ''
+            features: ics29-fee
           - package: injective
             command: injectived
             account_prefix: inj
             native_token: stake
-            features: forward-packet,fee-grant
+            features: forward-packet,fee-grant,ics29-fee
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -94,7 +94,7 @@ jobs:
             command: injectived
             account_prefix: inj
             native_token: stake
-            features: forward-packet,fee-grant,ics29-fee
+            features: forward-packet,fee-grant
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #3091

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR adds the `ics29-fee` feature to tests running with Migaloo.
With these additions Hermes will now test ICS29 with the following chains:

* Ibc-go simapp `v6`,  `v7` and `v8`
* Gaia
* ~Juno~ Current version has incorrect wiring of PFM and ICS29
* Migaloo
* ~Injective~ Current version has incorrect wiring of PFM and ICS29

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] ~Updated code comments and documentation (e.g., `docs/`).~
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
