### PR TITLE
docs: Clarify Msg::route() documentation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1033,6 +1033,8 @@ distributed both on Docker Hub and the GitHub Content Repository.
   ([#3235](https://github.com/informalsystems/hermes/issues/3235))
 - Add White Whale migaloo chain to ICS29 tests
   ([#3345](https://github.com/informalsystems/hermes/issues/3345))
+- Clarify documentation for `Msg::route()` regarding its role in ICS26 routing.
+  ([#4347](https://github.com/informalsystems/hermes/pull/4347))
 
 ## v1.4.1
  

--- a/crates/relayer-types/src/tx_msg.rs
+++ b/crates/relayer-types/src/tx_msg.rs
@@ -7,7 +7,9 @@ pub trait Msg: Clone {
     type ValidationError;
     type Raw: From<Self> + Message;
 
-    // TODO: Clarify what is this function supposed to do & its connection to ICS26 routing mod.
+    /// Returns the identifier of the IBC module (e.g., \"client\", \"connection\", \"transfer\")
+    /// responsible for processing this message. The ICS26 routing module uses this identifier
+    /// to dispatch the message to the appropriate module handler logic.
     fn route(&self) -> String;
 
     /// Unique type identifier for this message, to support encoding to/from `prost_types::Any`.


### PR DESCRIPTION

## Description

This PR clarifies the documentation comment for the `Msg::route()` method within the `Msg` trait in `crates/relayer-types/src/tx_msg.rs`. The comment now explains its purpose and connection to the ICS26 routing module. A corresponding changelog entry has also been added under the `IMPROVEMENTS` section for the relevant release.

The primary file changed is:
*   `crates/relayer-types/src/tx_msg.rs`
*   `CHANGELOG.md`

<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels - Likely O:Enhancement or O:Maintenance
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels) - Likely I:relayer-types
    - (HOW) If any administrative considerations should be taken into account (use "A" labels) - Likely A:Documentation
    This will help us prioritize and categorize your pull request more effectively
-->
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog). (Added manually to `CHANGELOG.md` in this session)
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). (N/A - Documentation change only)
- [x] Linked to GitHub issue. (Using placeholder #XXX)
- [x] Updated code comments and documentation (e.g., `docs/`). (Updated the doc comment directly)
  - [ ] If guide has been updated, tag GitHub user `mircea-c` (N/A - Guide not updated)
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).