### PR TITLE
skip malformed RPC events missing attributes

### DIFF
--- a/crates/relayer/src/chain/cosmos.rs
+++ b/crates/relayer/src/chain/cosmos.rs
@@ -86,7 +86,8 @@ use crate::chain::cosmos::query::denom_trace::query_denom_trace;
 use crate::chain::cosmos::query::fee::query_incentivized_packet;
 use crate::chain::cosmos::query::status::query_status;
 use crate::chain::cosmos::query::tx::{
-    filter_matching_event, query_packets_from_block, query_packets_from_txs, query_txs,
+    filter_matching_event, is_missing_event_attributes_rpc_error, query_packets_from_block,
+    query_packets_from_txs, query_txs,
 };
 use crate::chain::cosmos::query::{abci_query, fetch_version_specs, packet_query, QueryResponse};
 use crate::chain::cosmos::types::account::Account;
@@ -797,9 +798,17 @@ impl CosmosSdkChain {
         let tm_height =
             tendermint::block::Height::try_from(block_height.revision_height()).unwrap();
 
-        let response = self
-            .block_on(self.rpc_client.block_results(tm_height))
-            .map_err(|e| Error::rpc(self.config.rpc_addr.clone(), e))?;
+        let response = match self.block_on(self.rpc_client.block_results(tm_height)) {
+            Ok(response) => response,
+            Err(e) if is_missing_event_attributes_rpc_error(&e) => {
+                warn!(
+                    "skipping malformed block_results response at height {}: {}",
+                    tm_height, e
+                );
+                return Ok(Default::default());
+            }
+            Err(e) => return Err(Error::rpc(self.config.rpc_addr.clone(), e)),
+        };
 
         let response_height = ICSHeight::new(self.id().version(), u64::from(response.height))
             .map_err(|_| Error::invalid_height_no_source())?;
@@ -851,8 +860,7 @@ impl CosmosSdkChain {
         let mut end_block_events = vec![];
 
         for seq in request.sequences.iter().copied() {
-            let response = self
-                .block_on(self.rpc_client.block_search(
+            let response = match self.block_on(self.rpc_client.block_search(
                     packet_query(request, seq),
                     // We only need the first page
                     1,
@@ -869,8 +877,17 @@ impl CosmosSdkChain {
                     // much any height relative to the target blocks, so we went with most recent
                     // blocks first.
                     Order::Descending,
-                ))
-                .map_err(|e| Error::rpc(self.config.rpc_addr.clone(), e))?;
+                )) {
+                Ok(response) => response,
+                Err(e) if is_missing_event_attributes_rpc_error(&e) => {
+                    warn!(
+                        "skipping malformed block_search response for sequence {}: {}",
+                        seq, e
+                    );
+                    continue;
+                }
+                Err(e) => return Err(Error::rpc(self.config.rpc_addr.clone(), e)),
+            };
 
             for block in response.blocks.into_iter().map(|response| response.block) {
                 let response_height =

--- a/crates/relayer/src/chain/cosmos/query/tx.rs
+++ b/crates/relayer/src/chain/cosmos/query/tx.rs
@@ -6,7 +6,7 @@ use ibc_relayer_types::Height as ICSHeight;
 use tendermint::abci::Event;
 use tendermint::Hash as TxHash;
 use tendermint_rpc::endpoint::tx::Response as TxResponse;
-use tendermint_rpc::{Client, HttpClient, Order, Url};
+use tendermint_rpc::{Client, Error as RpcError, HttpClient, Order, Url};
 use tracing::warn;
 
 use crate::chain::cosmos::query::{header_query, packet_query, tx_hash_query};
@@ -16,6 +16,11 @@ use crate::chain::requests::{
 };
 use crate::error::Error;
 use crate::event::{ibc_event_try_from_abci_event, IbcEventWithHeight};
+
+pub(crate) fn is_missing_event_attributes_rpc_error(error: &RpcError) -> bool {
+    let msg = error.to_string();
+    msg.contains("serde parse error") && msg.contains("missing field `attributes`")
+}
 
 /// This function queries transactions for events matching certain criteria.
 /// 1. Client Update request - returns a vector with at most one update client event
@@ -130,10 +135,20 @@ pub async fn query_packets_from_txs(
 
     for seq in &request.sequences {
         // Query the latest 10 txs which include the event specified in the query request
-        let response = rpc_client
+        let response = match rpc_client
             .tx_search(packet_query(request, *seq), false, 1, 10, Order::Descending)
             .await
-            .map_err(|e| Error::rpc(rpc_address.clone(), e))?;
+        {
+            Ok(response) => response,
+            Err(e) if is_missing_event_attributes_rpc_error(&e) => {
+                warn!(
+                    "skipping malformed tx_search response for packet sequence {}: {}",
+                    seq, e
+                );
+                continue;
+            }
+            Err(e) => return Err(Error::rpc(rpc_address.clone(), e)),
+        };
 
         if response.txs.is_empty() {
             continue;
@@ -199,10 +214,17 @@ pub async fn query_packets_from_block(
     let height = Height::new(chain_id.version(), u64::from(tm_height))
         .map_err(|_| Error::invalid_height_no_source())?;
 
-    let block_results = rpc_client
-        .block_results(tm_height)
-        .await
-        .map_err(|e| Error::rpc(rpc_address.clone(), e))?;
+    let block_results = match rpc_client.block_results(tm_height).await {
+        Ok(block_results) => block_results,
+        Err(e) if is_missing_event_attributes_rpc_error(&e) => {
+            warn!(
+                "skipping malformed block_results response at height {}: {}",
+                tm_height, e
+            );
+            return Ok(vec![]);
+        }
+        Err(e) => return Err(Error::rpc(rpc_address.clone(), e)),
+    };
 
     let mut events: Vec<_> = block_results
         .begin_block_events

--- a/crates/relayer/src/chain/cosmos/query/tx.rs
+++ b/crates/relayer/src/chain/cosmos/query/tx.rs
@@ -18,7 +18,10 @@ use crate::error::Error;
 use crate::event::{ibc_event_try_from_abci_event, IbcEventWithHeight};
 
 pub(crate) fn is_missing_event_attributes_rpc_error(error: &RpcError) -> bool {
-    let msg = error.to_string();
+    is_missing_event_attributes_error_message(&error.to_string())
+}
+
+fn is_missing_event_attributes_error_message(msg: &str) -> bool {
     msg.contains("serde parse error") && msg.contains("missing field `attributes`")
 }
 
@@ -423,5 +426,33 @@ pub fn all_ibc_events_from_tx_search_response(
             .collect::<Vec<_>>();
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_missing_event_attributes_error_message;
+
+    #[test]
+    fn matches_only_missing_attributes_serde_error() {
+        let cases = [
+            (
+                "serde parse error: missing field `attributes`",
+                true,
+            ),
+            (
+                "serde parse error: missing field `events`",
+                false,
+            ),
+            ("tcp connect timeout", false),
+        ];
+
+        for (message, expected) in cases {
+            assert_eq!(
+                is_missing_event_attributes_error_message(message),
+                expected,
+                "unexpected match result for message: {message}"
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

* Packet clearing may fail during packet data lookup due to serde parse error: missing field 'attributes'.
* The issue is triggered by malformed block_results events missing attributes (e.g. oracle_prices in finalize_block_events at https://rpc.archive.dukong.mantrachain.io/block_results?height=12934203).
* This change makes Hermes skip those malformed events rather than aborting the query.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
  - [ ] If guide has been updated, tag GitHub user `mircea-c`
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
