### PR TITLE
Fix typos

### DIFF
--- a/crates/relayer-cli/src/conclude.rs
+++ b/crates/relayer-cli/src/conclude.rs
@@ -197,7 +197,7 @@ impl Output {
         Output::with_success().with_result(result)
     }
 
-    /// Quick-access constructor for an output message signalling a error `status`.
+    /// Quick-access constructor for an output message signalling an error `status`.
     pub fn error(msg: impl ToString) -> Self {
         Output::with_error().with_msg(msg)
     }

--- a/tools/integration-test/src/tests/client_upgrade.rs
+++ b/tools/integration-test/src/tests/client_upgrade.rs
@@ -86,7 +86,7 @@ impl BinaryChainTest for ClientUpgradeTest {
             MonoTagged::new(Denom::base(config.native_token(0)));
         let foreign_clients = chains.clone().foreign_clients;
 
-        // Create and send an chain upgrade proposal
+        // Create and send a chain upgrade proposal
         let opts = create_upgrade_plan(config, &chains, &upgraded_chain_id)?;
 
         build_and_send_ibc_upgrade_proposal(
@@ -245,7 +245,7 @@ impl BinaryChainTest for HeightTooHighClientUpgradeTest {
             MonoTagged::new(Denom::base(config.native_token(0)));
         let foreign_clients = chains.clone().foreign_clients;
 
-        // Create and send an chain upgrade proposal
+        // Create and send a chain upgrade proposal
         let opts = create_upgrade_plan(config, &chains, &upgraded_chain_id)?;
 
         build_and_send_ibc_upgrade_proposal(
@@ -439,7 +439,7 @@ fn create_upgrade_plan<ChainA: ChainHandle, ChainB: ChainHandle>(
     let src_client_id = foreign_clients.client_id_b().0.clone();
 
     let gov_account = chains.node_a.chain_driver().query_auth_module("gov")?;
-    // Create and send an chain upgrade proposal
+    // Create and send a chain upgrade proposal
     Ok(UpgradePlanOptions {
         src_client_id,
         amount: MIN_DEPOSIT,

--- a/tools/test-framework/src/docs/walkthroughs/simple.rs
+++ b/tools/test-framework/src/docs/walkthroughs/simple.rs
@@ -36,7 +36,7 @@
 //! completed handshakes.
 //!
 //! Note that the `run_binary_channel_test` (and indeed every `run_*` test function) takes as
-//! its single parameter an struct that represents the test case. While in this case, the struct
+//! its single parameter a struct that represents the test case. While in this case, the struct
 //! is empty, fields can be added to the struct in the case that you want to run multiple tests
 //! using it. See `tools/test-framework/src/docs/walkthroughs/memo.rs` as an example
 //! of a test that utilizes a non-empty struct as input. In order to customize the behavior

--- a/tools/test-framework/src/types/tagged/dual.rs
+++ b/tools/test-framework/src/types/tagged/dual.rs
@@ -357,7 +357,7 @@ impl<TagA, TagB, Value> Tagged<TagA, TagB, Option<Value>> {
 
 impl<TagA, TagB, Value, E> Tagged<TagA, TagB, Result<Value, E>> {
     /**
-        Convert a tagged [`Result`] value into an result tagged value.
+        Convert a tagged [`Result`] value into a result tagged value.
 
         Example:
 

--- a/tools/test-framework/src/types/tagged/mono.rs
+++ b/tools/test-framework/src/types/tagged/mono.rs
@@ -265,7 +265,7 @@ impl<Tag, Value> Tagged<Tag, Option<Value>> {
 
 impl<Tag, Value, E> Tagged<Tag, Result<Value, E>> {
     /**
-        Convert a tagged [`Result`] value into an result tagged value.
+        Convert a tagged [`Result`] value into a result tagged value.
 
         Example:
 


### PR DESCRIPTION
This PR corrects several typos in comments across multiple Rust files in the codebase. These changes improve readability and maintain consistency without affecting functionality.

#### Files and Changes:
- **`crates/relayer-cli/src/conclude.rs`**
  - Fixed "a error `status`" to "an error `status`."
- **`tools/integration-test/src/tests/client_upgrade.rs`**
  - Corrected "an chain upgrade proposal" to "a chain upgrade proposal."
- **`tools/test-framework/src/docs/walkthroughs/simple.rs`**
  - Fixed "an struct" to "a struct."
- **`tools/test-framework/src/types/tagged/dual.rs`**
  - Corrected "an result tagged value" to "a result tagged value."
- **`tools/test-framework/src/types/tagged/mono.rs`**
  - Corrected "an result tagged value" to "a result tagged value."
