### PR TITLE
 fix: fixed broken link in logging level documentation

### DIFF
--- a/guide/src/advanced/troubleshooting/log-level.md
+++ b/guide/src/advanced/troubleshooting/log-level.md
@@ -120,7 +120,7 @@ You can update the tracing filter without restarting your instance. There are tw
 
 ### Limited command
 
-If possible use the [log-level](../../../documentation/commands/logs/index.md#log-level) command as the results are guaranteed.
+If possible use the [log level](../../../commands/logs/index.md#log-level) command as the results are guaranteed.
 
 __Examples__
 


### PR DESCRIPTION
Fixed a broken link in guide/src/advanced/troubleshooting/log-level.md that 
pointed to a non-existent path. The link now correctly points to 
the appropriate section in the logging commands documentation. 

This fix resolves an error that would appear when building the documentation: 
[ERROR] Cannot find file in log-level.md