### PR TITLE
Deserialize ics20 v2 packet data with Protobuf

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/4098-deserialize-ics20-v2-packet-data-with-protobuf.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/4098-deserialize-ics20-v2-packet-data-with-protobuf.md
@@ -1,0 +1,2 @@
+- Deserialize ICS20 v2 packet data using Protobuf instead of JSON
+  ([\#4098](https://github.com/informalsystems/hermes/issues/4098))

--- a/crates/relayer/src/link.rs
+++ b/crates/relayer/src/link.rs
@@ -146,7 +146,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
         }
 
         // Query the channel if it exists in order to retrieve the channel version.
-        // If the channel doesn't exist, set the version to None.
+        // If the channel doesn't exist or the query fails, set the version to None.
         let maybe_channel_a = a_chain.query_channel(
             QueryChannelRequest {
                 port_id: opts.src_port_id.clone(),

--- a/crates/relayer/src/link/relay_path.rs
+++ b/crates/relayer/src/link/relay_path.rs
@@ -2,13 +2,15 @@ use alloc::collections::BTreeMap as HashMap;
 use alloc::collections::VecDeque;
 use ibc_relayer_types::core::ics04_channel::packet::Sequence;
 use ibc_relayer_types::core::ics04_channel::version::Version;
+use prost::Message;
+use serde::de::Error as _;
 use serde_json::Error;
 use std::ops::Sub;
 use std::time::{Duration, Instant};
 
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::ibc::applications::transfer::v2::FungibleTokenPacketData as RawPacketData;
-use ibc_proto::ibc::applications::transfer::v2::FungibleTokenPacketDataV2 as RawPacketDataV2;
+use ibc_proto::ibc::applications::transfer::v2::FungibleTokenPacketData;
+use ibc_proto::ibc::applications::transfer::v2::FungibleTokenPacketDataV2;
 use itertools::Itertools;
 use tracing::{debug, error, info, span, trace, warn, Level};
 
@@ -2020,12 +2022,12 @@ fn extract_memo_and_receiver(
     data: &[u8],
 ) -> Result<(String, String), Error> {
     if channel_version.is_ics20_v2() {
-        match serde_json::from_slice::<RawPacketDataV2>(data) {
+        match FungibleTokenPacketDataV2::decode(data) {
             Ok(packet_data) => Ok((packet_data.memo, packet_data.receiver)),
-            Err(e) => Err(e),
+            Err(e) => Err(Error::custom(e.to_string())),
         }
     } else {
-        match serde_json::from_slice::<RawPacketData>(data) {
+        match serde_json::from_slice::<FungibleTokenPacketData>(data) {
             Ok(packet_data) => Ok((packet_data.memo, packet_data.receiver)),
             Err(e) => Err(e),
         }

--- a/tools/integration-test/src/tests/ics20_filter/memo.rs
+++ b/tools/integration-test/src/tests/ics20_filter/memo.rs
@@ -10,6 +10,7 @@ fn test_memo_filter() -> Result<(), Error> {
     run_binary_channel_test(&IbcMemoFilterTest { ics20_version: 1 })
 }
 
+#[cfg(any(doc, feature = "ics20-v2"))]
 #[test]
 fn test_memo_filter_ics20_v2() -> Result<(), Error> {
     run_binary_channel_test(&IbcMemoFilterTest { ics20_version: 2 })

--- a/tools/integration-test/src/tests/ics20_filter/memo.rs
+++ b/tools/integration-test/src/tests/ics20_filter/memo.rs
@@ -1,16 +1,25 @@
 use byte_unit::Byte;
 
-use ibc_relayer::config::types::ics20_field_size_limit::Ics20FieldSizeLimit;
+use ibc_relayer::{
+    channel::version::Version, config::types::ics20_field_size_limit::Ics20FieldSizeLimit,
+};
 use ibc_test_framework::prelude::*;
 
 #[test]
 fn test_memo_filter() -> Result<(), Error> {
-    run_binary_channel_test(&IbcMemoFilterTest)
+    run_binary_channel_test(&IbcMemoFilterTest { ics20_version: 1 })
+}
+
+#[test]
+fn test_memo_filter_ics20_v2() -> Result<(), Error> {
+    run_binary_channel_test(&IbcMemoFilterTest { ics20_version: 2 })
 }
 
 const MEMO_SIZE_LIMIT: usize = 2000;
 
-pub struct IbcMemoFilterTest;
+pub struct IbcMemoFilterTest {
+    pub ics20_version: u64,
+}
 
 impl TestOverrides for IbcMemoFilterTest {
     fn modify_relayer_config(&self, config: &mut Config) {
@@ -18,6 +27,10 @@ impl TestOverrides for IbcMemoFilterTest {
             Ics20FieldSizeLimit::new(true, Byte::from_bytes(MEMO_SIZE_LIMIT as u64));
 
         config.mode.clients.misbehaviour = false;
+    }
+
+    fn channel_version(&self) -> Version {
+        Version::ics20(self.ics20_version)
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4098 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->

The encoding if ICS20 v2 PacketData was switched from JSON to Protobuf, https://github.com/cosmos/ibc/issues/1097. This PR updates how the packet data is deserialized when checking the length of the receiver and memo field.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
