### PR TITLE
Add warning if no packet data was pulled when clearing packets

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/4072-packet-clear-logs.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/4072-packet-clear-logs.md
@@ -1,0 +1,6 @@
+- Improve logs when clearing packet.
+  * When Hermes doesn't pull packet data it will now warn the user
+    instead of logging `pulled packet data for 0 events out of X`
+  * When ICS20 packets are filtered due to having a receiver or memo
+    field too big, the log will be at `warn` level instead of `debug`.
+  ([\#4072](https://github.com/informalsystems/hermes/issues/4072))

--- a/crates/relayer/src/link/packet_events.rs
+++ b/crates/relayer/src/link/packet_events.rs
@@ -41,7 +41,7 @@ where
             Ok(events) => {
                 events_left -= chunk.len();
 
-                if events.is_empty() && chunk.len() > events.len() {
+                if events.is_empty() && !chunk.is_empty() {
                     warn!("no packet data was pulled at height {query_height} for sequences {}, this might be due to the data not being available on the configured endpoint. \
                     Please verify that the RPC endpoint has the required packet data",
                     chunk.iter().copied().collated().format(", "));
@@ -49,7 +49,7 @@ where
                     info!(
                         events.total = %events_total,
                         events.left = %events_left,
-                        "pulled packet data for {} events out of {} sequences: {};",
+                        "pulled packet data for {} out of {} events: {}",
                         events.len(),
                         chunk.len(),
                         chunk.iter().copied().collated().format(", "),

--- a/crates/relayer/src/link/packet_events.rs
+++ b/crates/relayer/src/link/packet_events.rs
@@ -41,14 +41,21 @@ where
             Ok(events) => {
                 events_left -= chunk.len();
 
-                info!(
-                    events.total = %events_total,
-                    events.left = %events_left,
-                    "pulled packet data for {} events out of {} sequences: {};",
-                    events.len(),
-                    chunk.len(),
-                    chunk.iter().copied().collated().format(", "),
-                );
+                if events.is_empty() && chunk.len() > events.len() {
+                    warn!("no packet data was pulled at height {query_height} for sequences {}, this might be due to the data not being available on the configured endpoint. \
+                    Please verify that the RPC endpoint has the required packet data",
+                    chunk.iter().copied().collated().format(", "));
+                } else {
+                    info!(
+                        events.total = %events_total,
+                        events.left = %events_left,
+                        "pulled packet data for {} events out of {} sequences: {};",
+                        events.len(),
+                        chunk.len(),
+                        chunk.iter().copied().collated().format(", "),
+                    );
+                }
+
 
                 // Because we use the first event height to do the client update,
                 // if the heights of the events differ, we get proof verification failures.

--- a/crates/relayer/src/link/packet_events.rs
+++ b/crates/relayer/src/link/packet_events.rs
@@ -43,7 +43,7 @@ where
 
                 if events.is_empty() && !chunk.is_empty() {
                     warn!("no packet data was pulled at height {query_height} for sequences {}, this might be due to the data not being available on the configured endpoint. \
-                    Please verify that the RPC endpoint has the required packet data",
+                    Please verify that the RPC endpoint has the required packet data, for more details see https://hermes.informal.systems/advanced/troubleshooting/cross-comp-config.html#uncleared-pending-packets",
                     chunk.iter().copied().collated().format(", "));
                 } else {
                     info!(

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -1947,7 +1947,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
     }
 }
 
-#[tracing::instrument(skip(data))]
+#[tracing::instrument(skip_all)]
 fn check_ics20_fields_size(
     data: &[u8],
     memo_limit: Ics20FieldSizeLimit,
@@ -1962,9 +1962,9 @@ fn check_ics20_fields_size(
                 (ValidationResult::Valid, ValidationResult::Valid) => true,
 
                 (memo_validity, receiver_validity) => {
-                    debug!("found invalid ICS-20 packet data, not relaying packet!");
-                    debug!("    ICS-20 memo:     {memo_validity}");
-                    debug!("    ICS-20 receiver: {receiver_validity}");
+                    warn!("found invalid ICS-20 packet data, not relaying packet!");
+                    warn!("    ICS-20 memo:     {memo_validity}");
+                    warn!("    ICS-20 receiver: {receiver_validity}");
 
                     false
                 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4072

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

This PR replaces the info log `pulled packet data for {} events out of {} sequences: {};` with a warning when no packet data was pulled.

Update the log level for filtered ICS20 packets with invalid receiver or memo field from `debug` to `warn`.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- [ ] ~Updated code comments and documentation (e.g., `docs/`).~
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
