### PR TITLE
fix: move wait command outside loop in generate_commands_rec for proper parallel execution

### DIFF
--- a/scripts/auto_gen_templates.sh
+++ b/scripts/auto_gen_templates.sh
@@ -103,9 +103,9 @@ function generate_commands_rec(){
                 print_array_with_prefix $new_cmd_prefix $new_commands
                 generate_commands_rec $new_cmd_prefix $new_commands &
             fi
-            wait
         fi
     done
+    wait
 }
 
 function generate_commands(){


### PR DESCRIPTION
Fix logical error where wait was executed immediately after each background
process in the for loop, making parallel execution ineffective.

- Moved wait command from inside the loop to the end of generate_commands_rec function
- Now all recursive calls run in parallel and wait for completion at the end
- Improves performance by allowing concurrent subcommand processing