### PR TITLE
fix(event-source): handle websocket stream termination and add watchdog

### DIFF
--- a/crates/relayer/src/event/error.rs
+++ b/crates/relayer/src/event/error.rs
@@ -48,6 +48,16 @@ define_error! {
         Rpc
             [ TraceError<RpcError> ]
             |_| { "RPC error" },
+
+        StreamTerminated
+            |_| { "event stream terminated unexpectedly" },
+
+        WatchdogTimeout
+            { timeout_secs: u64 }
+            |e| { format!("no events received for {} seconds", e.timeout_secs) },
+
+        DriverChannelClosed
+            |_| { "websocket driver channel closed" },
     }
 }
 

--- a/crates/relayer/src/link.rs
+++ b/crates/relayer/src/link.rs
@@ -32,6 +32,9 @@ use tx_hashes::TxHashes;
 // Re-export the telemetries summary
 pub use relay_summary::RelaySummary;
 
+/// Timeout duration used for pending operations (5 minutes)
+pub use pending::TIMEOUT;
+
 pub use relay_path::{RelayPath, Resubmit};
 
 #[derive(Clone, Debug)]

--- a/crates/relayer/src/supervisor.rs
+++ b/crates/relayer/src/supervisor.rs
@@ -969,6 +969,24 @@ fn handle_batch<Chain: ChainHandle>(
             let _ = clear_pending_packets(workers, &chain_id)
                 .map_err(|e| error!("error during clearing pending packets: {}", e));
         }
+        Err(EventError(EventErrorDetail::StreamTerminated(_), _)) => {
+            warn!("event stream terminated unexpectedly, clearing pending packets");
+
+            let _ = clear_pending_packets(workers, &chain_id)
+                .map_err(|e| error!("error during clearing pending packets: {}", e));
+        }
+        Err(EventError(EventErrorDetail::WatchdogTimeout(_), _)) => {
+            warn!("websocket watchdog timeout, clearing pending packets");
+
+            let _ = clear_pending_packets(workers, &chain_id)
+                .map_err(|e| error!("error during clearing pending packets: {}", e));
+        }
+        Err(EventError(EventErrorDetail::DriverChannelClosed(_), _)) => {
+            warn!("websocket driver channel closed, clearing pending packets");
+
+            let _ = clear_pending_packets(workers, &chain_id)
+                .map_err(|e| error!("error during clearing pending packets: {}", e));
+        }
         Err(e) => {
             error!("error when receiving event batch: {}", e)
         }


### PR DESCRIPTION
## Summary

fixes silent websocket connection failures that could cause packets to be missed indefinitely.

the `tokio::select!` in websocket event source `run_loop` only matched on `Some(_)` for both branches. if the subscription stream silently terminated (returned `None` without an error), neither branch would match and the loop could hang indefinitely, causing packets to be missed when the websocket connection became stale.

## Changes

- explicitly handle `None` from `batches.next()` to detect stream termination
- explicitly handle `None` from `rx_err.recv()` to detect driver channel closure  
- add watchdog timeout using existing `link::TIMEOUT` (5 min) to detect stale connections
- add new error variants (`StreamTerminated`, `WatchdogTimeout`, `DriverChannelClosed`)
- propagate errors before reconnection so supervisor clears pending packets
- re-export `TIMEOUT` from link module for reuse

when any of these conditions are detected, an error is propagated to trigger packet clearing, then reconnection is initiated to restore event subscription.

## Related Issues

potentially related to stuck packet issues between chains (e.g. cosmos hub <-> penumbra) where websocket subscriptions silently fail without triggering reconnection or packet clearing.

## Test Plan

- [x] `cargo check -p ibc-relayer` passes
- [x] `cargo test -p ibc-relayer --lib` passes (72 tests)
- [ ] manual testing on affected channels recommended