### PR TITLE
refactor: Improve error messages and parameter naming in Namada config

### DIFF
--- a/tools/test-framework/src/chain/config/namada.rs
+++ b/tools/test-framework/src/chain/config/namada.rs
@@ -5,13 +5,13 @@ use toml::Value;
 pub fn set_rpc_port(config: &mut Value, port: u16) -> Result<(), Error> {
     config
         .get_mut("ledger")
-        .ok_or_else(|| eyre!("expect ledger section"))?
+        .ok_or_else(|| eyre!("expected ledger section"))?
         .get_mut("cometbft")
-        .ok_or_else(|| eyre!("expect cometbft section"))?
+        .ok_or_else(|| eyre!("expected cometbft section"))?
         .get_mut("rpc")
-        .ok_or_else(|| eyre!("expect cometbft rpc"))?
+        .ok_or_else(|| eyre!("expected cometbft rpc section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "laddr".to_string(),
             format!("tcp://0.0.0.0:{}", port).into(),
@@ -24,13 +24,13 @@ pub fn set_rpc_port(config: &mut Value, port: u16) -> Result<(), Error> {
 pub fn set_p2p_port(config: &mut Value, port: u16) -> Result<(), Error> {
     config
         .get_mut("ledger")
-        .ok_or_else(|| eyre!("expect ledger section"))?
+        .ok_or_else(|| eyre!("expected ledger section"))?
         .get_mut("cometbft")
-        .ok_or_else(|| eyre!("expect cometbft section"))?
+        .ok_or_else(|| eyre!("expected cometbft section"))?
         .get_mut("p2p")
-        .ok_or_else(|| eyre!("expect cometbft p2p"))?
+        .ok_or_else(|| eyre!("expected cometbft p2p section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "laddr".to_string(),
             format!("tcp://0.0.0.0:{}", port).into(),
@@ -43,11 +43,11 @@ pub fn set_p2p_port(config: &mut Value, port: u16) -> Result<(), Error> {
 pub fn set_proxy_app_port(config: &mut Value, port: u16) -> Result<(), Error> {
     config
         .get_mut("ledger")
-        .ok_or_else(|| eyre!("expect ledger section"))?
+        .ok_or_else(|| eyre!("expected ledger section"))?
         .get_mut("cometbft")
-        .ok_or_else(|| eyre!("expect cometbft section"))?
+        .ok_or_else(|| eyre!("expected cometbft section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "proxy_app".to_string(),
             format!("tcp://0.0.0.0:{}", port).into(),
@@ -57,56 +57,56 @@ pub fn set_proxy_app_port(config: &mut Value, port: u16) -> Result<(), Error> {
 }
 
 /// Set the `block_cache_bytes` field in the full node config.
-pub fn set_block_cache_bytes(config: &mut Value, block_cache_bytes: i64) -> Result<(), Error> {
+pub fn set_block_cache_bytes(config: &mut Value, cache_size: i64) -> Result<(), Error> {
     config
         .get_mut("ledger")
-        .ok_or_else(|| eyre!("expect ledger section"))?
+        .ok_or_else(|| eyre!("expected ledger section"))?
         .get_mut("shell")
-        .ok_or_else(|| eyre!("expect shell section"))?
+        .ok_or_else(|| eyre!("expected shell section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "block_cache_bytes".to_string(),
-            Value::Integer(block_cache_bytes),
+            Value::Integer(cache_size),
         );
 
     Ok(())
 }
 
-pub fn set_unbonding_len(parameters: &mut Value, unbonding_len: i64) -> Result<(), Error> {
+pub fn set_unbonding_len(parameters: &mut Value, length: i64) -> Result<(), Error> {
     parameters
         .get_mut("pos_params")
-        .ok_or_else(|| eyre!("expect pos_params section"))?
+        .ok_or_else(|| eyre!("expected pos_params section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
-        .insert("unbonding_len".to_string(), Value::Integer(unbonding_len));
+        .ok_or_else(|| eyre!("expected object"))?
+        .insert("unbonding_len".to_string(), Value::Integer(length));
 
     Ok(())
 }
 
-pub fn set_pipeline_len(parameters: &mut Value, pipeline_len: i64) -> Result<(), Error> {
+pub fn set_pipeline_len(parameters: &mut Value, length: i64) -> Result<(), Error> {
     parameters
         .get_mut("pos_params")
-        .ok_or_else(|| eyre!("expect pos_params section"))?
+        .ok_or_else(|| eyre!("expected pos_params section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
-        .insert("pipeline_len".to_string(), Value::Integer(pipeline_len));
+        .ok_or_else(|| eyre!("expected object"))?
+        .insert("pipeline_len".to_string(), Value::Integer(length));
 
     Ok(())
 }
 
 pub fn set_default_mint_limit(
     parameters: &mut Value,
-    default_mint_limit: i64,
+    limit: i64,
 ) -> Result<(), Error> {
     parameters
         .get_mut("ibc_params")
-        .ok_or_else(|| eyre!("expect ibc_params section"))?
+        .ok_or_else(|| eyre!("expected ibc_params section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "default_mint_limit".to_string(),
-            Value::String(default_mint_limit.to_string()),
+            Value::String(limit.to_string()),
         );
 
     Ok(())
@@ -114,30 +114,30 @@ pub fn set_default_mint_limit(
 
 pub fn set_default_per_epoch_throughput_limit(
     parameters: &mut Value,
-    default_per_epoch_throughput_limit: i64,
+    limit: i64,
 ) -> Result<(), Error> {
     parameters
         .get_mut("ibc_params")
-        .ok_or_else(|| eyre!("expect ibc_params section"))?
+        .ok_or_else(|| eyre!("expected ibc_params section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "default_per_epoch_throughput_limit".to_string(),
-            Value::String(default_per_epoch_throughput_limit.to_string()),
+            Value::String(limit.to_string()),
         );
 
     Ok(())
 }
 
-pub fn set_epochs_per_year(parameters: &mut Value, epochs_per_year: i64) -> Result<(), Error> {
+pub fn set_epochs_per_year(parameters: &mut Value, epochs: i64) -> Result<(), Error> {
     parameters
         .get_mut("parameters")
-        .ok_or_else(|| eyre!("expect parameters section"))?
+        .ok_or_else(|| eyre!("expected parameters section"))?
         .as_table_mut()
-        .ok_or_else(|| eyre!("expect object"))?
+        .ok_or_else(|| eyre!("expected object"))?
         .insert(
             "epochs_per_year".to_string(),
-            Value::Integer(epochs_per_year),
+            Value::Integer(epochs),
         );
 
     Ok(())


### PR DESCRIPTION
Description:
- Standardized error messages by changing "expect" to "expected" and adding "section" where missing
- Simplified parameter names for better readability (e.g. block_cache_bytes -> cache_size, default_mint_limit -> limit)
