### PR TITLE
feat(penumbra): add tilda shell file expansion support

### DIFF
--- a/.changelog/unreleased/improvements/4396-penumbra-tilda-file-expansion.md
+++ b/.changelog/unreleased/improvements/4396-penumbra-tilda-file-expansion.md
@@ -1,0 +1,2 @@
+- Add ~ shell expansion support in the penumbra view_service_storage_dir
+  ([\#4396](https://github.com/informalsystems/hermes/pull/4396))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4548,6 +4548,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
+ "shellexpand",
  "signature",
  "strum 0.25.0",
  "subtle-encoding",
@@ -9903,6 +9904,15 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -28,6 +28,7 @@ penumbra-sdk-fee         = "2.0.0"
 penumbra-sdk-view        = "2.0.0"
 penumbra-sdk-transaction = { version = "2.0.0", features = ["download-proving-keys"] }
 pbjson-types = "0.7"
+shellexpand  = "3.1.1"
 
 ibc-proto         = { workspace = true, features = ["serde"] }
 ibc-telemetry     = { workspace = true }

--- a/crates/relayer/src/chain/penumbra.rs
+++ b/crates/relayer/src/chain/penumbra.rs
@@ -505,7 +505,7 @@ impl ChainEndpoint for PenumbraChain {
         // which causes the ViewServiceClient to use an in-memory database.
         let view_file: Option<String> = match config.view_service_storage_dir {
             Some(ref dir_string) => {
-                let p = PathBuf::from(shellexpand::tilde(dir_string))
+                let p = PathBuf::from(shellexpand::tilde(dir_string).to_string())
                     .join("relayer-view.sqlite")
                     .to_str()
                     .ok_or_else(|| Error::temp_penumbra_error("Non-UTF8 view path".to_owned()))?

--- a/crates/relayer/src/chain/penumbra.rs
+++ b/crates/relayer/src/chain/penumbra.rs
@@ -505,7 +505,7 @@ impl ChainEndpoint for PenumbraChain {
         // which causes the ViewServiceClient to use an in-memory database.
         let view_file: Option<String> = match config.view_service_storage_dir {
             Some(ref dir_string) => {
-                let p = PathBuf::from(dir_string)
+                let p = PathBuf::from(shellexpand::tilde(dir_string))
                     .join("relayer-view.sqlite")
                     .to_str()
                     .ok_or_else(|| Error::temp_penumbra_error("Non-UTF8 view path".to_owned()))?


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds support to penumbra to support a generic `~` instead of a hardcoded home path value `/home/reece/`.  We want 1 config to work across our team since we will all be using the same account (for the relayer), it's not realistic for each of us to change this /home path

```toml
[[chains]]
id = 'penumbra-local-devnet'
type = 'Penumbra'
...
view_service_storage_dir = "~/.local/share/local1"
```

Tested locally

<img width="1550" height="438" alt="image" src="https://github.com/user-attachments/assets/0718a224-28b0-4ec8-ad17-38919bdc3b1f" />

NOTE: I had to build with `export CXXFLAGS="-include cstdint"` even without this change, maybe something useful for the quick-start docs

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
  - [ ] If guide has been updated, tag GitHub user `mircea-c`
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
