### PR TITLE
docs: Fix Typos

### DIFF
--- a/docs/architecture/adr-004-relayer-domain-decomposition.md
+++ b/docs/architecture/adr-004-relayer-domain-decomposition.md
@@ -211,7 +211,7 @@ impl Link {
                 let signed_headers = self.src_chain.get_minimal_set(current_height, target_height)?;
 
                 let mut attempt_datagrams = datagrams.clone();
-                attempt_datagrams.push(Datagram::ClientUpdat(ClientUpdate::new(signed_headers)));
+                attempt_datagrams.push(Datagram::ClientUpdate(ClientUpdate::new(signed_headers)));
 				
                 let transaction = Transaction::new(datagram);
                 self.dst_chain.submit(transaction.sign().encode())?;

--- a/docs/architecture/adr-011-light-client-crates-extraction.md
+++ b/docs/architecture/adr-011-light-client-crates-extraction.md
@@ -28,7 +28,7 @@ in [ADR003 - Dealing with chain-specific datatypes](https://github.com/informals
 ->
 > We could alternatively model all chain-specific datatypes as boxed trait objects (`Box<dyn Trait>`), but this approach
 > runs into a lot of limitations of trait objects, such as the inability to easily require such trait objects to be
-> Clonable, or Serializable, or to define an equality relation on them. Some support for such functionality can be found
+> Cloneable, or Serializable, or to define an equality relation on them. Some support for such functionality can be found
 > in third-party libraries, but the overall experience for the developer is too subpar.
 >
 > We thus settle on a different strategy: lifting chain-specific data into an enum over all possible chain types.


### PR DESCRIPTION
## Description

Corrected misspellings:

- `ClientUpdat` → `ClientUpdate`
- `Clonable` → `Cloneable`